### PR TITLE
Add Specification#clean_paths to specify paths to remove after downloading

### DIFF
--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -47,8 +47,14 @@ module Pod
         end
       end
 
-      def clean
+      def clean(clean_paths = [])
         (@pod_root + '.git').rmtree
+        clean_paths.each do |pattern|
+          pattern = @pod_root + pattern
+          pattern.glob.each do |path|
+            path.rmtree
+          end
+        end if clean_paths
       end
     end
   end

--- a/lib/cocoapods/specification.rb
+++ b/lib/cocoapods/specification.rb
@@ -74,6 +74,11 @@ module Pod
     end
     attr_reader :source_files
 
+    def clean_paths=(*patterns)
+      @clean_paths = patterns.flatten.map { |p| Pathname.new(p) }
+    end
+    attr_reader :clean_paths
+
     def dependency(*name_and_version_requirements)
       name, *version_requirements = name_and_version_requirements.flatten
       dep = Dependency.new(name, *version_requirements)
@@ -292,7 +297,7 @@ module Pod
     def download!
       downloader = Downloader.for_source(pod_destroot, @source)
       downloader.download
-      downloader.clean if config.clean
+      downloader.clean(clean_paths) if config.clean
     end
 
   end

--- a/spec/functional/downloader_spec.rb
+++ b/spec/functional/downloader_spec.rb
@@ -31,5 +31,14 @@ describe "Pod::Downloader" do
     downloader.clean
     (@dir + '.git').should.not.exist
   end
+
+  it "removes the clean_paths files and directories" do
+    downloader = Pod::Downloader.for_source(@dir,
+      :git => fixture('banana-lib'), :tag => 'v1.0'
+    )
+    downloader.download
+    downloader.clean(['README'])
+    (@dir + 'README').should.not.exist
+  end
 end
 


### PR DESCRIPTION
For example, a library could have documentation, tests, example files, or other files
which are not relevant for the purpose of using the library and can be removed after downloading.

E.g AFNetworking's _Example_ directory:
https://github.com/gowalla/AFNetworking/tree/master/Example

I think _clean_paths_ might not be the best name for this setting though.

Any other opinions on this?
