### PR TITLE
Make the default target for `platform :osx` the current system's version

### DIFF
--- a/lib/cocoapods/podfile.rb
+++ b/lib/cocoapods/podfile.rb
@@ -223,7 +223,13 @@ module Pod
         when :ios
           target = '4.3'
         when :osx
-          target = '10.6'
+          # Get the current version of OS X if we can, otherwise default to 10.6
+          begin
+            os_version = `sw_vers -productVersion`.chomp
+            target = os_version.split('.')[0, 2].join('.')
+          rescue
+            target = '10.6'
+          end
         else
           raise ::Pod::Podfile::Informative, "Unsupported platform: platform must be one of [:ios, :osx]"
         end


### PR DESCRIPTION
Installing AFNetworking is currently not working for platform `:osx` when target isn't defined (issue #578). This is due to the default target being hard coded to a version less than the minimum one that AFNetworking supports. This change makes the default target dynamic; If target is not specified in the podfile, the code will query the system for the current OS X version and use that as its target version, but will fallback to using 10.6 if it fails to get the current system's version. This should be a better default target since it will allow packages that take advantage of the most recent system's benefits to be installed in most cases without specifying the target in the podfile.
