### PR TITLE
Switching subversion downloader from checkout to export

### DIFF
--- a/lib/cocoapods/downloader/subversion.rb
+++ b/lib/cocoapods/downloader/subversion.rb
@@ -4,11 +4,11 @@ module Pod
       executable :svn
 
       def download
-        svn! %|checkout "#{reference_url}" "#{target_path}"|
+        svn! "export #{reference_url}" "#{target_path}"|
       end
 
       def download_head
-        svn! %|checkout "#{trunk_url}" "#{target_path}"|
+        svn! "export #{trunk_url}" "#{target_path}"|
       end
 
       def reference_url


### PR DESCRIPTION
This is for issue #245.

I don't know ruby, so I didn't understand the '%|checkout' syntax, so I instead just put "export" into the first quoted section.

Initially I had added a --force flag to the export operation, in order to work around the downloader already having created an empty dir with the same name, but I have not included the --force flag in this pull request because as mentioned in issue 245, the solution is to prevent the downloader from creating the empty dir.  However, I don't know where in the codebase that happens, so I haven't included that change here.  Note this means this checkin will break the svn downloader.

Also unaddressed is the issue of changing the bundle copy method to not include .svn directories.
