### PR TITLE
Prevent creation of multiple Resource Bundle targets with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 ###### Bug Fixes
 
+* Only create a single resource bundle for all targets. Prior to this change a resource bundle included
+  into multiple targets within the project would create duplicately named targets in the Pods Xcode project,
+  causing duplicately named Schemes to be created on each invocation of `pod install`. All targets that reference
+  a given resource bundle now have dependencies on a single common target.
+
+  [Blake Watters](https://github.com/blakewatters)
+  [#1338](https://github.com/CocoaPods/CocoaPods/issues/1338)
+  
 * Solved outstanding issues with CocoaPods resource bundles and Archive builds:
   1. The rsync task copies symlinks into the App Bundle, producing an invalid app. This change add `--copy-links`
   to the rsync invocation to ensure the target files are copied rather than the symlink.

--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -65,6 +65,11 @@ module Pod
         UI.message "- Adding resource bundles to Pods project" do
           library.file_accessors.each do |file_accessor|
             file_accessor.resource_bundles.each do |bundle_name, paths|
+              # Add a dependency on an existing Resource Bundle target if possible
+              if bundle_target = project.targets.detect { |target| target.name == bundle_name }
+                target.add_dependency(bundle_target)
+                next
+              end
               file_references = paths.map { |sf| project.reference_for_path(sf) }
               group = project.group_for_spec(file_accessor.spec.name, :products)
               product_group = project.group_for_spec(file_accessor.spec.name, :resources)


### PR DESCRIPTION
This pull request replaces the work previously done on CocoaPods/CocoaPods#1338.

With this change in place a Resource Bundle will only result in the creation of a single target in Pods.xcodeproj
