### PR TITLE
Better spec source validation

### DIFF
--- a/lib/cocoapods/command/spec.rb
+++ b/lib/cocoapods/command/spec.rb
@@ -316,7 +316,7 @@ module Pod
         end
 
         def source_valid?
-          spec.source && !spec.source =~ /http:\/\/EXAMPLE/
+          spec.source && !(spec.source =~ /http:\/\/EXAMPLE/)
         end
 
         def paths_starting_with_a_slash_errors


### PR DESCRIPTION
Linting a new spec file with a source entry of "http://EXAMPLE/blah.git" crashes without helpful output. I modified the existing source validation to address this case explicitly, although there may be a more general way to address the issue, either by validating source differently, or doing something to the Downloader. 
- What did you do?

Ran `pod spec lint` on a new spec file. 
- What did you expect to happen?

Either success or a helpful error message explaining what I'd done wrong.
- What happened instead?

See below.
### Stack

```
   CocoaPods : 0.10.0
        Ruby : ruby 1.8.7 (2012-02-08 patchlevel 358) [universal-darwin12.0]
    RubyGems : 1.8.24
        Host : Mac OS X 10.8 (12A269)
       Xcode : 4.4 (4F250)
Ruby lib dir : /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib
Repositories : master - https://github.com/CocoaPods/Specs.git @ 880a4b4e1e25f36ba01dd99540b2e38153749697
```
### Error

```
No such file or directory - /Users/cam/Library/Caches/CocoaPods/Git/da9199ffd58ebae9a2c6b67c7ae8e29643f38343
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/downloader/git.rb:144:in `chdir'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/downloader/git.rb:144:in `clone'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/downloader/git.rb:33:in `create_cache'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/downloader/git.rb:15:in `download'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/installer.rb:85:in `download_pod'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/installer.rb:60:in `install_dependencies!'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/installer.rb:48:in `each'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/installer.rb:48:in `install_dependencies!'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/installer.rb:108:in `install!'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:249:in `install_pod'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:236:in `peform_extensive_analysis'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:208:in `lint'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:195:in `each'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:195:in `lint'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:99:in `lint_podspecs'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:90:in `each'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:90:in `lint_podspecs'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:75:in `lint'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:47:in `send'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command/spec.rb:47:in `run'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/lib/cocoapods/command.rb:71:in `run'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.10.0/bin/pod:12
/usr/bin/pod:23:in `load'
/usr/bin/pod:23
```
