### PR TITLE
Pod search "+" raises an exception

### DIFF
--- a/lib/cocoapods/command/search.rb
+++ b/lib/cocoapods/command/search.rb
@@ -35,6 +35,10 @@ module Pod
       def validate!
         super
         help! "A search query is required." unless @query
+
+        /#{@query.join(' ').strip}/
+      rescue RegexpError
+        help! "A valid regular expression is required."
       end
 
       def run

--- a/spec/functional/command/search_spec.rb
+++ b/spec/functional/command/search_spec.rb
@@ -49,7 +49,11 @@ module Pod
       output = run_command('search', 'BananaLib', '--silent')
       output.should.include? 'BananaLib'
     end
-    
+
+    it "shows a friendly message when searching with invalid regex" do
+      lambda { run_command('search', '+') }.should.raise CLAide::Help
+    end
+
     describe "option --web" do
 
       extend SpecHelper::TemporaryRepos


### PR DESCRIPTION
### What did you do?

``` shell
$ pod search +
```
### What did you expect to happen?

I'd find a list of all pod's like http://cocoapods.org/?q=name%3A%2B
### What happened instead?

See stack trace
### Stack

```
   CocoaPods : 0.29.0
        Ruby : ruby 2.0.0p247 (2013-06-27 revision 41674) [universal.x86_64-darwin13]
    RubyGems : 2.0.3
        Host : Mac OS X 10.9.1 (13B42)
       Xcode : 5.0.2 (5A3005)
Ruby lib dir : /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib
Repositories : master - https://github.com/CocoaPods/Specs.git @ 5921fb92652ebde992a2b820bceeae71ac463530
```
### Error

```
RegexpError - target of repeat operator is not specified: /+/i
/Users/kylef/gems/gems/cocoapods-core-0.29.0/lib/cocoapods-core/source.rb:211:in `search_by_name'
/Users/kylef/gems/gems/cocoapods-core-0.29.0/lib/cocoapods-core/source/aggregate.rb:123:in `block in search_by_name'
/Users/kylef/gems/gems/cocoapods-core-0.29.0/lib/cocoapods-core/source/aggregate.rb:122:in `each'
/Users/kylef/gems/gems/cocoapods-core-0.29.0/lib/cocoapods-core/source/aggregate.rb:122:in `search_by_name'
/Users/kylef/gems/gems/cocoapods-0.29.0/lib/cocoapods/sources_manager.rb:76:in `search_by_name'
/Users/kylef/gems/gems/cocoapods-0.29.0/lib/cocoapods/command/search.rb:63:in `local_search'
/Users/kylef/gems/gems/cocoapods-0.29.0/lib/cocoapods/command/search.rb:44:in `run'
/Users/kylef/gems/gems/claide-0.4.0/lib/claide/command.rb:213:in `run'
/Users/kylef/gems/gems/cocoapods-0.29.0/lib/cocoapods/command.rb:51:in `run'
/Users/kylef/gems/gems/cocoapods-0.29.0/bin/pod:24:in `<top (required)>'
/Users/kylef/gems/bin/pod:23:in `load'
/Users/kylef/gems/bin/pod:23:in `<main>'
```
