### PR TITLE
Configuration specific preprocessor definition can generate a lot of warning

### DIFF
--- a/lib/cocoapods/generator/target_environment_header.rb
+++ b/lib/cocoapods/generator/target_environment_header.rb
@@ -49,7 +49,7 @@ module Pod
         specs_by_config = specs_scoped_by_configuration(common_specs, specs_by_configuration)
         specs_by_config.each do |config, specs|
           result << "// #{config} build configuration\n"
-          result << "#ifdef #{config.gsub(' ', '_').upcase}\n\n"
+          result << "#ifdef #{config.gsub(/[^a-zA-Z0-9_]/, '_').upcase}\n\n"
           specs.each { |spec| result << spec_defines(spec, 1) }
           result << "#endif\n"
         end


### PR DESCRIPTION
Hi,

This PR addresses an issue in the way CocoaPods defines the GCC_PREPROCESSOR_DEFINITIONS build settings for each build configuration.

b233a8a9302e0b81ccdf4ee535a59411fefa871a added preprocessor definition for build configurations (which essentially adds a #define CONFIGURATION_NAME to each build configuration).
That commit took care of replacing spaces with underscores, but it turns out dashes are also illegal (according to C99 if I believe the generated warning).
This ends up creating a lot of warning (one or more per pod, which can add up to about roughly two metric fucktons depending on how many pods you're pulling).

You can test with this sample project: https://github.com/olarivain/PreprocessorPod:
git clone https://github.com/olarivain/PreprocessorPod.git
cd PreprocessorPod && pod install && open PreprocessorPod.xcworkspace
make sure you pick the right configuration (cmd shift < and check Debug-With-Dashes is selected),
build and notice the flurry of warnings. On the sample it actually doesn't even build, not exactly sure why, but with the patch, it does build just fine).

The fix is simple, replace dashes with underscore.

It's important to note that this changes the configuration #define, **so any code relying on #ifdef CONFIGURATION-NAME-WITH-DASHES will break**. #ifdef DEBUG statements will be just fine since these don't have dashes in their name.
Considering the flurry of warnings this generates, and the fact that it was introduced in 0.34 which is brand new, it probably isn't that big a deal, but it's worth noting.
