### PR TITLE
Better error msg for missing podspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development do
   gem "webmock"
   gem "awesome_print"
   gem "pry"
-
+  gem "ruby-debug19", :require => "ruby-debug"
   gem 'yard'
   gem 'redcarpet'
   gem 'github-markup'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,12 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.2.8)
+    archive-tar-minitar (0.5.2)
     awesome_print (1.0.2)
     bacon (1.1.0)
     coderay (1.0.6)
     colored (1.2)
+    columnize (0.3.6)
     crack (0.3.1)
     escape (0.0.4)
     faraday (0.8.1)
@@ -24,6 +26,8 @@ GEM
     json (1.7.3)
     kicker (2.5.0)
       rb-fsevent
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     metaclass (0.0.1)
     method_source (0.7.1)
     mocha (0.11.4)
@@ -46,6 +50,16 @@ GEM
     rake (0.9.2.2)
     rb-fsevent (0.9.1)
     redcarpet (2.1.1)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
     slop (2.4.4)
     vcr (2.2.0)
     webmock (1.8.7)
@@ -72,6 +86,7 @@ DEPENDENCIES
   rake
   rb-fsevent
   redcarpet
+  ruby-debug19
   vcr
   webmock
   xcodeproj!

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -1,3 +1,4 @@
+require 'ruby-debug'
 require 'fileutils'
 
 module Pod
@@ -46,11 +47,31 @@ module Pod
       headers_root.rmtree if headers_root.exist?
     end
 
+    def path_for_podspec_in_project(pod_name)
+      Dir[root + "#{pod_name}/*.podspec"].first
+    end
+
+    def podspec_exists_in_project?(pod_name)
+      !path_for_podspec_in_project(pod_name).nil?
+    end
+
+    def path_for_local_podspec(pod_name)
+      Dir[root + "Local Podspecs/#{pod_name}.podspec"].first
+    end
+
+    def podspec_exists_in_local_dir?(pod_name)
+      !path_for_local_podspec(pod_name).nil?
+    end
+
     def podspec_for_name(name)
-      if spec_path = Dir[root + "#{name}/*.podspec"].first
-        Pathname.new(spec_path)
-      elsif spec_path = Dir[root + "Local Podspecs/#{name}.podspec"].first
-        Pathname.new(spec_path)
+      # debugger
+      if podspec_exists_in_project?(name)
+        Pathname.new(path_for_podspec_in_project(name))
+      elsif podspec_exists_in_local_dir?(name)
+        Pathname.new(path_for_local_podspec(name))
+      else
+        return nil
+        # raise "No podspec found for #{name}. Please specify the :podspec option instead to point to a podspec for the #{name} Pod"
       end
     end
 


### PR DESCRIPTION
First checks the project's root for a .podspec,
Then goes on to check the Local Pods folder,
if that can't be found raises an informative error.

Currently this breaks a couple of tests, as the behavior for `sandbox#podspec_for_name(name)` of returning nil apparently is being depended on.  Submitting a pull request to begin the discussion.

Do you think this is the right approach?

The tests that are broken:

**`Pod::Resolver`**
- holds the context state, such as cached specification sets [FAILED]
- returns all specs needed for the dependency [FAILED]

**`Pod::Command::Spec::Linter`**
- uses xcodebuild to generate notes and warnings [FAILED]
- checks for file patterns [FAILED]

If you think this is the right approach, I'll look at how to fix these specs to not depend on a `nil` return value from that method.
