### PR TITLE
Fix Pods-resources.sh: add missing newline between install_resource calls

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -70,7 +70,7 @@ module Pod
       def script
         script = install_resources_function
         resources.each do |resource|
-          script += "install_resource '#{resource}'"
+          script += "install_resource '#{resource}'\n"
         end
         script
       end


### PR DESCRIPTION
After #1030 `Pods-resources.sh` fails if more than one resource is present because there are no newlines between `install_resource` calls:

```
install_resource 'MyFile.xib'install_resource 'arrow.png'
```

Error (edited):

```
PhaseScriptExecution "Copy Pods Resources" 
...
rsync -av --exclude '*/.svn/*' .../MyFile.xibinstall_resource .../arrow.png
MyFile.xibinstall_resource" failed: No such file or directory (2)

```
