### PR TITLE
Fixes a small typo in search result text.

### DIFF
--- a/lib/cocoapods/source.rb
+++ b/lib/cocoapods/source.rb
@@ -20,8 +20,8 @@ module Pod
       result = all.map { |s| s.search_by_name(query, full_text_search) }.flatten
       if result.empty?
         extra = ", summary, or description" if full_text_search
-        raise(Informative, "Unable to find a pod who's name" \
-                           "#{extra} matches `#{query}'")
+        raise(Informative, "Unable to find a pod with name" \
+                           "#{extra} matching `#{query}'")
       end
       result
     end

--- a/spec/functional/command_spec.rb
+++ b/spec/functional/command_spec.rb
@@ -64,7 +64,7 @@ describe "Pod::Command" do
     config.repos_dir = tmp_repos_path
   end
 
-  it "searches for a pod who's name matches the given query ignoring case" do
+  it "searches for a pod with name matching the given query ignoring case" do
     [
       [
         ' s ',
@@ -96,7 +96,7 @@ describe "Pod::Command" do
     end
   end
 
-  it "searches for a pod who's name, summary, or description matches the given query ignoring case" do
+  it "searches for a pod with name, summary, or description matching the given query ignoring case" do
     [
       [
         'systemCONfiguration',


### PR DESCRIPTION
Fix for "who's", which means "who is". "whose" would be correct if pods were persons. I changed it such that it uses "with", as in "Unable to find a pod with name matching ...".
