### PR TITLE
Fixes an issue where XCTest is missing in Xcode 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [#2060](https://github.com/CocoaPods/CocoaPods/issues/2060)
 
 * Fixed `pod outdated` to not include subspecs.
-  [Ash Furrow](ashfurrow]
+  [Ash Furrow](ashfurrow)
   [#2136](https://github.com/CocoaPods/CocoaPods/issues/2136)
 
 * Always evaluate podspecs from the original podspec directory. This fixes
@@ -18,6 +18,10 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   pod's via `:path`.  
   [Kyle Fuller](kylef)
   [pod-template#50](https://github.com/CocoaPods/pod-template/issues/50)
+
+* Fixed missing XCTest framework in Xcode 6
+  [Paul Williamson](squarefrog)
+  [#2296](https://github.com/CocoaPods/CocoaPods/issues/2296)
 
 
 ## 0.33.1

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -111,6 +111,8 @@ module Pod
             else
               search_paths_to_add << '"$(DEVELOPER_LIBRARY_DIR)/Frameworks"'
             end
+            frameworks_path = '"$(PLATFORM_DIR)/Developer/Library/Frameworks"'
+            search_paths_to_add << frameworks_path
             search_paths_to_add.each do |search_path|
               unless search_paths.include?(search_path)
                 search_paths << ' ' unless search_paths.empty?

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -188,6 +188,8 @@ module Pod
             frameworks_search_paths = xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS']
             frameworks_search_paths.should.include?('$(inherited)')
             frameworks_search_paths.should.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
+            frameworks_path = '"$(PLATFORM_DIR)/Developer/Library/Frameworks"'
+            frameworks_search_paths.should.include?(frameworks_path)
             frameworks_search_paths.should.not.include?('"$(DEVELOPER_LIBRARY_DIR)/Frameworks"')
           end
 


### PR DESCRIPTION
The XCTest.framework bundle has changed location in Xcode 6. This PR
fixes this issue [#2296](https://github.com/CocoaPods/CocoaPods/issues/2296)
