### PR TITLE
Make PodsDummy class unique to each target

### DIFF
--- a/lib/cocoapods/generator/dummy_source.rb
+++ b/lib/cocoapods/generator/dummy_source.rb
@@ -1,11 +1,18 @@
 module Pod
   module Generator
     class DummySource
+      attr_reader :class_name
+
+      def initialize(class_name_identifier)
+        validated_class_name_identifier = class_name_identifier.gsub(/[^0-9a-z_]/i, '_')
+        @class_name = "PodsDummy_#{validated_class_name_identifier}"
+      end
+
       def save_as(pathname)
         pathname.open('w') do |source|
-          source.puts "@interface PodsDummy : NSObject"
+          source.puts "@interface #{class_name} : NSObject"
           source.puts "@end"
-          source.puts "@implementation PodsDummy"
+          source.puts "@implementation #{class_name}"
           source.puts "@end"
         end
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -114,8 +114,31 @@ else
           installer = SpecHelper::Installer.new(podfile)
           installer.install!
 
-          dummy = (config.project_pods_root + 'PodsDummy.m').read
-          dummy.should.include?('@implementation PodsDummy')
+          dummy = (config.project_pods_root + 'PodsDummy_Pods.m').read
+          dummy.should.include?('@implementation PodsDummy_Pods')
+        end
+
+        it "installs a dummy source file unique to the target" do
+          create_config!
+          podfile = Pod::Podfile.new do
+            self.platform :ios
+            xcodeproj 'dummy'
+            pod do |s|
+              s.name         = 'JSONKit'
+              s.version      = '1.2'
+              s.source       = { :git => SpecHelper.fixture('integration/JSONKit').to_s, :tag => 'v1.2' }
+              s.source_files = 'JSONKit.*'
+            end
+            target :AnotherTarget do
+              pod 'ASIHTTPRequest'
+            end
+          end
+
+          installer = SpecHelper::Installer.new(podfile)
+          installer.install!
+
+          dummy = (config.project_pods_root + 'PodsDummy_Pods_AnotherTarget.m').read
+          dummy.should.include?('@implementation PodsDummy_Pods_AnotherTarget')
         end
 
         it "installs a library with a podspec defined inline" do

--- a/spec/unit/generator/dummy_source_spec.rb
+++ b/spec/unit/generator/dummy_source_spec.rb
@@ -11,15 +11,28 @@ describe Pod::Generator::DummySource do
     teardown_temporary_directory
   end
 
-  it "generates a dummy sourcefile with the appropriate class" do
-    generator = Pod::Generator::DummySource.new
+  it "generates a dummy sourcefile with the appropriate class for the class name identifier" do
+    generator = Pod::Generator::DummySource.new('SomeIdentification')
     file = temporary_directory + 'PodsDummy.m'
     generator.save_as(file)
     file.read.should == <<-EOS
-@interface PodsDummy : NSObject
+@interface PodsDummy_SomeIdentification : NSObject
 @end
-@implementation PodsDummy
+@implementation PodsDummy_SomeIdentification
 @end
 EOS
   end
+
+it "generates a dummy sourcefile with the appropriate class, replacing non-alphanumeric characters with underscores" do
+  generator = Pod::Generator::DummySource.new('This!has_non-alphanumeric+characters in it.0123456789')
+  file = temporary_directory + 'PodsDummy.m'
+  generator.save_as(file)
+  file.read.should == <<-EOS
+@interface PodsDummy_This_has_non_alphanumeric_characters_in_it_0123456789 : NSObject
+@end
+@implementation PodsDummy_This_has_non_alphanumeric_characters_in_it_0123456789
+@end
+EOS
+  end
+
 end


### PR DESCRIPTION
The PodsDummy class can cause linker errors when using a static library project and a unit test. I changed the installer to create unique PodsDummy classes using the label provided by TargetDefinition.

This should fix:
https://github.com/CocoaPods/CocoaPods/issues/342
https://github.com/CocoaPods/CocoaPods/issues/370
