### PR TITLE
[Installer] Load '*.podspec.json' file from `:path` directive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides/installing_cocoapods.html).
 
+## Master
+
+##### Bug Fixes
+
+* Fixes the detection of JSON podspecs included via `:path`.
+  [laiso](https://github.com/laiso)
+  [#2489](https://github.com/CocoaPods/CocoaPods/pull/2489)
+
 
 ## 0.34.0.rc2
 

--- a/lib/cocoapods/external_sources/path_source.rb
+++ b/lib/cocoapods/external_sources/path_source.rb
@@ -16,7 +16,7 @@ module Pod
             raise Informative, "No podspec found for `#{name}` in " \
               "`#{declared_path}`"
           end
-          store_podspec(sandbox, podspec)
+          store_podspec(sandbox, podspec, podspec.extname == '.json')
           is_absolute = absolute?(declared_path)
           sandbox.store_local_path(name, podspec.dirname, is_absolute)
         end
@@ -42,7 +42,8 @@ module Pod
       # @return [Pathname] The absolute path of the podspec.
       #
       def podspec_path
-        Pathname(normalized_podspec_path(declared_path))
+        path = Pathname(normalized_podspec_path(declared_path))
+        path.exist? ? path : Pathname("#{path}.json")
       end
 
       # @return [Bool]

--- a/spec/unit/external_sources/path_source_spec.rb
+++ b/spec/unit/external_sources/path_source_spec.rb
@@ -87,6 +87,13 @@ module Pod
         path = @subject.send(:podspec_path)
         path.should == Pathname(ENV['HOME']) + 'Reachability/Reachability.podspec'
       end
+
+      it 'falls back to .podspec.json when .podspec doesnt exist' do
+        @subject.stubs(:params).returns(:path => 'Reachability')
+        Pathname.any_instance.stubs(:exist?).returns(false)
+        path = @subject.send(:podspec_path)
+        path.should == fixture('integration/Reachability/Reachability.podspec.json')
+      end
     end
 
     describe '#absolute?' do


### PR DESCRIPTION
I've created a Podfile the following:

```
# Podfile
pod 'MyPrivateModule', :path => '~/src/MyPrivateModule' 
```

`MyPrivateModule.podspec.json` is exist in this directory, 
but `MyPrivateModule.podspec(RUBY)` is not exist.

And, `pod install` failed in this situation.

```
# Console Out
Preparing
Analyzing dependencies
Fetching podspec for `MyPrivateModule` from `/Users/laiso/src/MyPrivateModule`
[!] No podspec found for `MyPrivateModule` in `/Users/laiso/src/MyPrivateModule`
```

I think this problem to be resolved by change to `external_sources/path_source.rb`.
- JSON spec can not be found using :path option · Issue #2331
