### PR TITLE
Clean paths fix

### DIFF
--- a/lib/cocoapods/local_pod.rb
+++ b/lib/cocoapods/local_pod.rb
@@ -167,7 +167,7 @@ module Pod
     #
     def clean_paths
       used = used_files
-      files = Dir.glob(root + "**/*", [File::FNM_DOTMATCH, File::FNM_CASEFOLD])
+      files = Dir.glob(root + "**/*", File::FNM_DOTMATCH | File::FNM_CASEFOLD)
 
       files.reject! do |candidate|
         candidate.end_with?('.', '..') || used.any? do |path|


### PR DESCRIPTION
This pull request contains the changes discussed in https://github.com/CocoaPods/CocoaPods/pull/572. Specifically, the `clean_paths` and `expand_paths` methods both use the `File::FNM_CASEFOLD flag in their calls to`Dir.glob`.
