### PR TITLE
Running any pod command displays news updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development do
   gem "mocha-on-bacon"
   gem 'prettybacon', :git => 'https://github.com/irrationalfab/PrettyBacon.git', :branch => 'master'
   gem 'rake', '~> 10.1.0'   # Ruby 1.8.7
+  gem 'feedjira'
 
   # For the integration tests
   gem "diffy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,9 +103,14 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    curb (0.8.5)
     diffy (3.0.3)
     docile (1.1.3)
     escape (0.0.4)
+    feedjira (1.1.0)
+      curb (~> 0.8.1)
+      loofah (~> 1.2.1)
+      sax-machine (~> 0.2.1)
     ffi (1.9.3)
     fuzzy_match (2.0.4)
     github-markup (1.1.0)
@@ -116,9 +121,12 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
+    loofah (1.2.1)
+      nokogiri (>= 1.4.4)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (1.25.1)
+    mini_portile (0.5.3)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
@@ -126,6 +134,8 @@ GEM
     multi_json (1.9.2)
     nap (0.6.0)
     netrc (0.7.7)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     notify (0.5.2)
     open4 (1.3.3)
     posix-spawn (0.3.8)
@@ -145,6 +155,8 @@ GEM
     redcarpet (2.3.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    sax-machine (0.2.1)
+      nokogiri (~> 1.6.0)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
@@ -172,6 +184,7 @@ DEPENDENCIES
   cocoapods-try!
   coveralls
   diffy
+  feedjira
   github-markup
   kicker!
   mime-types (< 2)

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -1,5 +1,8 @@
 require 'colored'
 require 'claide'
+require 'feedjira'
+
+NEWS_FEED_URL = "http://blog.cocoapods.org/feed.xml"
 
 module Pod
   class PlainInformative
@@ -48,6 +51,7 @@ module Pod
         UI.puts VERSION
         exit 0
       end
+      self.check_for_news
       super(argv)
       UI.print_warnings
     end
@@ -112,6 +116,13 @@ module Pod
     def verify_lockfile_exists!
       unless config.lockfile
         raise Informative, "No `Podfile.lock' found in the current working directory, run `pod install'."
+      end
+    end
+
+    def self.check_for_news
+      feed = Feedjira::Feed.fetch_and_parse NEWS_FEED_URL
+      feed.entries.each do |post|
+        UI.warn post.title
       end
     end
   end

--- a/spec/fixtures/important.xml
+++ b/spec/fixtures/important.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>CocoaPods Blog - Important</title>
+    <description>Posts categorized as 'important'</description>
+    <link>http://blog.cocoapods.org</link>
+    <atom:link href="http://blog.cocoapods.org/important.xml" rel="self" type="application/rss+xml" />
+
+      <item>
+        <title>BREAKING: CocoaPods is awesome!!!</title>
+        <description></description>
+        <pubDate>Sat, 29 Mar 2013 00:00:00 -0400</pubDate>
+        <link>http://blog.cocoapods.org/CocoaPods-is-awesome</link>
+        <guid isPermaLink="true">http://blog.cocoapods.org/CocoaPods-Is-Awesome</guid>
+      </item>
+
+      <item>
+        <title>We broke everything</title>
+        <description></description>
+        <pubDate>Fri, 28 Mar 2013 00:00:00 -0400</pubDate>
+        <link>http://blog.cocoapods.org/We-broke-everything</link>
+        <guid isPermaLink="true">http://blog.cocoapods.org/We-broke-everything</guid>
+      </item>
+
+  </channel>
+</rss>

--- a/spec/functional/command_spec.rb
+++ b/spec/functional/command_spec.rb
@@ -14,5 +14,15 @@ module Pod
       UI.output.should.include 'spec/fixtures/spec-repos/master/AFNetworking'
     end
 
+    it "displays all news items from the blog" do
+      feed_xml = File.read('spec/fixtures/important.xml')
+      feed = Feedjira::Feed.parse(feed_xml)
+      Feedjira::Feed.stubs(:fetch_and_parse).returns(feed)
+
+      Pod::Command.run(['spec', 'which', 'AFNetworking'])
+      UI.warnings.should.include "BREAKING: CocoaPods is awesome!!!"
+      UI.warnings.should.include "We broke everything"
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ $:.unshift((ROOT + 'spec').to_s)
 
 require 'cocoapods'
 require 'claide'
+require 'feedjira'
 #require 'awesome_print'
 
 require 'spec_helper/command'         # Allows to run Pod commands and returns their output.


### PR DESCRIPTION
This is for issue #1780.

Any (non-failing, non-"--version") `pod` commmand will now display the title of each blog post on the CocoaPods blog tagged 'important' as a warning.

I'd imagine this should eventually display the body of each post as well, but right now they're coming through as formatted HTML; I figured just displaying the title was a good start to this to see if it's at all useful.

Similarly, right now this is using the same UI hooks and end-user experience as any warnings generated by a command. Eventually this might want to be split off from that so it can be visually distinct, but, again, I figured just getting something up and running was best.
