### PR TITLE
External encoding set to UTF-8 on Ruby 1.9 to fix crash caused by non-ascii characters in pod description

### DIFF
--- a/bin/pod
+++ b/bin/pod
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > '1.8.7'
+
 if $0 == __FILE__
   $:.unshift File.expand_path('../../external/Xcodeproj/ext', __FILE__)
   $:.unshift File.expand_path('../../external/Xcodeproj/lib', __FILE__)


### PR DESCRIPTION
If I try to run `pod list` on Ruby 1.9, I'll get a crash with `invalid multibyte char (US-ASCII)`, specifically

<pre>

/Users/darthdeus/.cocoapods/master/ATMHud/0.0.1/ATMHud.podspec:7: invalid multibyte char (US-ASCII)
/Users/darthdeus/.cocoapods/master/ATMHud/0.0.1/ATMHud.podspec:7: invalid multibyte char (US-ASCII)
/Users/darthdeus/.cocoapods/master/ATMHud/0.0.1/ATMHud.podspec:7: syntax error, unexpected $end, expecting tASSOC
  s.author   = { 'Marcel Müller' => 'pool@atomton.net' }
                            ^
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/specification.rb:5:in `eval'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/specification.rb:5:in `_eval_podspec'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/specification.rb:16:in `from_file'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/specification/set.rb:59:in `specification'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/command/list.rb:19:in `block (2 levels) in run'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/command/list.rb:17:in `each'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/command/list.rb:17:in `block in run'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/command/list.rb:16:in `each'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/command/list.rb:16:in `run'
/Users/darthdeus/projects/fun/CocoaPods/lib/cocoapods/command.rb:53:in `run'
./bin/pod:13:in `<main>'
</pre>


Forcing external encoding to UTF-8 fixes the issue, since 1.9 defaults to US-ASCII if nothing is specified.
