### PR TITLE
Validate on all pod commands that the user is using a terminal in utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Swizzlr](https://github.com/swizzlr)
   [#1560](https://github.com/CocoaPods/CocoaPods/pull/1560)
 
+* Users are now warned if their terminal encoding is not UTF-8. This fixes an issue
+  with a small percentage of pod names that are incompatible with ASCII.
+  [Joshua Kalpin](https://github.com/Kapin)
+  [#1570](https://github.com/CocoaPods/CocoaPods/pull/1570)
+
 
 ## 0.27.1
 [CocoaPods](https://github.com/CocoaPods/CocoaPods/compare/0.26.2...0.27.1)

--- a/bin/pod
+++ b/bin/pod
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 
+if RUBY_VERSION > '1.8.7' && Encoding.default_external != Encoding::UTF_8
+  puts "\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding."
+  puts "See https://github.com/CocoaPods/guides.cocoapods.org/issues/26 for details on how to fix this\e[0m"
+end
+
 if $0 == __FILE__ && !ENV['COCOAPODS_NO_BUNDLER']
   ENV['BUNDLE_GEMFILE'] = File.expand_path('../../Gemfile', __FILE__)
   require "rubygems"
@@ -10,7 +15,7 @@ elsif ENV['COCOAPODS_NO_BUNDLER']
   gem "cocoapods"
 end
 
-if (ENV['CP_STDOUT_SYNC'] == 'TRUE')
+if ENV['CP_STDOUT_SYNC'] == 'TRUE'
   STDOUT.sync = true
 end
 


### PR DESCRIPTION
Squash of #1570 that fixes #1542.
