### PR TITLE
Radically reduce first run pod setup bandwidth.

### DIFF
--- a/lib/cocoapods/command/repo.rb
+++ b/lib/cocoapods/command/repo.rb
@@ -34,7 +34,7 @@ module Pod
         def run
           UI.section("Cloning spec repo `#{@name}` from `#{@url}`#{" (branch `#{@branch}`)" if @branch}") do
             config.repos_dir.mkpath
-            Dir.chdir(config.repos_dir) { git!("clone '#{@url}' #{@name}") }
+            Dir.chdir(config.repos_dir) { git!("clone --depth=1 '#{@url}' #{@name}") }
             Dir.chdir(dir) { git!("checkout #{@branch}") } if @branch
             SourcesManager.check_version_information(dir)
           end


### PR DESCRIPTION
Given that Cocoapods doesn't need the history of the Specs repo we can radically improve the initial setup time by only checking out HEAD. This reduces the initial download from >200MB to roughly 3.5MB, a massive win for folks with slow interwebs.

git pull/git fetch+git rebase work as expected.
