### PR TITLE
[Analyzer] support multiple values in ARCHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides/installing_cocoapods.html).
 
+## Master
+[CocoaPods](https://github.com/CocoaPods/CocoaPods/compare/0.31.1...master)
+• [CocoaPods-Core](https://github.com/CocoaPods/Core/compare/0.31.1...master)
+
+##### Enhancements
+
+##### Bug Fixes
+* Support multiple values in ARCHS
+  [Robert Zuber](https://github.com/z00b)
+  [#1904](https://github.com/CocoaPods/CocoaPods/issues/1904)
+
+
 ## 0.31.1
 [CocoaPods](https://github.com/CocoaPods/CocoaPods/compare/0.31.1...0.31.0)
 • [CocoaPods-Core](https://github.com/CocoaPods/Core/compare/0.31.1...0.31.0)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -466,12 +466,8 @@ module Pod
         end
 
         archs = archs.compact.uniq.sort
-        if archs.count > 1
-          UI.warn "Found multiple values (`#{archs.join('`, `')}`) for the " \
-          "architectures (`ARCHS`) build setting for the " \
-          "`#{target_definition}` target definition. Using the first."
-        end
-        archs.first
+        UI.puts("Using `ARCHS` setting to build architectures: (`#{archs.join('`, `')}`)")
+        archs.length > 1 ? archs : archs.first
       end
 
       # Precompute the platforms for each target_definition in the Podfile

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -364,20 +364,20 @@ module Pod
         it "handles an Array of ARCHs defined in a single user target" do
           user_project = Xcodeproj::Project.new('path')
           target = user_project.new_target(:application, 'Target', :ios)
-          target.build_configuration_list.set_setting('ARCHS', 'armv7')
+          target.build_configuration_list.set_setting('ARCHS', ['armv7', 'i386'])
 
           target_definition = Podfile::TargetDefinition.new(:default, nil)
           target_definition.set_platform(:ios, '4.0')
           user_targets = [target]
 
           archs = @analyzer.send(:compute_archs_for_target_definition, target_definition, user_targets)
-          archs.should == 'armv7'
+          ['armv7', 'i386'].each { |a| archs.should.include a }
         end
 
         it "handles an Array of ARCHs defined multiple user targets" do
           user_project = Xcodeproj::Project.new('path')
           targeta = user_project.new_target(:application, 'Target', :ios)
-          targeta.build_configuration_list.set_setting('ARCHS', 'armv7')
+          targeta.build_configuration_list.set_setting('ARCHS', ['armv7', 'armv7s'])
           targetb = user_project.new_target(:application, 'Target', :ios)
           targetb.build_configuration_list.set_setting('ARCHS', ['armv7', 'i386'])
 
@@ -386,9 +386,8 @@ module Pod
           user_targets = [targeta, targetb]
 
           archs = @analyzer.send(:compute_archs_for_target_definition, target_definition, user_targets)
-          archs.should == 'armv7'
+          ['armv7', 'armv7s', 'i386'].each { |a| archs.should.include a }
         end
-
       end
 
       #--------------------------------------#


### PR DESCRIPTION
Add a command line option to support building all defined `ARCHS`. (done as a flag to not break implementations assuming existing functionality).

Targets defining custom values for the `ARCHS` build setting require support libs to be built with at least those same settings to be usable.

Related issues: #1875 and #1787

I wrote this against c21203aa7e04a8e125353c43ab4992b543132b0c because we have already rolled it into our production builds and wanted to introduce minimal change, but looks like it will merge against master, too.

Also, my first time looking at CocoaPods code.  Happy to change anything to adhere more closely to standards or cover anything that's not obvious to me.

Thanks!
