### PR TITLE
Ability to manually set DNS_BLOCK_ASSERTIONS=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Fixes
+
+* [#802](https://github.com/CocoaPods/CocoaPods/issues/802): Ability to add
+`-DNS_BLOCK_ASSERTIONS=1` to `OTHER_CFLAGS` and `OTHER_CPLUSPLUSFLAGS` with
+  `set_dns_block_assertions_flag!` to your Podfile.
+
 ## 0.16.2
 [CocoaPods](https://github.com/CocoaPods/CocoaPods/compare/0.16.1...0.16.2) • [Xcodeproj](https://github.com/CocoaPods/Xcodeproj/compare/0.4.1...0.4.3)
 

--- a/lib/cocoapods/installer/target_installer.rb
+++ b/lib/cocoapods/installer/target_installer.rb
@@ -74,6 +74,8 @@ module Pod
         xcconfig = Xcodeproj::Config.new({
           'ALWAYS_SEARCH_USER_PATHS' => 'YES', # needed to make EmbedReader build
           'OTHER_LDFLAGS'            => default_ld_flags,
+          'OTHER_CFLAGS'             => default_c_flags,
+          'OTHER_CPLUSPLUSFLAGS'     => default_cplusplus_flags,
           'HEADER_SEARCH_PATHS'      => '${PODS_HEADERS_SEARCH_PATHS}',
           # CocoaPods global keys
           'PODS_ROOT'                         => @target_definition.relative_pods_root,
@@ -129,6 +131,8 @@ module Pod
         @target.build_configurations.each do |config|
           config.base_configuration_reference = xcconfig_file
           config.build_settings['OTHER_LDFLAGS'] = ''
+          config.build_settings['OTHER_CFLAGS'] = ''
+          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = ''
           config.build_settings['GCC_PREFIX_HEADER'] = @target_definition.prefix_header_name
           config.build_settings['PODS_ROOT'] = '${SRCROOT}'
           config.build_settings['PODS_HEADERS_SEARCH_PATHS'] = '${PODS_BUILD_HEADERS_SEARCH_PATHS}'
@@ -171,6 +175,19 @@ module Pod
         flags << '-fobjc-arc' if @podfile.set_arc_compatibility_flag? && self.requires_arc
         flags.join(" ")
       end
+
+      def default_c_flags
+        flags = []
+        flags << '-DNS_BLOCK_ASSERTIONS=1' if @podfile.set_dns_block_assertions_flag?
+        flags.join(" ")
+      end
+
+      def default_cplusplus_flags
+        flags = []
+        flags << '-DNS_BLOCK_ASSERTIONS=1' if @podfile.set_dns_block_assertions_flag?
+        flags.join(" ")
+      end
+
     end
   end
 end

--- a/lib/cocoapods/podfile.rb
+++ b/lib/cocoapods/podfile.rb
@@ -503,6 +503,10 @@ module Pod
       @set_arc_compatibility_flag = true
     end
 
+    def set_dns_block_assertions_flag!
+      @set_dns_block_assertions_flag = true
+    end
+
     # Not attributes
 
     def podfile?
@@ -526,6 +530,10 @@ module Pod
 
     def set_arc_compatibility_flag?
       @set_arc_compatibility_flag
+    end
+
+    def set_dns_block_assertions_flag?
+      @set_dns_block_assertions_flag
     end
 
     def user_build_configurations

--- a/spec/unit/installer/target_installer_spec.rb
+++ b/spec/unit/installer/target_installer_spec.rb
@@ -68,6 +68,13 @@ describe Pod::Installer::TargetInstaller do
     @installer.xcconfig.to_hash['OTHER_LDFLAGS'].split(" ").should.include("-fobjc-arc")
   end
 
+  it "adds the -DNS_BLOCK_ASSERTIONS=1 to OTHER_CFLAGS if set_dns_block_assertions_flag is set" do
+    @podfile.stubs(:set_dns_block_assertions_flag? => true)
+    do_install!
+    @installer.xcconfig.to_hash['OTHER_CFLAGS'].split(" ").should.include("-DNS_BLOCK_ASSERTIONS=1")
+    @installer.xcconfig.to_hash['OTHER_CPLUSPLUSFLAGS'].split(" ").should.include("-DNS_BLOCK_ASSERTIONS=1")
+  end
+
   it "does not enable the GCC_WARN_INHIBIT_ALL_WARNINGS flag by default" do
     do_install!
     @installer.target.build_configurations.each do |config|

--- a/spec/unit/podfile_spec.rb
+++ b/spec/unit/podfile_spec.rb
@@ -79,6 +79,10 @@ describe "Pod::Podfile" do
     Pod::Podfile.new { set_arc_compatibility_flag! }.should.set_arc_compatibility_flag
   end
 
+  it "specifies that DNS_BLOCK_ASSERTIONS flag should be generated" do
+    Pod::Podfile.new { set_dns_block_assertions_flag! }.should.set_dns_block_assertions_flag
+  end
+
   it "stores a block that will be called with the Installer before the target integration" do
     yielded = nil
     Pod::Podfile.new do


### PR DESCRIPTION
Ability to add
`-DNS_BLOCK_ASSERTIONS=1` to `OTHER_CFLAGS` and `OTHER_CPLUSPLUSFLAGS` with
  `set_dns_block_assertions_flag!` to your Podfile.
Possibly closes [#802](https://github.com/CocoaPods/CocoaPods/issues/802)
