### PR TITLE
Removed broken Xcodeproj bundle install command from rake bootstrap task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -208,7 +208,6 @@ task :bootstrap do
 
   puts "Installing gems"
   `bundle install`
-  `cd external/XcodeProj && bundle install`
 end
 
 desc "Run all specs"


### PR DESCRIPTION
Title pretty much says it all. Line removed from rake bootstrap task as discussed in [this issue](https://github.com/CocoaPods/CocoaPods/issues/217#issuecomment-5260552).
