### PR TITLE
[init] Changes the check used to determine if a Podfile already exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Fabio Pelosin][irrationalfab]
   [Core#132](https://github.com/CocoaPods/Core/issues/132)
 
+* Fixed `pod init` so that it doesn't recurse when checking for Podfiles.
+  [Paddy O'Brien](tapi)
+  [#2181](https://github.com/CocoaPods/CocoaPods/issues/2181)
+
+
 * Fixed missing XCTest framework in Xcode 6
   [Paul Williamson](squarefrog)
   [#2296](https://github.com/CocoaPods/CocoaPods/issues/2296)
@@ -481,7 +486,7 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Joshua Kalpin](https://github.com/Kapin)
   [Core#39](https://github.com/CocoaPods/Core/pull/39)
   [#1610](https://github.com/CocoaPods/CocoaPods/issues/1610)
-  
+
 * Having the silent flag enabled in the config will no longer cause issues
   with `pod search`. In addition, the flag `--silent` is no longer supported
   for the command.  
@@ -505,9 +510,9 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Carson McDonald](https://github.com/carsonmcdonald)
   [#1628](https://github.com/CocoaPods/CocoaPods/issues/1628)
 
-* Fixed all issues caused by `/tmp` being a symlink to `/private/tmp`. 
-  This affected mostly `pod lib lint`, causing it to fail when the 
-  Pod used `prefix_header_*` or when the pod headers imported headers 
+* Fixed all issues caused by `/tmp` being a symlink to `/private/tmp`.
+  This affected mostly `pod lib lint`, causing it to fail when the
+  Pod used `prefix_header_*` or when the pod headers imported headers
   using the namespaced syntax (e.g. `#import <MyPod/Header.h>`).  
   [kra Larivain/OpenTable](https://github.com/opentable)
   [#1514](https://github.com/CocoaPods/CocoaPods/pull/1514)
@@ -637,7 +642,7 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Noah McCann](https://github.com/nmccann)
   [#29](https://github.com/CocoaPods/Core/pull/29)
 
-* The developer dir relative to the SDK is not added anymore if testing 
+* The developer dir relative to the SDK is not added anymore if testing
   frameworks are detected in OS X targets, as it doesn't exists, avoiding the
   presentation of the relative warning in Xcode.  
   [Fabio Pelosin](https://github.com/irrationalfab)
@@ -797,7 +802,7 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 * Added `pod init` command which generates a Podfile according to the
   targets of the project stored in the working directory and to the templates
-  stored in the `~/.cocoapods/templates` folder. Two templates are supported: 
+  stored in the `~/.cocoapods/templates` folder. Two templates are supported:
     - the `Podfile.default` template for regular targets.
     - and the `Podfile.test` template for test targets.
   [Ian Ynda-Hummel](https://github.com/ianyh)

--- a/lib/cocoapods/command/init.rb
+++ b/lib/cocoapods/command/init.rb
@@ -30,7 +30,7 @@ module Pod
 
       def validate!
         super
-        raise Informative, "Existing Podfile found in directory" unless config.podfile.nil?
+        raise Informative, "Existing Podfile found in directory" unless config.podfile_path_in_dir(Pathname.pwd).nil?
         if @project_path
           help! "Xcode project at #{@project_path} does not exist" unless File.exist? @project_path
           project_path = @project_path

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -320,6 +320,8 @@ module Pod
       'Podfile',
     ]
 
+    public
+
     # Returns the path of the Podfile in the given dir if any exists.
     #
     # @param  [Pathname] dir


### PR DESCRIPTION
Previously init would check to ensure that the current config did not have a Podfile.
This presented issues in cases where the init command was run in a directory who's parent had a Podfile because config will search its parent if one is not found in the present directory.
Fixed the issue by exposing `podfile_path_in_dir` and using it in the init command to test if the pwd had a Podfile. This is the behaviour that was being tested for in spec/functional/command/init_spec.rb:26.

Fixes #2181
