### PR TITLE
separated spec:unit from spec:unit_quiet

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -167,9 +167,16 @@ namespace :spec do
 
   #--------------------------------------#
 
+  unit_specs_command = "bundle exec bacon #{specs('unit/**')}"
+
   desc "Run the unit specs"
   task :unit => :unpack_fixture_tarballs do
-    sh "bundle exec bacon #{specs('unit/**')} -q"
+    sh unit_specs_command
+  end
+
+  desc "Run the unit specs quietly (fail fast, display only one failure)"
+  task :unit_quiet => :unpack_fixture_tarballs do
+    sh "#{unit_specs_command} -q"
   end
 
   #--------------------------------------#


### PR DESCRIPTION
When you run `rake spec:unit`,  bacon stops running tests and shows you the first failure.
This is due to `-q` flag being set by default in our rake task.

It runs in about 1.5 seconds which is quite nice if you're hunting for a particular bug,
so I've kept that behavior as `rake spec:unit_quiet`.

```
29 disabled specifications
524 specifications (0 requirements), 0 failures, 1 errors
rake aborted!
Command failed with status (1): [bundle exec bacon spec/unit/installer_spec...]
/Users/musalj/code/OSS/cocoapods/CocoaPods/Rakefile:172:in `block (2 levels) in <top (required)>'
Tasks: TOP => spec:unit
(See full trace by running task with --trace)
        1.67 real         1.37 user         0.28 sys
```

However, the default `rake spec:unit` task should show all the failures.
