### PR TITLE
`pod` shows help when there's no Podfile found

### DIFF
--- a/lib/cocoapods/command/project.rb
+++ b/lib/cocoapods/command/project.rb
@@ -64,6 +64,7 @@ module Pod
       DESC
 
       def run
+        help! if invoked_as_default && !config.podfile
         verify_podfile_exists!
         run_install_with_update(false)
       end
@@ -85,4 +86,3 @@ module Pod
 
   end
 end
-

--- a/spec/functional/command/project_spec.rb
+++ b/spec/functional/command/project_spec.rb
@@ -20,6 +20,13 @@ module Pod
       exception.message.should.include "No `Podfile' found in the current working directory."
     end
 
+    it "shows help when runned as default command but no Podfile found" do
+      command = Command::Install.new(CLAide::ARGV.new([]))
+      command.invoked_as_default = true
+      exception = lambda { command.run }.should.raise CLAide::Help
+      exception.message.should.include "CocoaPods, the Objective-C library package manager."
+    end
+
   end
 
   #---------------------------------------------------------------------------#
@@ -46,4 +53,3 @@ module Pod
   #---------------------------------------------------------------------------#
 
 end
-


### PR DESCRIPTION
This should be a non-breaking fix for #1771.

```
$ pod
CocoaPods, the Objective-C library package manager.

Commands:

    * help       Show help for the given command.
<SKIP>
$ touch Podfile
$ pod
Analyzing dependencies
<SKIP>
```

cc/ #1952 & @dbgrandi
