### PR TITLE
Include declared_path in 'No podspec found..' error message for PathSource

### DIFF
--- a/lib/cocoapods/external_sources.rb
+++ b/lib/cocoapods/external_sources.rb
@@ -378,7 +378,7 @@ module Pod
         pathname      = Pathname.new(absolute_path)
 
         unless pathname.exist?
-          raise Informative, "No podspec found for `#{name}` in `#{params[:local]}`"
+          raise Informative, "No podspec found for `#{name}` in `#{declared_path}`"
         end
         pathname
       end

--- a/spec/unit/external_sources_spec.rb
+++ b/spec/unit/external_sources_spec.rb
@@ -295,7 +295,7 @@ module Pod
       it "raises if the podspec cannot be found" do
         @external_source.stubs(:params).returns(:path => temporary_directory)
         e = lambda { @external_source.send(:podspec_path) }.should.raise Informative
-        e.message.should.match /No podspec found/
+        e.message.should.match /No podspec found for `Reachability` in `#{temporary_directory}`/
       end
     end
   end


### PR DESCRIPTION
Fixes issue #1825:

Turns this error output:

```
Fetching podspec for `QMBParallaxScrollViewController` from `../QMBParallaxScrolViewController`
[!] No podspec found for `QMBParallaxScrollViewController` in ``
```

Into this:

```
Fetching podspec for `QMBParallaxScrollViewController` from `../QMBParallaxScrolViewController`
[!] No podspec found for `QMBParallaxScrollViewController` in `../QMBParallaxScrolViewController`
```
