### PR TITLE
Add support for .tar.gz source file.

### DIFF
--- a/lib/cocoapods/downloader/http.rb
+++ b/lib/cocoapods/downloader/http.rb
@@ -29,7 +29,7 @@ module Pod
       def type_with_url(url)
         if url =~ /.zip$/
           :zip
-        elsif url =~ /.tgz$/
+        elsif url =~ /.(tgz|tar\.gz)$/
           :tgz
         elsif url =~ /.tar$/
           :tar


### PR DESCRIPTION
The HTTP downloader did not support .tar.gz files. This patch fixes that.
