### PR TITLE
SVN pre-download support

### DIFF
--- a/lib/cocoapods/dependency.rb
+++ b/lib/cocoapods/dependency.rb
@@ -234,7 +234,7 @@ module Pod
         def description
           "from `#{@params[:svn]}'".tap do |description|
             # TODO is the :folder param meaningful here ?
-            description << ", folder `#{@params[:folder]}'" if @params[:revision]
+            description << ", folder `#{@params[:folder]}'" if @params[:folder]
             description << ", tag `#{@params[:tag]}'" if @params[:tag]
             description << ", revision `#{@params[:revision]}'" if @params[:revision]
           end


### PR DESCRIPTION
See issue #524

There's one open point left, when the SVN cannot validate the server certificate or provide user credentials.
I had to manually run the `svn export` once before it worked right with `pod`.

Also, is the :folder parameter still meaningful in this context? What is its use anyway?
