### PR TITLE
Allow specific source files to be ignored entirely

### DIFF
--- a/lib/cocoapods/specification.rb
+++ b/lib/cocoapods/specification.rb
@@ -27,7 +27,7 @@ module Pod
 
     # TODO This is just to work around a MacRuby bug
     def post_initialize
-      @dependencies, @source_files, @resources, @clean_paths, @subspecs = [], [], [], [], []
+      @dependencies, @source_files, @ignored_source_files, @resources, @clean_paths, @subspecs = [], [], [], [], [], []
       @xcconfig = Xcodeproj::Config.new
     end
 
@@ -79,6 +79,11 @@ module Pod
       @source_files = pattern_list(patterns)
     end
     attr_reader :source_files
+    
+    def ignored_source_files=(patterns)
+      @ignored_source_files = pattern_list(patterns)
+    end
+    attr_reader :ignored_source_files
 
     def resources=(patterns)
       @resources = pattern_list(patterns)
@@ -256,6 +261,13 @@ module Pod
         pattern = pattern + '*.{h,m,mm,c,cpp}' if pattern.directory?
         pattern.glob.each do |file|
           files << file.relative_path_from(config.project_pods_root)
+        end
+      end
+      ignored_source_files.each do |pattern|
+        pattern = pod_destroot + pattern
+        pattern = pattern + '*.{h,m,mm,c,cpp}' if pattern.directory?
+        pattern.glob.each do |file|
+          files.delete file.relative_path_from(config.project_pods_root)
         end
       end
       files

--- a/spec/unit/specification_spec.rb
+++ b/spec/unit/specification_spec.rb
@@ -152,6 +152,14 @@ describe "A Pod::Specification, with installed source," do
     files = files.map { |file| file.relative_path_from(config.project_pods_root) }
     @spec.expanded_source_files.sort.should == files.sort
   end
+  
+  it "returns the list of files that the source_files pattern expand to, minus any ignored files" do
+    files = @destroot.glob('**/*.{h,c,m}')
+    files = files.map { |file| file.relative_path_from(config.project_pods_root) }
+    @spec.ignored_source_files = ["**/zip.*"]
+    @spec.expanded_source_files.include?(Pathname.new("SSZipArchive/minizip/zip.c")).should == false
+    @spec.expanded_source_files.include?(Pathname.new("SSZipArchive/minizip/zip.h")).should == false
+  end
 
   it "returns the list of headers" do
     files = @destroot.glob('**/*.h')


### PR DESCRIPTION
I couldn't figure out a way to make this work using source_files= and a glob, so I added an ignored_source_files attribute to specification.

I haven't committed this directly; I'm doing this as a pull request to see if there is any feedback first.

Use case: I'm trying to write an inline spec for MGTwitterEngine but I don't want to include any of the YAJL parsing classes as I don't want to include YAJL.
