### PR TITLE
fix installing cocoapods on mavericks

### DIFF
--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -26,6 +26,8 @@ s.files = Dir["lib/**/*.rb"] + %w{ bin/pod bin/sandbox-pod README.md LICENSE CHA
   s.executables   = %w{ pod sandbox-pod }
   s.require_paths = %w{ lib }
 
+  # Installing cocoapods on Mavericks system ruby fails without Rake.
+  s.add_runtime_dependency 'rake'
   # Link with the version of CocoaPods-Core
   s.add_runtime_dependency 'cocoapods-core',       "= #{Pod::VERSION}"
   s.add_runtime_dependency 'claide',               '~> 0.3.2'


### PR DESCRIPTION
It seems like rake isn't installed by default on system ruby (Mavericks).
I haven't required a rake version on purpose, if you know what I mean.
