### PR TITLE
Cleanup pod directory when download fails (probably due to a network error)

### DIFF
--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -63,6 +63,10 @@ module Pod
       def install!
         download_source unless predownloaded? || local?
         run_prepare_command
+      rescue => e
+        UI.notice("Error installing #{root_spec.name}")
+        clean!
+        raise
       end
 
       # Cleans the installations if appropriate.

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -61,6 +61,23 @@ module Pod
           }
         end
 
+        it "cleans up directory when an error occurs during download" do
+          config.sandbox.store_head_pod('BananaLib')
+          pod_folder = config.sandbox.root + 'BananaLib'
+          partially_downloaded_file = pod_folder + 'partially_downloaded_file'
+          mock_downloader = Object.new
+          mock_downloader.define_singleton_method(:download_head) do
+            FileUtils.mkdir_p(pod_folder)
+            FileUtils.touch(partially_downloaded_file)
+            raise("some network error")
+          end
+          @installer.stubs(:downloader).returns(mock_downloader)
+          lambda {
+            @installer.install!
+          }.should.raise(RuntimeError).message.should.equal('some network error')
+          partially_downloaded_file.should.not.exist
+        end
+
       end
 
       #--------------------------------------#


### PR DESCRIPTION
Fixes #1482
