### PR TITLE
Try to fix spec failure on master

### DIFF
--- a/spec/functional/command/repo_spec.rb
+++ b/spec/functional/command/repo_spec.rb
@@ -40,6 +40,7 @@ module Pod
       before do
         set_up_test_repo
         config.repos_dir = SpecHelper.tmp_repos_path
+        ::REST.stubs(:head => stub(:success? => true))
       end
 
       it "lints a repository" do


### PR DESCRIPTION
Apparently the failure was introduced from CocoaPods/Core#70. 
Sorry for the mess, and I'm trying to fix it.
