### PR TITLE
Fix linter not throwing errors when a vendored library's path is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Joshua Kalpin](https://github.com/Kapin)
   [Core#38](https://github.com/CocoaPods/Core/pull/38)
 
-* Vendored Libraries' paths are now validated correctly
+* Vendored Libraries and Vendored Frameworks now have their paths validated correctly.
   [Joshua Kalpin](https://github.com/Kapin)
   [#1567](https://github.com/CocoaPods/CocoaPods/pull/1567)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -250,7 +250,7 @@ module Pod
     # @return [void]
     #
     def check_file_patterns
-      [:source_files, :resources, :preserve_paths, :vendored_libraries].each do |attr_name|
+      [:source_files, :resources, :preserve_paths, :vendored_libraries, :vendored_frameworks].each do |attr_name|
         # file_attr = Specification::DSL.attributes.values.find{|attr| attr.name == attr_name }
         if !file_accessor.spec_consumer.send(attr_name).empty? && file_accessor.send(attr_name).empty?
           error "The `#{attr_name}` pattern did not match any file."


### PR DESCRIPTION
This should fix #1559
