### PR TITLE
Support extracting .tar.bz2 files

### DIFF
--- a/lib/cocoapods/downloader/http.rb
+++ b/lib/cocoapods/downloader/http.rb
@@ -33,6 +33,8 @@ module Pod
           :tgz
         elsif url =~ /.tar$/
           :tar
+        elsif url =~ /.(tbz|tar\.bz2)$/
+          :tbz
         else
           nil
         end
@@ -46,6 +48,8 @@ module Pod
           "file.tgz"
         when :tar
           "file.tar"
+        when :tbz
+          "file.tbz"
         else
           raise UnsupportedFileTypeError.new "Unsupported file type: #{type}"
         end
@@ -63,6 +67,8 @@ module Pod
           tar! "xfz '#{full_filename}' -C '#{target_path}'"
         when :tar
           tar! "xf '#{full_filename}' -C '#{target_path}'"
+        when :tbz
+          tar! "xfj '#{full_filename}' -C '#{target_path}'"
         else
           raise UnsupportedFileTypeError.new "Unsupported file type: #{type}"
         end

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -33,6 +33,12 @@ describe Pod::Downloader::Http do
     downloader.type.should == :tgz
 
     downloader = Pod::Downloader.for_pod(stub_pod_with_source(
+      :http => 'http://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.bz2'
+    ))
+    downloader.should.be.instance_of Pod::Downloader::Http
+    downloader.type.should == :tbz
+
+    downloader = Pod::Downloader.for_pod(stub_pod_with_source(
       :http => 'https://testflightapp.com/media/sdk-downloads/TestFlightSDK1.0',
       :type => :zip
     ))
@@ -53,6 +59,13 @@ describe Pod::Downloader::Http do
     ))
     downloader.expects(:download_file).with(anything())
     downloader.expects(:extract_with_type).with(anything(), :tgz).at_least_once
+    downloader.download
+
+    downloader = Pod::Downloader.for_pod(stub_pod_with_source(
+      :http => 'http://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.bz2'
+    ))
+    downloader.expects(:download_file).with(anything())
+    downloader.expects(:extract_with_type).with(anything(), :tbz).at_least_once
     downloader.download
   end
 


### PR DESCRIPTION
Chartboost (and likely other sites) distribute source code in bz2
format.  Support for recognizing and extracting these files will come in
handy.
