### PR TITLE
Include a space between `-isystem` and the directory

### DIFF
--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -44,7 +44,7 @@ module Pod
       # @return [Xcodeproj::Config]
       #
       def generate
-      	header_search_path_flags = target.sandbox.public_headers.search_paths.map {|path| '-isystem'+path}
+        header_search_path_flags = target.sandbox.public_headers.search_paths.map {|path| '-isystem ' + path}
         @xcconfig = Xcodeproj::Config.new({
           'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),
           'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(target.sandbox.public_headers.search_paths),

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -61,7 +61,7 @@ module Pod
         end
 
         it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
-          expected = "$(inherited) \"-isystem#{config.sandbox.public_headers.search_paths.join('" -isystem"')}\""
+          expected = "$(inherited) \"-isystem #{config.sandbox.public_headers.search_paths.join('" -isystem "')}\""
           @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
         end
 


### PR DESCRIPTION
According to clang's help it should have a space.

```
-isystem <directory>    Add directory to SYSTEM include search path
```

Closes #1862
