### PR TITLE
Lazy repo update.

### DIFF
--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -142,14 +142,6 @@ module Pod
         raise Informative, "No `Podfile.lock' found in the current working directory, run `pod install'."
       end
     end
-
-    def update_spec_repos_if_necessary!
-      if @update_repo
-        UI.section 'Updating Spec Repositories' do
-          Repo.new(ARGV.new(["update"])).run
-        end
-      end
-    end
   end
 end
 

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -27,7 +27,6 @@ module Pod
           ["--no-clean",     "Leave SCM dirs like `.git' and `.svn' intact after downloading"],
           ["--no-doc",       "Skip documentation generation with appledoc"],
           ["--no-integrate", "Skip integration of the Pods libraries in the Xcode project(s)"],
-          ["--no-update",    "Skip running `pod repo update` before install"],
         ].concat(super)
       end
 
@@ -35,7 +34,6 @@ module Pod
         config.clean             = !argv.option('--no-clean')
         config.generate_docs     = !argv.option('--no-doc')
         config.integrate_targets = !argv.option('--no-integrate')
-        @update_repo             = !argv.option('--no-update')
         super unless argv.empty?
       end
 
@@ -48,7 +46,6 @@ module Pod
 
       def run
         verify_podfile_exists!
-        update_spec_repos_if_necessary!
         run_install_with_update(false)
       end
     end

--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -10,21 +10,13 @@ module Pod
       spec repos, not those from local/external sources or `:head' versions.}
       end
 
-      def self.options
-        [
-          ["--no-update", "Skip running `pod repo update` before install"],
-        ].concat(super)
-      end
-
       def initialize(argv)
-        @update_repo = !argv.option('--no-update')
         super unless argv.empty?
       end
 
       def run
         verify_podfile_exists!
         verify_lockfile_exists!
-        update_spec_repos_if_necessary!
 
         sandbox = Sandbox.new(config.project_pods_root)
         resolver = Resolver.new(config.podfile, config.lockfile, sandbox)

--- a/lib/cocoapods/command/update.rb
+++ b/lib/cocoapods/command/update.rb
@@ -12,7 +12,6 @@ module Pod
       def run
         verify_podfile_exists!
         verify_lockfile_exists!
-        update_spec_repos_if_necessary!
         run_install_with_update(true)
       end
     end

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -77,6 +77,11 @@ module Pod
             end
           end
         end if config.verbose?
+
+        UI.section 'Updating Spec Repositories' do
+          Command::Repo.new(Command::ARGV.new(["update"])).run
+        end if !(@pods_by_state[:added] + @pods_by_state[:changed]).empty? || update_mode
+
         @pods_to_lock = (lockfile.pods_names - @pods_by_state[:added] - @pods_by_state[:changed] - @pods_by_state[:removed]).uniq
       end
 


### PR DESCRIPTION
Prof of concept patch that allows `pod install` to update the repos only if needed. 

I'm not sure if we should keep the `no-update` option.
