### PR TITLE
[ErrorReport] List the installed plugins

### DIFF
--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -32,6 +32,12 @@ module Pod
 Ruby lib dir : #{RbConfig::CONFIG['libdir']}
 Repositories : #{repo_information.join("\n               ")}
 ```
+
+### Plugins
+
+```
+#{plugins_string}
+```
 #{markdown_podfile}
 ### Error
 
@@ -97,6 +103,19 @@ EOS
         def xcode_information
           version, build = `xcodebuild -version`.strip.split("\n").map { |line| line.split(' ').last }
           "#{version} (#{build})"
+        end
+
+        def installed_plugins
+          CLAide::Command::PluginsHelper.specifications.
+            reduce({}) { |hash, s| hash.tap { |h| h[s.name] = s.version.to_s } }
+        end
+
+        def plugins_string
+          plugins = installed_plugins
+          max_name_length = plugins.keys.map(&:length).max
+          plugins.map do |name, version|
+            "#{name.ljust(max_name_length)} : #{version}"
+          end.sort.join("\n")
         end
 
         def repo_information

--- a/spec/unit/user_interface/error_report_spec.rb
+++ b/spec/unit/user_interface/error_report_spec.rb
@@ -40,6 +40,14 @@ Repositories : repo_1
                repo_2
 ```
 
+### Plugins
+
+```
+cocoapods         : #{Pod::VERSION}
+cocoapods-core    : #{Pod::VERSION}
+cocoapods-plugins : 1.2.3
+```
+
 ### Podfile
 
 ```ruby
@@ -78,6 +86,11 @@ EOS
         @report.stubs(:host_information).returns(':host_information')
         @report.stubs(:xcode_information).returns(':xcode_information')
         @report.stubs(:repo_information).returns(%w(repo_1 repo_2))
+        @report.stubs(:installed_plugins).returns({
+                                                    'cocoapods' => Pod::VERSION,
+                                                    'cocoapods-core' => Pod::VERSION,
+                                                    'cocoapods-plugins' => '1.2.3'
+                                                  })
         report = remove_color(@report.report(@exception))
         report.should == expected
       end


### PR DESCRIPTION
Adds the following section to the error report:
### Plugins

```
cocoapods            : 0.33.1
cocoapods-core       : 0.33.1
cocoapods-downloader : 0.6.1
cocoapods-plugins    : 0.2.0
cocoapods-trunk      : 0.1.3
cocoapods-try        : 0.3.0
```
