### PR TITLE
Replacing "Remove" messages color .red with .yellow -

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -190,9 +190,9 @@ module Pod
       sandbox.public_headers.implode!
 
       unless sandbox_state.deleted.empty?
-        title_options = { :verbose_prefix => "-> ".red }
+        title_options = { :verbose_prefix => "-> ".yellow }
         sandbox_state.deleted.each do |pod_name|
-          UI.titled_section("Removing #{pod_name}".red, title_options) do
+          UI.titled_section("Removing #{pod_name}".yellow, title_options) do
             sandbox.clean_pod(pod_name)
           end
         end


### PR DESCRIPTION
Although (incredibly) superficial it always scares the crap out of me when I see red in my terminal(s). May I suggest a more neutral yellow (notification) instead? 

Removed pods are (usually) by design.
