### PR TITLE
Pod init should save xcodeproj if it was defined

### DIFF
--- a/lib/cocoapods/command/init.rb
+++ b/lib/cocoapods/command/init.rb
@@ -31,12 +31,13 @@ module Pod
         raise Informative, "Existing Podfile found in directory" unless config.podfile.nil?
         if @project_path
           help! "Xcode project at #{@project_path} does not exist" unless File.exist? @project_path
+          project_path = @project_path
         else
           raise Informative, "No xcode project found, please specify one" unless @project_paths.length > 0
           raise Informative, "Multiple xcode projects found, please specify one" unless @project_paths.length == 1
-          @project_path = @project_paths.first
+          project_path = @project_paths.first
         end
-        @xcode_project = Xcodeproj::Project.open(@project_path)
+        @xcode_project = Xcodeproj::Project.open(project_path)
       end
 
       def run
@@ -51,7 +52,9 @@ module Pod
       # @return [String] the text of the Podfile for the provided project
       #
       def podfile_template(project)
-        podfile = <<-PLATFORM.strip_heredoc
+        podfile = ''
+        podfile << "xcodeproj '#{@project_path}'\n\n" if @project_path
+        podfile << <<-PLATFORM.strip_heredoc
           # Uncomment this line to define a global platform for your project
           # platform :ios, "6.0"
         PLATFORM

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -122,5 +122,27 @@ module Pod
       end
     end
 
+    it "saves xcode project file in Podfile if one was supplied" do
+      Dir.chdir(temporary_directory) do
+        Xcodeproj::Project.new(temporary_directory + 'test1.xcodeproj').save
+        Xcodeproj::Project.new(temporary_directory + 'Project.xcodeproj').save
+
+        run_command('init', 'Project.xcodeproj')
+
+        target_definition = config.podfile.target_definitions.values.first
+        target_definition.user_project_path.should == 'Project.xcodeproj'
+      end
+    end
+
+    it "doesn't save xcode project file in Podfile if one wasn't supplied" do
+      Dir.chdir(temporary_directory) do
+        Xcodeproj::Project.new(temporary_directory + 'Project.xcodeproj').save
+
+        run_command('init')
+
+        target_definition = config.podfile.target_definitions.values.first
+        target_definition.user_project_path.should == nil
+      end
+    end
   end
 end


### PR DESCRIPTION
``` bash
$ pod init Project.xcodeproj
$ pod
Analyzing dependencies
[!] Could not automatically select an Xcode project. Specify one in your Podfile like so:

    xcodeproj 'path/to/Project.xcodeproj
```

Pod init should save a line defining the project as the pod install error indicates.
