### PR TITLE
Remove -all_load linker flag as it is no longer needed as a linker bug workaround. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ And then you [install the dependencies](https://github.com/CocoaPods/CocoaPods/w
 
 _Where ‘App.xcodeproj’ is the name of your actual application project._
 
+The next time you change your Podfile, you can update your project by simply running:
+
+    $ pod install
+
 Remember to always open the Xcode workspace instead of the project file when you're building.
 
     $ open App.xcworkspace


### PR DESCRIPTION
I'm putting this up for discussion and verification.

The -all_load was needed as for a linker bug as mentioned here:
http://developer.apple.com/library/mac/#qa/qa1490/_index.html

However, the linker bug reportedly is fixed now:
http://stackoverflow.com/questions/7942616/why-is-force-load-no-longer-required-for-my-three20-dependencies-in-xcode-4-2/7942924#7942924

I just built an iOS 5.0 app with Xcode 4.2 and could verify that categories from the pods library still worked – even if built without -all_load.

As I don't have information in which version the bug is fixed, I'm not sure if this is the right time to remove that flag by default. Anyone can verify that this also works for other projects?
