### PR TITLE
Branch in depenedency/podspec

### DIFF
--- a/lib/cocoapods/dependency.rb
+++ b/lib/cocoapods/dependency.rb
@@ -160,6 +160,7 @@ module Pod
           "from `#{@params[:git]}'".tap do |description|
             description << ", commit `#{@params[:commit]}'" if @params[:commit]
             description << ", tag `#{@params[:tag]}'" if @params[:tag]
+            description << ", branch `#{@params[:branch]}'" if @params[:branch]
           end
         end
       end

--- a/lib/cocoapods/downloader/git.rb
+++ b/lib/cocoapods/downloader/git.rb
@@ -18,6 +18,8 @@ module Pod
           download_tag
         elsif options[:commit]
           download_commit
+        elsif options[:branch]
+          download_branch
         else
           download_head
         end
@@ -110,6 +112,13 @@ module Pod
         git "clone '#{clone_url}' '#{target_path}'"
         Dir.chdir(target_path) do
           git "checkout -b activated-pod-commit #{options[:commit]}"
+        end
+      end
+      
+      def download_branch
+        Dir.chdir(target_path) do
+          git "clone '#{clone_url}' -b '#{options[:branch]}' '#{target_path}'" 
+          git "checkout -b activated-pod-commit"
         end
       end
     end


### PR DESCRIPTION
Needed to use :branch instead of tag/commit to have local versions of an internal library. When in early stages of a library or testing fase this hinders having tag hell or changing commit hash in podspec for each update

Missing caching implementation
