### PR TITLE
Update Version.rb to support Semantic Versioning pre-release versions

### DIFF
--- a/lib/cocoapods/version.rb
+++ b/lib/cocoapods/version.rb
@@ -1,6 +1,14 @@
 module Pod
   class Version < Gem::Version
+    
+    # Conforms to Semantic Versioning by including a hyphen
+    VERSION_PATTERN = '[0-9]+(\.[0-9a-zA-Z\-]+)*' # :nodoc:
+    ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})*\s*\z/ # :nodoc:
 
+    def self.correct? version
+      version.to_s =~ ANCHORED_VERSION_PATTERN
+    end
+    
     # @returns A Version described by its #to_s method.
     #
     # @TODO The `from' part of the regexp should be remove before 1.0.0.
@@ -20,6 +28,12 @@ module Pod
 
     def to_s
       head? ? "HEAD based on #{super}" : super
+    end
+    
+    # Conform to Semantic Versioning instead of RubyGems
+    # pre-release gems can contain a hyphen and/or a letter
+    def prerelease?
+      @prerelease ||= @version =~ /[a-zA-Z\-]/
     end
   end
 end

--- a/spec/unit/version_spec.rb
+++ b/spec/unit/version_spec.rb
@@ -24,5 +24,23 @@ module Pod
       version.should.be.head
       version.to_s.should == 'HEAD based on 1.2.3'
     end
+    
+    it "identifies release versions" do
+      version = Version.from_string('1.0.0')
+      version.should.not.be.prerelease
+    end
+    
+    it "matches Semantic Version pre-release versions" do
+      version = Version.from_string('1.0.0a1')
+      version.should.be.prerelease
+      version = Version.from_string('1.0.0-alpha')
+      version.should.be.prerelease
+      version = Version.from_string('1.0.0-alpha.1')
+      version.should.be.prerelease
+      version = Version.from_string('1.0.0-0.3.7')
+      version.should.be.prerelease
+      version = Version.from_string('1.0.0-x.7.z.92')
+      version.should.be.prerelease
+    end
   end
 end


### PR DESCRIPTION
Modifies the regular expression used for validating versions and evaluating pre-releases to support pre-release version numbers conforming to the Semantic Versioning spec. Closes #583
