### PR TITLE
Don't call download_head directly from the installer.

### DIFF
--- a/lib/cocoapods/downloader/git.rb
+++ b/lib/cocoapods/downloader/git.rb
@@ -14,7 +14,9 @@ module Pod
       def download
         create_cache unless cache_exist?
         puts '-> Cloning git repo' if config.verbose?
-        if options[:tag]
+        if options[:head]
+          download_head
+        elsif options[:tag]
           download_tag
         elsif options[:branch]
           download_branch

--- a/lib/cocoapods/downloader/mercurial.rb
+++ b/lib/cocoapods/downloader/mercurial.rb
@@ -4,7 +4,9 @@ module Pod
       executable :hg
 
       def download
-        if options[:revision]
+        if options[:head]
+          download_head
+        elsif options[:revision]
           download_revision
         else
           download_head

--- a/lib/cocoapods/downloader/subversion.rb
+++ b/lib/cocoapods/downloader/subversion.rb
@@ -4,7 +4,9 @@ module Pod
       executable :svn
 
       def download
-        if options[:revision]
+        if options[:head]
+          download_head
+        elsif options[:revision]
           download_revision
         else
           download_head

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -77,6 +77,7 @@ module Pod
       # Force the `bleeding edge' version if necessary.
       if pod.top_specification.version.head?
         if downloader.respond_to?(:download_head)
+          downloader.options[:head] = 1
           downloader.download
         else
           raise Informative, "The downloader of class `#{downloader.class.name}' does not support the `:head' option."


### PR DESCRIPTION
download_head isn't able to handle the case where there isn't a currently cached version of the repo (as that's handled inside of download). Calling download ensures that create_cache will be called if needed.

Thanks!
