### PR TITLE
Uniformize spec template quotes

### DIFF
--- a/lib/cocoapods/command/spec.rb
+++ b/lib/cocoapods/command/spec.rb
@@ -461,9 +461,9 @@ Pod::Spec.new do |s|
   #  summary should be tweet-length, and the description more in depth.
   #
 
-  s.name         = '#{data[:name]}'
-  s.version      = '#{data[:version]}'
-  s.summary      = '#{data[:summary]}'
+  s.name         = "#{data[:name]}"
+  s.version      = "#{data[:version]}"
+  s.summary      = "#{data[:summary]}"
 
   s.description  = <<-DESC
                    A longer description of #{data[:name]} in Markdown format.
@@ -474,8 +474,8 @@ Pod::Spec.new do |s|
                    * Finally, don't worry about the indent, CocoaPods strips it!
                    DESC
 
-  s.homepage     = '#{data[:homepage]}'
-  # s.screenshots  = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
+  s.homepage     = "#{data[:homepage]}"
+  # s.screenshots  = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
 
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -485,8 +485,8 @@ Pod::Spec.new do |s|
   #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
   #
 
-  s.license      = 'MIT (example)'
-  # s.license      = { :type => 'MIT', :file => 'FILE_LICENSE' }
+  s.license      = "MIT (example)"
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
 
 
   # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -499,10 +499,10 @@ Pod::Spec.new do |s|
   #  profile URL.
   #
   
-  s.author             = { '#{data[:author_name]}' => '#{data[:author_email]}' }
-  # Or just: s.author  = '#{data[:author_name]}'
-  # s.authors          = { '#{data[:author_name]}' => '#{data[:author_email]}' }
-  # s.social_media_url = 'http://twitter.com/#{data[:author_name]}'
+  s.author             = { "#{data[:author_name]}" => "#{data[:author_email]}" }
+  # Or just: s.author    = "#{data[:author_name]}"
+  # s.authors            = { "#{data[:author_name]}" => "#{data[:author_email]}" }
+  # s.social_media_url   = "http://twitter.com/#{data[:author_name]}"
 
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
@@ -511,11 +511,11 @@ Pod::Spec.new do |s|
   #
 
   # s.platform     = :ios
-  # s.platform     = :ios, '5.0'
+  # s.platform     = :ios, "5.0"
 
   #  When using multiple platforms
-  # s.ios.deployment_target = '5.0'
-  # s.osx.deployment_target = '10.7'
+  # s.ios.deployment_target = "5.0"
+  # s.osx.deployment_target = "10.7"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -524,7 +524,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => '#{data[:source_url]}', #{data[:ref_type]} => '#{data[:ref]}' }
+  s.source       = { :git => "#{data[:source_url]}", #{data[:ref_type]} => "#{data[:ref]}" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -535,10 +535,10 @@ Pod::Spec.new do |s|
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = 'Classes', 'Classes/**/*.{h,m}'
-  s.exclude_files = 'Classes/Exclude'
+  s.source_files  = "Classes", "Classes/**/*.{h,m}"
+  s.exclude_files = "Classes/Exclude"
 
-  # s.public_header_files = 'Classes/**/*.h'
+  # s.public_header_files = "Classes/**/*.h"
 
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -549,10 +549,10 @@ Pod::Spec.new do |s|
   #  non-essential files like tests, examples and documentation.
   #
 
-  # s.resource  = 'icon.png'
-  # s.resources = 'Resources/*.png'
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
 
-  # s.preserve_paths = 'FilesToSave', 'MoreFilesToSave'
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
 
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -561,11 +561,11 @@ Pod::Spec.new do |s|
   #  the lib prefix of their name.
   #
 
-  # s.framework  = 'SomeFramework'
-  # s.frameworks = 'SomeFramework', 'AnotherFramework'
+  # s.framework  = "SomeFramework"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
 
-  # s.library   = 'iconv'
-  # s.libraries = 'iconv', 'xml2'
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
 
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -576,8 +576,8 @@ Pod::Spec.new do |s|
 
   # s.requires_arc = true
 
-  # s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
-  # s.dependency 'JSONKit', '~> 1.4'
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
 
 end
       SPEC


### PR DESCRIPTION
Take that as a personal OCD, but I’d rather see uniform quotation marks in the spec template. Or am I missing something?
