### PR TITLE
raise informative error message when user supplied invalid platform

### DIFF
--- a/lib/cocoapods/podfile.rb
+++ b/lib/cocoapods/podfile.rb
@@ -199,6 +199,8 @@ module Pod
           target = '4.3'
         when :osx
           target = '10.6'
+        else
+          raise Informative, "Unsupported platform: platform must be one of [:ios, :osx]"
         end
       end
       @target_definition.platform = Platform.new(name, target)

--- a/spec/unit/podfile_spec.rb
+++ b/spec/unit/podfile_spec.rb
@@ -16,6 +16,12 @@ describe "Pod::Podfile" do
     podfile.target_definitions[:default].platform.deployment_target.should == Pod::Version.new('4.3')
   end
 
+  it "raise error if unsupported platform is supplied" do
+    lambda {
+      Pod::Podfile.new { platform :iOS }
+    }.should.raise(StandardError, "Unsupported platform")
+  end
+
   it "adds dependencies" do
     podfile = Pod::Podfile.new { pod 'ASIHTTPRequest'; pod 'SSZipArchive', '>= 0.1' }
     podfile.dependencies.size.should == 2


### PR DESCRIPTION
A small patch to add informative error message for error like issue #401.

For following Podfile:

``` ruby
platform :iOS

pod 'CoconutKit'
```

Instead of crash on ``pod install` it now throw:

``` ruby
> pod install
[!] Unsupported platform: Platform must be one of [:ios, :osx]
```
