### PR TITLE
[Analyzer] Fixes an issue using the lock version of a subspec

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -151,9 +151,6 @@ module Pod
           pods_state = nil
           UI.section "Finding Podfile changes" do
             pods_by_state = lockfile.detect_changes_with_podfile(podfile)
-            pods_by_state.dup.each do |state, full_names|
-              pods_by_state[state] = full_names.map { |fn| Specification.root_name(fn) }
-            end
             pods_state = SpecsState.new(pods_by_state)
             pods_state.print
           end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -52,7 +52,7 @@ module Pod
 
       it "computes the state of the Podfile respect to the Lockfile" do
         state = @analyzer.analyze.podfile_state
-        state.added.should     == ["AFNetworking", "libextobjc"]
+        state.added.should     == ["AFNetworking", "libextobjc/EXTKeyPathCoding"]
         state.changed.should   == ["JSONKit"]
         state.unchanged.should == ["SVPullToRefresh"]
         state.deleted.should   == ["NUI"]


### PR DESCRIPTION
Basically, `generate_podfile_state` was flattening the subspecs to the root name. Then later `generate_version_locking_dependencies` would call `dependency_to_lock_pod_named` with the root name. Which would match the first subspec.

Fixed #2135

/cc @alloy @segiddins @irrationalfab
