### PR TITLE
Clarify author documentation and template

### DIFF
--- a/lib/cocoapods/command/spec.rb
+++ b/lib/cocoapods/command/spec.rb
@@ -493,7 +493,7 @@ Pod::Spec.new do |s|
   #
   #  Specify the authors of the library, with email addresses. Email addresses
   #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you don't want to provide email addresses.
+  #  accepts just a name if you'd rather not provide an email addresses.
   #
   #  Specify a social_media_url where others can refer to, for example a twitter
   #  profile URL.


### PR DESCRIPTION
I noticed pod spec writers sometimes leaving in "other author" for the author in their specs, and since this slightly dirty data makes the cocoapods.org search engine find pods which should not be found, I am trying to make a start such that people provide cleaner data.

This removes the "other author" in the example.
