### PR TITLE
Add support for Core Data model

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -19,6 +19,10 @@ install_resource()
       echo "rsync -rp ${PODS_ROOT}/$1 ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
       rsync -rp "${PODS_ROOT}/$1" "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
       ;;
+    *.xcdatamodeld)
+      echo "xcrun momc ${PODS_ROOT}/$1 ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename $1 .xcdatamodeld`.momd"
+      xcrun momc "${PODS_ROOT}/$1" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename $1 .xcdatamodeld`.momd"
+      ;;
     *)
       echo "cp -R ${PODS_ROOT}/$1 ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
       cp -R "${PODS_ROOT}/$1" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"


### PR DESCRIPTION
Instead of just copying the `xcdatamodeld` file, it has to be compiled first - like xib and storyboard files.

I've seen a [workaround](https://gist.github.com/alloy/38a3400bffc0837af5f3) to add Core Data model files as a resource, where the `xcdatamodeld` file is compiled first and the resulted `momd` files is added as a resource. I don't like this solutions because it adds overhead to the `podspec` file and I have to do it for every model file.

I'm not sure why this hasn't been implemented already in the install resources script - seems so obvious...
