### PR TITLE
[Search][POD::UserInterface] Use specification:derepecated? instead of t...

### DIFF
--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -163,7 +163,7 @@ module Pod
         else
           pod = Specification::Set::Presenter.new(set, statistics_provider)
           title = "\n-> #{pod.name} (#{pod.version})"
-          if pod.deprecated?
+          if pod.spec.deprecated?
             title += " #{pod.deprecation_description}"
             colored_title = title.red
           else


### PR DESCRIPTION
...he remove presenter:deprecated?

Needs https://github.com/CocoaPods/Core/pull/157 merged first. 
