### PR TITLE
Warn users that large libraries cause slowness during `pod install`

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -119,7 +119,7 @@ module Pod
         install_dependencies!
       end
 
-      UI.section "Generating support files" do
+      UI.section "Generating support files (may take minutes for large libraries)" do
         UI.message "- Running pre install hooks" do
           run_pre_install_hooks
         end


### PR DESCRIPTION
Generating support files for AWSiOSSDK took > 4 mins. Found & read long thread on the issue, figured a better message would have saved me the research.
