### PR TITLE
--version should result in exit status 0

### DIFF
--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -76,6 +76,7 @@ module Pod
       if e.is_a?(PlainInformative) # also catches Informative
         puts e.message
         puts *e.backtrace if Config.instance.verbose?
+        exit 0
       else
         puts ErrorReport.report(e)
       end


### PR DESCRIPTION
Hey guys,

Just a tiny pedantic pull request -- I noticed that running 'pod --version' causes pod to exit with status 1 instead of status 0.

-jason
