### PR TITLE
Required parameters should not contain square braces

### DIFF
--- a/lib/cocoapods/command/search.rb
+++ b/lib/cocoapods/command/search.rb
@@ -9,7 +9,7 @@ module Pod
         description of the pods.
       DESC
 
-      self.arguments = '[QUERY]'
+      self.arguments = 'QUERY'
 
       def self.options
         [


### PR DESCRIPTION
Just like in https://github.com/pietbrauer/CocoaPods/commit/fef59f73fbf18e0c2de4ad84faff617d01e12ffa
