### PR TITLE
Add support for swift source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides/installing_cocoapods.html).
 
+## Master
+
+##### Enhancements
+
+* Added support for swift source files.
+  [Kyle Fuller][kylef]
 
 ## 0.34.0.rc2
 

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -197,7 +197,7 @@ module Pod
       #
       def glob_for_attribute(attrbute)
         globs = {
-          :source_files => '*.{h,hpp,hh,m,mm,c,cpp}'.freeze,
+          :source_files => '*.{h,hpp,hh,m,mm,c,cpp,swift}'.freeze,
           :public_header_files => "*.{#{ HEADER_EXTENSIONS * ',' }}".freeze,
         }
         globs[attrbute]

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -165,7 +165,7 @@ module Pod
           file_patterns = ['Classes/*.{h,m,d}', 'Vendor']
           options = {
             :exclude_patterns => ['Classes/**/osx/**/*', 'Resources/**/osx/**/*'],
-            :dir_pattern => '*.{h,hpp,hh,m,mm,c,cpp}',
+            :dir_pattern => "*.{h,hpp,hh,m,mm,c,cpp,swift}",
             :include_dirs => false,
           }
           @spec.exclude_files = options[:exclude_patterns]


### PR DESCRIPTION
:boom:

Incomplete, it adds the files but I think we need to create a module.
- [ ] Support generating frameworks instead of static libraries (this should be done in a different issue/PR)
- [x] Add support for swift file extension
- [ ] Create bridging headers

---
- [ ] Decide on the best way to design this as backwards compatible (vague, I know – swizzlr)
