### PR TITLE
Add #import <Foundation/Foundation.h> to generated source so it compiles…

### DIFF
--- a/lib/cocoapods/generator/dummy_source.rb
+++ b/lib/cocoapods/generator/dummy_source.rb
@@ -10,6 +10,7 @@ module Pod
 
       def save_as(pathname)
         pathname.open('w') do |source|
+          source.puts "#import <Foundation/Foundation.h>"
           source.puts "@interface #{class_name} : NSObject"
           source.puts "@end"
           source.puts "@implementation #{class_name}"


### PR DESCRIPTION
... without a prefix header in the project's build settings.
