### PR TITLE
CocoaPod's shouldn't let you run as root

### DIFF
--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -43,11 +43,14 @@ module Pod
     end
 
     def self.run(argv)
+      help! "You cannot run CocoaPods as root" if Process.uid == 0
+
       argv = CLAide::ARGV.new(argv)
       if argv.flag?('version')
         UI.puts VERSION
         exit 0
       end
+
       super(argv)
       UI.print_warnings
     end

--- a/spec/functional/command_spec.rb
+++ b/spec/functional/command_spec.rb
@@ -14,5 +14,9 @@ module Pod
       UI.output.should.include 'spec/fixtures/spec-repos/master/AFNetworking'
     end
 
+    it "doesn't let you run as root" do
+      Process.stubs(:uid).returns(0)
+      lambda { Pod::Command.run(['--version']) }.should.raise CLAide::Help
+    end
   end
 end


### PR DESCRIPTION
I'm often finding people using `sudo` the first time because they needed it to install and they don't fully understand they don't need it in the future. This leads to problems further down the line when they don't use sudo.

It's currently possible to make both your repositories and library caches as root so running subsequent commands will cause hard to understand failures.

Thinking we should do something like this (someone to think of better copy):

``` bash
$ sudo pod
Hey, it's just pod you will need to drop sudo.
```

We also need to facilitate with things being root because you won't be able to continue running as root.

~/Libraries/Caches/(not sure on exact location) can be root and cause failure, perhaps we should drop these? Or get a friendlier message when "git clone" from cocoapods-downloader fails due to permission.
~/.cocoapods/repos/master could be root.
