### PR TITLE
Handle extraction paths with spaces for http sources

### DIFF
--- a/lib/cocoapods/downloader/http.rb
+++ b/lib/cocoapods/downloader/http.rb
@@ -58,11 +58,11 @@ module Pod
       def extract_with_type(full_filename, type=:zip)
         case type
         when :zip
-          unzip "'#{full_filename}' -d #{target_path}"
+          unzip "'#{full_filename}' -d '#{target_path}'"
         when :tgz
-          tar "xfz '#{full_filename}' -C #{target_path}"
+          tar "xfz '#{full_filename}' -C '#{target_path}'"
         when :tar
-          tar "xf '#{full_filename}' -C #{target_path}"
+          tar "xf '#{full_filename}' -C '#{target_path}'"
         else
           raise UnsupportedFileTypeError.new "Unsupported file type: #{type}"
         end


### PR DESCRIPTION
Just wrapped the extraction path in apostrophes
