### PR TITLE
Unpack tgz files into pod's root #727

### DIFF
--- a/lib/cocoapods/downloader/http.rb
+++ b/lib/cocoapods/downloader/http.rb
@@ -73,6 +73,15 @@ module Pod
         else
           raise UnsupportedFileTypeError.new "Unsupported file type: #{type}"
         end
+        
+        # If the archive only contained a folder, move its contents to the target (#727)
+        contents = Dir[target_path.to_s+"/*"]
+        contents.delete(full_filename.to_s)
+        if contents.count == 1 && File.directory?(contents[0]) then
+          Dir[contents[0]+"/*"].each do |thing|
+            FileUtils.move thing, target_path
+          end
+        end
       end
 
     end

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -84,4 +84,23 @@ describe Pod::Downloader::Http do
     downloader.download rescue nil
 
   end
+  
+  it 'should move unpacked contents to parent dir when archive contains only a folder (#727)' do
+    downloader = Pod::Downloader.for_pod(stub_pod_with_source(
+      :http => 'http://www.openssl.org/source/openssl-1.0.0a.tar.gz'
+    ))
+    downloader.download
+    # Archive contains one folder, which contains 49 items. The archive is 1, and the
+    # parent folder that we moved stuff out of is 1.
+    Dir[downloader.target_path.to_s+"/*"].count.should == 49 + 1 + 1
+    
+    downloader = Pod::Downloader.for_pod(stub_pod_with_source(
+      :http => 'https://testflightapp.com/media/sdk-downloads/TestFlightSDK1.0.zip'
+    ))
+    downloader.download
+    
+    # Archive contains 4 files, and the archive is 1
+    Dir[downloader.target_path.to_s+"/*"].count.should == 4 + 1
+    
+  end
 end


### PR DESCRIPTION
Zip files are usually packaged with their contents in the archive file's root.
Tgz files are usually packaged with only a folder in the root.
Make them both behave the same by moving that single folder's contents up.
This is basically the opposite of what Finder does (which creates a folder for the zip file's
contents, so you always unarchive into a folder).
