### PR TITLE
[CocoaPods/CocoaPods#1249] Separate header paths for different targets in .xcconfig files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Samuel Giddins](https://github.com/segiddins)
   [#2553](https://github.com/CocoaPods/CocoaPods/issues/2553)
 
+* Proper scoping of header search paths to the target platform.
+  [Michael Melanson](https://github.com/michaelmelanson)
+  [#1249](https://github.com/CocoaPods/CocoaPods/issues/1249)
 
 ## 0.34.1
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -47,10 +47,10 @@ module Pod
         # @return [Xcodeproj::Config]
         #
         def generate
-          header_search_path_flags = target.sandbox.public_headers.search_paths
+          header_search_path_flags = target.sandbox.public_headers.search_paths(target.platform)
           @xcconfig = Xcodeproj::Config.new(
                                               'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),
-                                              'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(target.sandbox.public_headers.search_paths),
+                                              'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(header_search_path_flags),
                                               'PODS_ROOT' => target.relative_pods_root,
                                               'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1',
                                               'OTHER_CFLAGS' => '$(inherited) ' + XCConfigHelper.quote(header_search_path_flags, '-isystem')

--- a/lib/cocoapods/generator/xcconfig/private_pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/private_pod_xcconfig.rb
@@ -45,7 +45,10 @@ module Pod
         # @return [Xcodeproj::Config]
         #
         def generate
-          search_paths = target.build_headers.search_paths.concat(target.sandbox.public_headers.search_paths)
+          target_search_paths = target.build_headers.search_paths(target.platform)
+          sandbox_search_paths = target.sandbox.public_headers.search_paths(target.platform)
+          search_paths = target_search_paths.concat(sandbox_search_paths).uniq
+
           config = {
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),
             'PODS_ROOT'  => '${SRCROOT}',

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -114,15 +114,15 @@ module Pod
           libraries.each do |library|
             library.file_accessors.each do |file_accessor|
               headers_sandbox = Pathname.new(file_accessor.spec.root.name)
-              library.build_headers.add_search_path(headers_sandbox)
-              sandbox.public_headers.add_search_path(headers_sandbox)
+              library.build_headers.add_search_path(headers_sandbox, library.platform)
+              sandbox.public_headers.add_search_path(headers_sandbox, library.platform)
 
               header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
-                library.build_headers.add_files(namespaced_path, files)
+                library.build_headers.add_files(namespaced_path, files, library.platform)
               end
 
               header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
-                sandbox.public_headers.add_files(namespaced_path, files)
+                sandbox.public_headers.add_files(namespaced_path, files, library.platform)
               end
             end
           end

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -58,12 +58,12 @@ module Pod
         end
 
         it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as header search paths' do
-          expected = "\"#{config.sandbox.public_headers.search_paths.join('" "')}\""
+          expected = "\"#{config.sandbox.public_headers.search_paths(:ios).join('" "')}\""
           @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == expected
         end
 
         it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
-          expected = "$(inherited) -isystem \"#{config.sandbox.public_headers.search_paths.join('" -isystem "')}\""
+          expected = "$(inherited) -isystem \"#{config.sandbox.public_headers.search_paths(:ios).join('" -isystem "')}\""
           @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
         end
 

--- a/spec/unit/generator/xcconfig/private_pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/private_pod_xcconfig_spec.rb
@@ -44,8 +44,8 @@ module Pod
           end
 
           it 'adds the library build headers and public headers search paths to the xcconfig, with quotes' do
-            private_headers = "\"#{@pod_target.build_headers.search_paths.join('" "')}\""
-            public_headers = "\"#{config.sandbox.public_headers.search_paths.join('" "')}\""
+            private_headers = "\"#{@pod_target.build_headers.search_paths(:ios).join('" "')}\""
+            public_headers = "\"#{config.sandbox.public_headers.search_paths(:ios).join('" "')}\""
             @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include private_headers
             @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include public_headers
           end

--- a/spec/unit/installer/file_references_installer_spec.rb
+++ b/spec/unit/installer/file_references_installer_spec.rb
@@ -6,6 +6,7 @@ module Pod
     before do
       @file_accessor = fixture_file_accessor('banana-lib/BananaLib.podspec')
       @pod_target = PodTarget.new([], nil, config.sandbox)
+      @pod_target.stubs(:platform).returns(Platform.new(:ios, '6.0'))
       @pod_target.file_accessors = [@file_accessor]
       @project = Project.new(config.sandbox.project_path)
       @project.add_pod_group('BananaLib', fixture('banana-lib'))

--- a/spec/unit/sandbox/headers_store_spec.rb
+++ b/spec/unit/sandbox/headers_store_spec.rb
@@ -22,7 +22,7 @@ module Pod
       relative_header_paths.each do |path|
         File.open(@sandbox.root + path, 'w') { |file| file.write('hello') }
       end
-      symlink_paths = @header_dir.add_files(namespace_path, relative_header_paths)
+      symlink_paths = @header_dir.add_files(namespace_path, relative_header_paths, :fake_platform)
       symlink_paths.each do |path|
         path.should.be.symlink
         File.read(path).should == 'hello'
@@ -39,12 +39,12 @@ module Pod
       relative_header_paths.each do |path|
         File.open(@sandbox.root + path, 'w') { |file| file.write('hello') }
       end
-      @header_dir.add_files(namespace_path, relative_header_paths)
-      @header_dir.search_paths.should.include('${PODS_ROOT}/Headers/Public/ExampleLib')
+      @header_dir.add_files(namespace_path, relative_header_paths, :fake_platform)
+      @header_dir.search_paths(:fake_platform).should.include('${PODS_ROOT}/Headers/Public/ExampleLib')
     end
 
     it 'always adds the Headers root to the header search paths' do
-      @header_dir.search_paths.should.include('${PODS_ROOT}/Headers/Public')
+      @header_dir.search_paths(:fake_platform).should.include('${PODS_ROOT}/Headers/Public')
     end
   end
 end


### PR DESCRIPTION
This is an update to an earlier pull request #1590 for issue #904. That issue was merged into #1249, so I have relabelled the pull request.

It is a fix for a bug where the header search paths for dependencies for one platform would leak into targets for another platform. For example, if a project has an iOS target and an OS X target, and the OS X target includes an OS X-only dependency, its OS X-only headers would be cross-linked into the iOS project.

:rainbow: 
