### PR TITLE
Skip MercurialSource specs without `hg` installed

### DIFF
--- a/spec/unit/external_sources_spec.rb
+++ b/spec/unit/external_sources_spec.rb
@@ -123,7 +123,13 @@ module Pod
 
   #---------------------------------------------------------------------------#
 
-  describe ExternalSources::MercurialSource do
+  RSpec.configure do |c|
+    hg_installed = system("which hg > /dev/null 2>&1")
+    puts "Skipping ExternalSources::MercurialSource specs because `hg` cannot be found" unless hg_installed
+    c.filter_run_excluding hg_not_installed: !hg_installed
+  end
+
+  describe ExternalSources::MercurialSource, hg_not_installed: true do
 
     before do
       dependency = Dependency.new("MercurialSource", :hg => fixture('mercurial-repo'))


### PR DESCRIPTION
@orta suggested this to avoid tests failing just because `hg` isn't installed. Would appreciate any improvements to logging the warning
