### PR TITLE
Dependency link

### DIFF
--- a/lib/cocoapods/local_pod.rb
+++ b/lib/cocoapods/local_pod.rb
@@ -1,9 +1,7 @@
 module Pod
   class LocalPod
-
-    attr_reader   :specification
-    attr_reader   :sandbox
-    attr_accessor :link_path
+    attr_reader :specification
+    attr_reader :sandbox
 
     def initialize(specification, sandbox)
       @specification, @sandbox = specification, sandbox
@@ -19,9 +17,9 @@ module Pod
     
     def to_s
       if specification.local?
-        "#{specification} [LOCAL]"
-      elsif @link_path
-        "#{specification} -> #{@link_path}"
+        "[LOCAL] #{specification}"
+      elsif specification.linked?
+        "[LINK] #{specification}"
       else
         specification.to_s
       end
@@ -49,7 +47,7 @@ module Pod
     end
     
     def clean
-      clean_paths.each { |path| FileUtils.rm_rf(path) } if !@link_path
+      clean_paths.each { |path| FileUtils.rm_rf(path) } if !specification.linked?
     end
     
     def source_files

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -14,8 +14,8 @@ module Pod
       @specs = {}
 
       result = @podfile.target_definitions.values.inject({}) do |result, target_definition|
-      @log_indent = 0;
-      puts "Finding dependencies for #{target_definition.lib_name}" if Config.instance.verbose?
+        @log_indent = 0;
+        puts "Finding dependencies for #{target_definition.lib_name}" if Config.instance.verbose?
         @loaded_specs = []
         find_dependency_sets(@podfile, target_definition.dependencies)
         result[target_definition] = @specs.values_at(*@loaded_specs).sort_by(&:name)
@@ -51,7 +51,7 @@ module Pod
     def find_dependency_sets(dependent_specification, dependencies)
       @log_indent += 1
       dependencies.each do |dependency|
-        puts '  ' * @log_indent + "- #{dependency.name}" if Config.instance.verbose?
+        puts '  ' * @log_indent + "- #{dependency}" if Config.instance.verbose?
         set = find_cached_set(dependency)
         set.required_by(dependent_specification)
         # Ensure we don't resolve the same spec twice

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -47,16 +47,13 @@ module Pod
     end
 
     def podspec_for_name(name)
-      pod_path = Dir[root + name + "*.podspec"][0] || Dir[root + 'Local Podspecs' + "*.podspec"][0]
-      pod_path = Pathname.new(pod_path) if pod_path
+      path = Dir[root + name + "*.podspec"][0] || Dir[root + 'Local Podspecs' + "*.podspec"][0]
+      podspec_path = Pathname.new(path) if path
     end
 
     def installed_pod_named(name)
-      if podspec_for_name(name)
-        LocalPod.from_podspec(podspec_for_name(name), self)
-      else
-        nil
-      end
+      podspec = podspec_for_name(name)
+      LocalPod.from_podspec(podspec, self) if podspec
     end
   end
 end

--- a/lib/cocoapods/specification.rb
+++ b/lib/cocoapods/specification.rb
@@ -170,6 +170,11 @@ module Pod
       Pathname.new(File.expand_path(source[:local]))
     end
 
+    attr_accessor :link_path
+    def linked?
+      !link_path.nil?
+    end
+
     # This is assigned the other spec, of which this pod's source is a part, by
     # a Resolver.
     attr_accessor :part_of_specification


### PR DESCRIPTION
My attempt to take full advantage from the workspace feature. It is just an external source that works by making a symbolic link. I tested it a bit and seems to work. But I'm not sure what would happen in edge conditions (e.g. if somebody mixes it with a local pod). As, usual is still missing tests.
###### Usage

in the podfile:

``` ruby
dependency 'Reachability', :link => '/Users/fabio/libs/Reachability'

```

Previous discussion at #178 - #179.
