### PR TITLE
Add Pod::Podfile::Informative error which show lines in Podfile

### DIFF
--- a/lib/cocoapods/podfile.rb
+++ b/lib/cocoapods/podfile.rb
@@ -1,5 +1,19 @@
 module Pod
   class Podfile
+    class Informative < ::Pod::Informative
+      def podfile_line
+        @podfile_line ||= self.backtrace.find {|t| t =~ /Podfile/}
+      end
+
+      def message
+        if podfile_line
+          super + " (#{podfile_line})\n".red
+        else
+          super
+        end
+      end
+    end
+
     class UserProject
       include Config::Mixin
 
@@ -200,7 +214,7 @@ module Pod
         when :osx
           target = '10.6'
         else
-          raise Informative, "Unsupported platform: platform must be one of [:ios, :osx]"
+          raise ::Pod::Podfile::Informative, "Unsupported platform: platform must be one of [:ios, :osx]"
         end
       end
       @target_definition.platform = Platform.new(name, target)

--- a/spec/unit/podfile_spec.rb
+++ b/spec/unit/podfile_spec.rb
@@ -19,7 +19,14 @@ describe "Pod::Podfile" do
   it "raise error if unsupported platform is supplied" do
     lambda {
       Pod::Podfile.new { platform :iOS }
-    }.should.raise(StandardError, "Unsupported platform")
+    }.should.raise Pod::Podfile::Informative
+
+    begin
+      Pod::Podfile.new { platform :iOS }
+    rescue Pod::Podfile::Informative => e
+      e.stubs(:podfile_line).returns("./podfile_spec.rb:1")
+      e.message.should.be =~ /podfile_spec\.rb:1/
+    end
   end
 
   it "adds dependencies" do


### PR DESCRIPTION
Improve informative error message in podfile.

For following Podfile:

```
platform :iOS

pod 'CoconutKit'
```

run `pod install` show following error:

```
[!] Unsupported platform: platform must be one of [:ios, :osx]
 (/Users/siuying/Documents/workspace/Sample/Podfile:1:in `block in from_file')
```
