### PR TITLE
Small fix for copy_resources_script.rb

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -9,7 +9,7 @@ install_resource()
   case $1 in
     *\.xib)
       echo "ibtool --errors --warnings --notices --output-format human-readable-text --compile ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename $1 .xib`.nib ${SRCROOT}/Pods/$1 --sdk ${SDKROOT}"
-      ibtool --errors --warnings --notices --output-format human-readable-text --compile ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename $1 .xib`.nib ${SRCROOT}/Pods/$1 --sdk ${SDKROOT}
+      ibtool --errors --warnings --notices --output-format human-readable-text --compile "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename $1 .xib`.nib" "${SRCROOT}/Pods/$1" --sdk "${SDKROOT}"
       ;;
     *)
       echo "cp -R ${SRCROOT}/Pods/$1 ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"


### PR DESCRIPTION
Added weak quoting to ibtool arguments to support path with spaces.
