### PR TITLE
Update AppleDoc install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ $ [sudo] gem install cocoapods
 If you want to have CocoaPods generate documentation for each library, then install the [appledoc](http://gentlebytes.com/appledoc/) tool:
 
 ```
-$ brew install appledoc --HEAD
-$ ln -sf "`brew --prefix`/Cellar/appledoc/HEAD/Templates" ~/Library/Application\ Support/appledoc
+$ brew install appledoc
 ```
 
 Now that you've got CocoaPods installed you can easily add it to your project.


### PR DESCRIPTION
@tomaz tagged a new version of AppleDoc which resolves the issue requiring the `--HEAD` param to `brew`, and @adamv [pulled in the change](https://github.com/mxcl/homebrew/pull/14693) to mxcl/homebrew that both updates to the new code and also uses the [new compile-time template location](https://github.com/tomaz/appledoc/pull/231) to avoid the second step.
