### PR TITLE
Remove intrusive, obnoxious "Cocoapods NEW_VERSION is available" message

### DIFF
--- a/lib/cocoapods/command/repo.rb
+++ b/lib/cocoapods/command/repo.rb
@@ -142,7 +142,6 @@ module Pod
           "\n[!] The `#{dir.basename.to_s}' repo requires CocoaPods #{version_msg}\n".red +
           "Update Cocoapods, or checkout the appropriate tag in the repo.\n\n"
         end
-        puts "\nCocoapods #{versions['last']} is available.\n".green if has_update(versions)
       end
 
       def self.compatible?(name)
@@ -172,15 +171,6 @@ module Pod
         supports_min = !min || bin_version >= Gem::Version.new(min)
         supports_max = !max || bin_version <= Gem::Version.new(max)
         supports_min && supports_max
-      end
-
-      def has_update(versions)
-        self.class.has_update(versions)
-      end
-
-      def self.has_update(versions)
-        last = versions['last']
-        last && Gem::Version.new(last) > bin_version
       end
 
       def self.bin_version

--- a/spec/functional/command/repo_spec.rb
+++ b/spec/functional/command/repo_spec.rb
@@ -95,10 +95,10 @@ describe "Pod::Command::Repo" do
       lambda { run_command('repo', 'update') }.should.raise Pod::Informative
     end
 
-    it "informs about a higher known CocoaPods version" do
+    it "does not inform about a higher known CocoaPods version since this is intrusive and obnoxious" do
       yaml = YAML.dump({'last' => "999.0.0"})
       File.open(versions_file, 'w') {|f| f.write(yaml) }
-      run_command('repo', 'update').should.include "Cocoapods 999.0.0 is available"
+      run_command('repo', 'update').should.not.include "Cocoapods 999.0.0 is available"
     end
 
     it "has a class method that returns if a repo is supported" do

--- a/spec/unit/command/repo_spec.rb
+++ b/spec/unit/command/repo_spec.rb
@@ -27,15 +27,5 @@ describe "Pod::Command::Repo" do
     versions = { 'max' => '0.5' }
     @command.class.send(:is_compatilbe, versions).should == false
   end
-
-  it "detects if no update is available" do
-    versions = { 'last' => '0.5' }
-    @command.class.send(:has_update, versions).should == false
-  end
-
-  it "detects if an update is available" do
-    versions = { 'last' => '0.999' }
-    @command.class.send(:has_update, versions).should == true
-  end
 end
 


### PR DESCRIPTION
I'm really sick of seeing this message appear in my builds. I'll update Cocoapods when it's ready. I don't need this library to have an attitude with me and when I choose to update it. 
