### PR TITLE
Fixed http downloader with tar files

### DIFF
--- a/lib/cocoapods/downloader/http.rb
+++ b/lib/cocoapods/downloader/http.rb
@@ -60,9 +60,9 @@ module Pod
         when :zip
           unzip "'#{full_filename}' -d #{target_path}"
         when :tgz
-          tar "xfz '#{full_filename}' -d #{target_path}"
+          tar "xfz '#{full_filename}' -C #{target_path}"
         when :tar
-          tar "xf '#{full_filename}' -d #{target_path}"
+          tar "xf '#{full_filename}' -C #{target_path}"
         else
           raise UnsupportedFileTypeError.new "Unsupported file type: #{type}"
         end


### PR DESCRIPTION
The new http downloader used a -d argument to specify the output directory. This is not the correct argument, and I changed it to -C.
