### PR TITLE
Install pods recursively.

### DIFF
--- a/spec/functional/command/project_spec.rb
+++ b/spec/functional/command/project_spec.rb
@@ -15,9 +15,28 @@ module Pod
 
   describe Command::Install do
 
-    it "tells the user that no Podfile or podspec was found in the current working dir" do
+    it "tells the user that no Podfile or podspec was found in the current working dir or subdirs" do
       exception = lambda { run_command('install', '--no-repo-update') }.should.raise Informative
       exception.message.should.include "No `Podfile' found in the current working directory."
+    end
+    
+    describe "concerning recursive searches of Podfiles and podspecs" do
+      before do
+        @prevdir = (Dir.getwd)
+        Dir.mkdir(temporary_directory + 'subdir')
+        file = temporary_directory + 'subdir/' + 'Podfile'
+        File.open(file, 'w') {|f| f.write('platform :ios') }
+        Dir.chdir(temporary_directory)
+      end
+      
+      after do
+        File.delete(temporary_directory + 'subdir/' + 'Podfile')
+        Dir.rmdir(temporary_directory + 'subdir/')
+        Dir.chdir(@prevdir)
+      end
+      it "finds the Podfile in subdir" do
+        lambda { run_command('install', '--no-repo-update') }.should.not.raise Informative
+      end
     end
 
   end


### PR DESCRIPTION
Find a test describing the behaviour in the commit.

I have a workspace with a podfile in a subdirectory. The workspace contains a private library, a Mac harness and an iOS harness. The iOS harness is using the podfile. I want Cocoapods to pod install in the top level directory by searching recursively for a podfile, then changing to that directory and running a pod install. This would benefit projects which have a podspec which needs installing and a sample project. We could suppress it using '--no-recursive' or even offer an environment variable.
