### PR TITLE
Add advice for UTF-8 issue on Travis CI

### DIFF
--- a/bin/pod
+++ b/bin/pod
@@ -1,11 +1,20 @@
 #!/usr/bin/env ruby
 
 if RUBY_VERSION > '1.8.7' && Encoding.default_external != Encoding::UTF_8
-  puts <<-DOC
-\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
+  puts "\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding."
+  if ENV["TRAVIS"]
+    puts <<-DOC
+Consider adding the following settings to .travis.yml
+
+before_script:
+  - export LANG=en_US.UTF-8\e[0m\n
+    DOC
+  else
+    puts <<-DOC
 See https://github.com/CocoaPods/guides.cocoapods.org/issues/26 for
 possible solutions.\e[0m\n
-  DOC
+    DOC
+  end
 end
 
 if $PROGRAM_NAME == __FILE__ && !ENV['COCOAPODS_NO_BUNDLER']


### PR DESCRIPTION
Use ENV['TRAVIS'] to check if it's Travis CI environment.

```
WARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
Consider adding the following settings to .travis.yml

before_script:
  - export LANG=en_US.UTF-8
```

This closes #1933
