### PR TITLE
Fix RubyGems too old error message

### DIFF
--- a/lib/cocoapods.rb
+++ b/lib/cocoapods.rb
@@ -7,7 +7,7 @@ require 'rubygems'
 #
 # E.g. https://github.com/CocoaPods/CocoaPods/issues/398
 unless Gem::Version::Requirement.new('>= 1.4.0').satisfied_by?(Gem::Version.new(Gem::VERSION))
-  STDERR.puts "\e[1;31m" + "Your RubyGems version (1.8.24) is too old, please update with: `gem update --system`" + "\e[0m"
+  STDERR.puts "\e[1;31m" + "Your RubyGems version (#{Gem::VERSION}) is too old, please update with: `gem update --system`" + "\e[0m"
   exit 1
 end
 


### PR DESCRIPTION
Noticed the error message showed "Your RubyGems version (1.8.24) is too old" which was not my version of RubyGems, fixed to show the system version of RubyGems instead of 1.8.24.
