### PR TITLE
Remove hardcode template URL messages

### DIFF
--- a/lib/cocoapods/command/lib.rb
+++ b/lib/cocoapods/command/lib.rb
@@ -45,8 +45,6 @@ module Pod
         executable :ruby
 
         TEMPLATE_REPO = "https://github.com/CocoaPods/pod-template.git"
-        TEMPLATE_INFO_URL = "https://github.com/CocoaPods/pod-template"
-        CREATE_NEW_POD_INFO_URL = "http://guides.cocoapods.org/making/making-a-cocoapod"
 
         # Clones the template from the remote in the working directory using
         # the name of the Pod.
@@ -77,7 +75,6 @@ module Pod
         #
         def print_info
           UI.puts "\nTo learn more about the template see `#{template_repo_url}`."
-          UI.puts "To learn more about creating a new pod, see `#{CREATE_NEW_POD_INFO_URL}`."
         end
 
         # Checks if a template URL is given else returns the TEMPLATE_REPO URL

--- a/spec/functional/command/lib_spec.rb
+++ b/spec/functional/command/lib_spec.rb
@@ -73,11 +73,6 @@ module Pod
       end
     end
 
-    it "should show link to new pod guide after creation" do
-      output = run_command('lib', 'create', 'TestPod')
-      output.should.include? 'http://guides.cocoapods.org/making/making-a-cocoapod'
-    end
-
     before do
       Command::Lib::Create.any_instance.stubs(:configure_template)
       Command::Lib::Create.any_instance.stubs(:git!)


### PR DESCRIPTION
Output for additional information about the template should go into the
`_CONFIGURE.rb` of the template.
