### PR TITLE
Truncating resources-to-copy.txt if it already exists

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -81,7 +81,7 @@ module Pod
 #!/bin/sh
 
 RESOURCES_TO_COPY=${PODS_ROOT}/resources-to-copy.txt
-touch "$RESOURCES_TO_COPY"
+> "$RESOURCES_TO_COPY"
 
 install_resource()
 {


### PR DESCRIPTION
To fix the problem described in https://github.com/CocoaPods/CocoaPods/issues/1087.
