### PR TITLE
Show available versions of a Pod when the required version can't be found

### DIFF
--- a/lib/cocoapods/specification/set.rb
+++ b/lib/cocoapods/specification/set.rb
@@ -61,7 +61,7 @@ module Pod
       # Return the first version that matches the current dependency.
       def required_version
         versions.find { |v| dependency.match?(name, v) } ||
-          raise(Informative, "Required version (#{dependency}) not found for `#{name}'.")
+          raise(Informative, "Required version (#{dependency}) not found for `#{name}'.\nAvailable versions: #{versions.join(', ')}")
       end
 
       def ==(other)


### PR DESCRIPTION
Output of pod install with an wrong version in a Podfile before the change:

```
$ pod install
Installing dependencies of: /Users/mk/sauspiel/sauspiel-iphone/Podfile
Required version (Reachability (~> 3.0.1)) not found for `Reachability'.
```

After change:

```
$ pod install
Installing dependencies of: /Users/mk/sauspiel/sauspiel-iphone/Podfile
Required version (Reachability (~> 3.0.1)) not found for `Reachability'.
Available versions: 3.0.0, 2.0.5, 2.0.4
```
