### PR TITLE
Fix podspec in Podfile with no options.

### DIFF
--- a/lib/cocoapods/podfile.rb
+++ b/lib/cocoapods/podfile.rb
@@ -403,7 +403,7 @@ module Pod
         name = File.extname(name) == '.podspec' ? name : "#{name}.podspec"
         file = config.project_root + name
       else
-        file = config.project_root.glob('*.podspec').first
+        file = Pathname.glob(config.project_root + '*.podspec').first
       end
 
       spec = Specification.from_file(file)

--- a/spec/fixtures/podspecs/1st.podspec
+++ b/spec/fixtures/podspecs/1st.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = 'FirstLib'
+  s.version      = '1.0'
+  s.homepage     = 'https://firstlib.local/firstlib'
+  s.summary      = 'The First Lib'
+  s.authors      = { 'First Lib Creator' => 'creator@firstlib.local' }
+  s.source       = { :git => 'https://firstlib.local/firstlib.git', :tag => '1.0' }
+  s.source_files = 'Classes/*.{h,m}'
+  s.license      = 'MIT'
+
+  s.dependency     'FirstDep'
+end

--- a/spec/fixtures/podspecs/2nd.podspec
+++ b/spec/fixtures/podspecs/2nd.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = 'SecondLib'
+  s.version      = '1.0'
+  s.homepage     = 'https://secondlib.local/secondlib'
+  s.summary      = 'The Second Lib'
+  s.authors      = { 'Second Lib Creator' => 'creator@secondlib.local' }
+  s.source       = { :git => 'https://secondlib.local/secondlib.git', :tag => '1.0' }
+  s.source_files = 'Classes/*.{h,m}'
+  s.license      = 'MIT'
+
+  s.dependency     'SecondDep'
+end

--- a/spec/unit/podfile_spec.rb
+++ b/spec/unit/podfile_spec.rb
@@ -341,16 +341,59 @@ describe "Pod::Podfile" do
     end
   end
   describe "concerning the podspec method" do
-    xit "it can use use the dependencies of a podspec" do
-
+    before do
+      FileUtils.cp(fixture('podspecs/1st.podspec'), config.project_root)
+      FileUtils.cp(fixture('podspecs/2nd.podspec'), config.project_root)
     end
 
-    xit "it allows to specify the name of a podspec" do
+    it "it uses the first podspec in the project root by default" do
+      podfile = Pod::Podfile.new do
+        platform :ios
+        podspec
+      end
 
+      podfile.dependencies.size.should == 1
+      podfile.dependency_by_top_level_spec_name('FirstDep').should == Pod::Dependency.new('FirstDep')
     end
 
-    xit "it allows to specify the path of a podspec" do
+    it "it allows to specify the name of a podspec" do
+      podfile = Pod::Podfile.new do
+        platform :ios
+        podspec :name => '2nd.podspec'
+      end
 
+      podfile.dependencies.size.should == 1
+      podfile.dependency_by_top_level_spec_name('SecondDep').should == Pod::Dependency.new('SecondDep')
+    end
+
+    it "it allows to specify the name of a podspec without extension" do
+      podfile = Pod::Podfile.new do
+        platform :ios
+        podspec :name => '2nd'
+      end
+
+      podfile.dependencies.size.should == 1
+      podfile.dependency_by_top_level_spec_name('SecondDep').should == Pod::Dependency.new('SecondDep')
+    end
+
+    it "it allows to specify the path of a podspec" do
+      podfile = Pod::Podfile.new do
+        platform :ios
+        podspec :path => (config.project_root + '2nd.podspec').to_s
+      end
+
+      podfile.dependencies.size.should == 1
+      podfile.dependency_by_top_level_spec_name('SecondDep').should == Pod::Dependency.new('SecondDep')
+    end
+
+    it "it allows to specify the path of a podspec without extension" do
+      podfile = Pod::Podfile.new do
+        platform :ios
+        podspec :path => (config.project_root + '2nd').to_s
+      end
+
+      podfile.dependencies.size.should == 1
+      podfile.dependency_by_top_level_spec_name('SecondDep').should == Pod::Dependency.new('SecondDep')
     end
   end
 


### PR DESCRIPTION
Added specs to test podspec method inside Podfile. Specs for the
default, no options version; the :name version and the :path
version.

I have added two fixture podspecs (`1st.podspec` and `2nd.podspec`) to test the default option, and the name and path options. There is already a couple of podspecs in the fixture directories, so if someone wants me to use a couple of those, instead of adding two new ones, just ask.

Should fix #708 
