### PR TITLE
fix_lib_lint

### DIFF
--- a/lib/cocoapods/command/lib.rb
+++ b/lib/cocoapods/command/lib.rb
@@ -135,7 +135,6 @@ module Pod
           podspecs_to_lint.each do |podspec|
 
             validator             = Validator.new(podspec)
-            validator.local       = true
             validator.quick       = @quick
             validator.no_clean    = !@clean
             validator.only_errors = @only_errors


### PR DESCRIPTION
```
$ pod lib lint
```

It passed validation.
But,

```
$ pod trunk push
```

The podspec does not valiidate.
This cause was spec.source in podspec.
