### PR TITLE
Remove trailing '\n' character in update prompt

### DIFF
--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -246,7 +246,7 @@ module Pod
           install_message << 'gem install cocoapods'
           install_message << ' --pre' if Gem::Version.new(last).prerelease?
           UI.puts "\nCocoaPods #{versions['last']} is available.\n" \
-            "To update use: `#{install_message}`".green + "\n"
+            "To update use: `#{install_message}`".green
         end
       end
 


### PR DESCRIPTION
This character isn't needed at the end of the string.  Having the '\n' shows up in the terminal as:
![screen shot 2014-10-01 at 3 21 36 pm](https://cloud.githubusercontent.com/assets/709713/4481506/99c7ef8e-49a0-11e4-8a0d-b836a1782e1a.png)
