### PR TITLE
Proposed extension for issue #812

### DIFF
--- a/lib/cocoapods/downloader/http.rb
+++ b/lib/cocoapods/downloader/http.rb
@@ -26,6 +26,16 @@ module Pod
         options[:type] || type_with_url(url)
       end
 
+      def should_flatten?
+        if options.has_key? :flatten
+          options[:flatten] # spec file can always override
+        elsif [:tgz, :tar, :tbz].include? type
+          true # those archives flatten by default
+        else
+          false # all others (actually only .zip) default not to flatten
+        end
+      end
+
       private
       def type_with_url(url)
         if url =~ /.zip$/
@@ -74,8 +84,7 @@ module Pod
           raise UnsupportedFileTypeError.new "Unsupported file type: #{type}"
         end
 
-        # If the archive is a tarball and it only contained a folder, move its contents to the target (#727)
-        if [:tgz, :tar, :tbz].include? type
+        if should_flatten?
           contents = target_path.children
           contents.delete(full_filename)
           entry = contents.first

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -101,4 +101,15 @@ describe Pod::Downloader::Http do
     # Archive contains 4 files, and the archive is 1
     Dir.glob(downloader.target_path + '*').count.should == 4 + 1
   end
+
+  it 'should flatten zip archives, when the spec explicitly demands it' do
+    downloader = Pod::Downloader.for_pod(stub_pod_with_source(
+      :http => 'https://github.com/kevinoneill/Useful-Bits/archive/1.0.zip',
+      :flatten => true
+    ))
+    downloader.download
+    # Archive contains one folder, which contains 8 items. The archive is 1, and the
+    # parent folder that we moved stuff out of is 1.
+    Dir.glob(downloader.target_path + '*').count.should == 8 + 1 + 1
+  end
 end


### PR DESCRIPTION
With the change in 0.16.3, which disabled flattening for zip files
some pods seem to break. While the rationale for the flattening
change is a good one, it would be nice to reenable flattening support
explicitly in the source configuration for your pod.

references https://github.com/CocoaPods/CocoaPods/issues/812
