### PR TITLE
Use `cocoapods` as CLAide#Command.plugin_prefix

### DIFF
--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -26,6 +26,7 @@ module Pod
     self.default_subcommand = 'install'
     self.command = 'pod'
     self.description = 'CocoaPods, the Objective-C library package manager.'
+    self.plugin_prefix = 'cocoapods'
 
     def self.options
       [


### PR DESCRIPTION
To create a CocoaPods subcommand plugin gem, add the file
`lib/cocoapods_plugin.rb` and load your subcommand implementation from there.

When the `pod` command runs, it will look for that file in your gem and load
it before parsing the command line.

Use this PR with https://github.com/CocoaPods/CLAide/pull/3 .
