### PR TITLE
Match IPHONEOS_DEPLOYMENT_TARGET build setting with deployment_target option in generated Pods project file

### DIFF
--- a/lib/cocoapods/xcodeproj_pods.rb
+++ b/lib/cocoapods/xcodeproj_pods.rb
@@ -98,6 +98,9 @@ module Xcodeproj
       if platform.requires_legacy_ios_archs?
         settings['ARCHS'] = "armv6 armv7"
       end
+      if platform == :ios && platform.deployment_target
+        settings['IPHONEOS_DEPLOYMENT_TARGET'] = platform.deployment_target.to_s
+      end
       if scheme == :debug
         settings.merge!(COMMON_BUILD_SETTINGS[:debug])
         settings['ONLY_ACTIVE_ARCH'] = 'YES' if platform == :osx

--- a/spec/unit/xcodeproj_ext_spec.rb
+++ b/spec/unit/xcodeproj_ext_spec.rb
@@ -76,5 +76,15 @@ describe 'Xcodeproj::Project' do
       @project.build_configuration("Debug").buildSettings["ARCHS"].should == "$(ARCHS_STANDARD_32_BIT)"
       @project.build_configuration("Release").buildSettings["ARCHS"].should == "$(ARCHS_STANDARD_32_BIT)"
     end
+    
+    it "sets IPHONEOS_DEPLOYMENT_TARGET for both configurations" do
+      @project = Xcodeproj::Project.for_platform(Pod::Platform.new(:ios))
+      @project.build_configuration("Debug").buildSettings["IPHONEOS_DEPLOYMENT_TARGET"].should == "4.3"
+      @project.build_configuration("Release").buildSettings["IPHONEOS_DEPLOYMENT_TARGET"].should == "4.3"
+
+      @project = Xcodeproj::Project.for_platform(Pod::Platform.new(:ios, :deployment_target => "4.0"))
+      @project.build_configuration("Debug").buildSettings["IPHONEOS_DEPLOYMENT_TARGET"].should == "4.0"
+      @project.build_configuration("Release").buildSettings["IPHONEOS_DEPLOYMENT_TARGET"].should == "4.0"
+    end
   end
 end


### PR DESCRIPTION
It's nice that CocoaPods allows me to specify a `:deployment_target` in my Podfile, but the generated `Pods.xcodeproj` always contains an actual deployment target of 4.3. This PR should fix that. Any particular reason why this wasn't done before?
