### PR TITLE
[pod init] Set `source` directive to use `master` repo URL.

### DIFF
--- a/lib/cocoapods/command/init.rb
+++ b/lib/cocoapods/command/init.rb
@@ -59,7 +59,7 @@ module Pod
           # Uncomment this line to define a global platform for your project
           # platform :ios, "6.0"
 
-          source 'master'
+          source '#{Command::Setup.read_only_url}'
         PLATFORM
 
         project.targets.each do |target|

--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -116,18 +116,18 @@ module Pod
       #         be enabled.
       #
       def url
-        push? ? read_write_url : read_only_url
+        push? ? self.class.read_write_url : self.class.read_only_url
       end
 
       # @return [String] the read only url of the master repo.
       #
-      def read_only_url
+      def self.read_only_url
         'https://github.com/CocoaPods/Specs.git'
       end
 
       # @return [String] the read-write url of the master repo.
       #
-      def read_write_url
+      def self.read_write_url
         'git@github.com:CocoaPods/Specs.git'
       end
 
@@ -146,7 +146,7 @@ module Pod
         return false unless master_repo_dir.exist?
         Dir.chdir(master_repo_dir) do
           url = git('config --get remote.origin.url')
-          url.chomp == read_write_url
+          url.chomp == self.class.read_write_url
         end
       end
 

--- a/spec/functional/command/setup_spec.rb
+++ b/spec/functional/command/setup_spec.rb
@@ -23,7 +23,7 @@ module Pod
 
     before do
       set_up_test_repo
-      Command::Setup.any_instance.stubs(:read_only_url).returns(test_repo_path.to_s)
+      Command::Setup.stubs(:read_only_url).returns(test_repo_path.to_s)
       config.repos_dir = SpecHelper.temporary_directory
     end
 
@@ -44,7 +44,7 @@ module Pod
         `echo 'touch' > touch && git add touch && git commit -m 'updated'`
       end
       # Need to use file:// to test local use of --depth=1
-      Command::Setup.any_instance.stubs(:read_only_url).returns("file://#{test_repo_path}")
+      Command::Setup.stubs(:read_only_url).returns("file://#{test_repo_path}")
       run_command('setup')
       Dir.chdir(config.repos_dir + 'master') do
         `git log --pretty=oneline`.strip.split("\n").size.should == 1
@@ -66,7 +66,7 @@ module Pod
         `echo 'touch' > touch && git add touch && git commit -m 'updated'`
       end
       # Need to use file:// to test local use of --depth=1
-      Command::Setup.any_instance.stubs(:read_write_url).returns("file://#{test_repo_path}")
+      Command::Setup.stubs(:read_write_url).returns("file://#{test_repo_path}")
       cmd = run_command('setup', '--push')
       Dir.chdir(config.repos_dir + 'master') do
         `git log --pretty=oneline`.strip.split("\n").size.should > 1


### PR DESCRIPTION
Related to:
- https://github.com/CocoaPods/Core/issues/170
- https://github.com/CocoaPods/CocoaPods/pull/2513
- https://github.com/CocoaPods/CocoaPods/issues/2515#issuecomment-56801012

/cc @segiddins @fabiopelosin
