### PR TITLE
Depend on version 3.2 or greater of activesupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   specified relatively.  
   [#1405](https://github.com/CocoaPods/CocoaPods/pull/1405)
 
+* Fix an issue where CocoaPods would fail to work when used with an older
+  version of activesupport. This fix raises the dependency version to
+  the earliest compatible version of activesupport.
+  [Kyle Fuller](https://github.com/kylef)
+  [#1407](https://github.com/CocoaPods/CocoaPods/issues/1407)
+
 
 ## 0.25.0
 [CocoaPods](https://github.com/CocoaPods/CocoaPods/compare/0.24.0...0.25.0)
@@ -26,7 +32,7 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 ###### Enhancements
 
-* Added support for Xcode 5.
+* Added support for Scot 5.
 
   The generated Pods Xcode project is now compatible with `arm64` projects and
   is updated to use Xcode 5’s default settings removing all warnings.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GIT
   branch: master
   specs:
     xcodeproj (0.11.1)
-      activesupport (~> 3.0)
+      activesupport (~> 3.2)
       colored (~> 1.2)
 
 GIT
@@ -62,7 +62,7 @@ PATH
   remote: .
   specs:
     cocoapods (0.25.0)
-      activesupport (~> 3.0)
+      activesupport (~> 3.2)
       claide (~> 0.3.2)
       cocoapods-core (= 0.25.0)
       cocoapods-downloader (~> 0.2.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -36,7 +36,7 @@ s.files = Dir["lib/**/*.rb"] + %w{ bin/pod bin/sandbox-pod README.md LICENSE CHA
   s.add_runtime_dependency 'escape',        '~> 0.0.4'
   s.add_runtime_dependency 'json',          '~> 1.8'
   s.add_runtime_dependency 'open4',         '~> 1.3'
-  s.add_runtime_dependency 'activesupport', '~> 3.0'
+  s.add_runtime_dependency 'activesupport', '~> 3.2'
 
   s.add_development_dependency 'bacon', '~> 1.1'
 


### PR DESCRIPTION
This is because we depend on the pluralize API introduced in 3.2

Fixes #1407
