### PR TITLE
Only include *.xcassets from Pods

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -137,7 +137,7 @@ EOS
 
       XCASSETS_COMPILE = <<EOS
 
-if [[ -n "${WRAPPER_EXTENSION}" ]] && [ `xcrun --find actool` ] && [ `find . -name '*.xcassets' | wc -l` -ne 0 ]
+if [[ -n "${WRAPPER_EXTENSION}" ]] && [ `xcrun --find actool` ] && [ `find Pods -name '*.xcassets' | wc -l` -ne 0 ]
 then
   case "${TARGETED_DEVICE_FAMILY}" in 
     1,2)


### PR DESCRIPTION
Fixes #1546

If you had multiple xcassets anywhere underneath your root project directory, but were only picking one of them for each build, the `Pods-resources.sh` script would include ALL of them in the build. This could cause resources from the correct xcassets to be overwritten by all the others.

Now, `Pods-resources.sh` will only include the xcassets found in `Pods`. All other xcassets can be included in the build by adding them to the Xcode project, as per usual.
