### PR TITLE
Unset the `CDPATH` env variable before shelling-out. #1694

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides/installing_cocoapods.html).
 
+## Master
+[CocoaPods](https://github.com/jverkoey/CocoaPods/compare/0.30.0...master)
+
+###### Enhancements
+
+* Unset the `CDPATH` env variable before shelling-out on `prepare_command`  
+  [Marc Boquet](https://github.com/apalancat)
+  [#1943](https://github.com/CocoaPods/CocoaPods/pull/1943)
+
 ## 0.30.0
 [CocoaPods](https://github.com/jverkoey/CocoaPods/compare/0.29.0...0.30.0)
 

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -114,6 +114,10 @@ module Pod
 
       # Runs the prepare command bash script of the spec.
       #
+      # @note   Unsets the `CDPATH` env variable before running the
+      #         shell script to avoid issues with relative paths
+      #         (issue #1694).
+      #
       # @return [void]
       #
       def run_prepare_command

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -83,6 +83,13 @@ module Pod
             @installer.install!
           end.message.should.match /command not found/
         end
+
+        it "unsets $CDPATH environment variable" do
+          ENV['CDPATH'] = "BogusPath"
+          @spec.prepare_command = "cd Classes;ls Banana.h"
+          lambda { @installer.install! }.should.not.raise
+        end
+        
       end
 
       #--------------------------------------#


### PR DESCRIPTION
I guess bash is only used in `run_prepare_command`, but I'm not sure if the `CDPATH` should be unset globally at some other point so it can't create problems in the future.
Also, should this have a test?
