### PR TITLE
Example fix

### DIFF
--- a/examples/Example.podspec
+++ b/examples/Example.podspec
@@ -13,13 +13,13 @@ Pod::Spec.new do |s|
   # s.description  = <<-DESC
   #                   An optional longer description of Example.podspec
   #
-  #                   * Markdonw format.
+  #                   * Markdown format.
   #                   * Don't worry about the indent, we strip it!
   #                  DESC
   s.homepage     = "http://EXAMPLE/Example.podspec"
 
   # Specify the license type. CocoaPods detects automatically the license file if it is named
-  # `LICENSE*.*', however if the name is different, specify it.
+  # `LICEN{C,S}E*.*', however if the name is different, specify it.
   s.license      = 'MIT (example)'
   # s.license      = { :type => 'MIT (example)', :file => 'FILE_LICENSE' }
   #

--- a/lib/cocoapods/command/spec.rb
+++ b/lib/cocoapods/command/spec.rb
@@ -230,7 +230,7 @@ Pod::Spec.new do |s|
   s.homepage     = "#{data[:homepage]}"
 
   # Specify the license type. CocoaPods detects automatically the license file if it is named
-  # `LICENSE*.*', however if the name is different, specify it.
+  # `LICEN{C,S}E*.*', however if the name is different, specify it.
   s.license      = 'MIT (example)'
   # s.license      = { :type => 'MIT (example)', :file => 'FILE_LICENSE' }
   #


### PR DESCRIPTION
Tiny docs fix to reflect being able to handle either spelling of `Licen{c,s}e*.*` so I don't do [this](https://github.com/CocoaPods/Specs/pull/803#issuecomment-10742405) again.

Referencing [this code](https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/local_pod.rb#L337) 
