### PR TITLE
Fix a bug when a local podspec is used by multiple targets with different platforms

### DIFF
--- a/lib/cocoapods/installer/target_installer.rb
+++ b/lib/cocoapods/installer/target_installer.rb
@@ -39,6 +39,8 @@ module Pod
       #                                 should be generated.
       #
       def install!(pods, sandbox)
+        pods.each { |p| p.top_specification.activate_platform(@target_definition.platform) }
+      
         self.requires_arc = pods.any? { |pod| pod.requires_arc? }
 
         @target = @project.add_pod_target(@target_definition.label, @target_definition.platform)


### PR DESCRIPTION
Here's what happened:
1. Created a Podfile with two targets, the default one (iOS) and another exclusive one (OS X 10.7).
2. Both targets reference a local podspec that requires different frameworks to be linked for iOS and OS X (the source code itself is not necessarily local).
3. CocoaPods generates separate xcconfig files for each target, but the frameworks are the same in both files. (In my case, they both had the OS X frameworks)

This change fixed the issue for me. Probably not the most elegant way to solve the problem, but probably the easiest and least likely to break anything.
