### PR TITLE
[Specification] `wants_head` attribute.

### DIFF
--- a/lib/cocoapods/specification.rb
+++ b/lib/cocoapods/specification.rb
@@ -193,10 +193,20 @@ module Pod
     top_attr_accessor :summary
     top_attr_accessor :documentation
     top_attr_accessor :requires_arc
-    top_attr_accessor :version,             lambda { |v| Version.new(v) }
-
+    top_attr_accessor :wants_head
     top_attr_reader   :description,         lambda { |instance, ivar| ivar || instance.summary }
     top_attr_writer   :description,         lambda { |d| d.strip_heredoc }
+
+    # @!method version
+    #
+    top_attr_reader :version, lambda { |instance, ivar|
+      ivar.head = true if instance.wants_head
+      ivar
+    }
+
+    # @!method version=
+    #
+    top_attr_writer :version, lambda { |v| Version.new(v) }
 
     # @!method license
     #


### PR DESCRIPTION
##### Description

An attribute that allows a podspec to declare that it wants to use the head version.

This attribute should be set to true only in the last version of a podspec. If a version of a pod wants head and  a change in the interface of the library is introduced a new version should be created and the previous version should point to the last valid/compatible reference (commit) of the library.

To persevere the idempotence of pod install in a team, the `Podfile.lock` should keep track of the information necessary to retrieve the library from the reference of the first install. 

As usual with my experimental proposals this is a proof of concept, missing tests.
##### Rationale

I think that the ruby approach of versioning every release is not the best balance for CocoaPods. Objective-C is a statically compiled and heavily influenced by very stable frameworks. This is usually reflected by the community by rarely releasing breaking changes in libraries.

This approach would allow us to support with ease libraries that are in maintenance mode and unversioned libraries where the head of the repo is intended as being always backwards compatible by the author. Also it would reduce the need to ask authors to change their behavior by starting tagging.
