### PR TITLE
[Installer] Fix issue inheriting pods into empty target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Samuel Giddins](https://github.com/segiddins)
   [#2553](https://github.com/CocoaPods/CocoaPods/issues/2553)
 
+* Fix a crash when running `pod install` with an empty target that inherits a
+  pod from a parent target.  
+  [Kyle Fuller](https://github.com/kylef)
+  [#2591](https://github.com/CocoaPods/CocoaPods/issues/2591)
+
 
 ## 0.34.1
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -402,13 +402,13 @@ module Pod
     def install_libraries
       UI.message '- Installing targets' do
         pod_targets.sort_by(&:name).each do |pod_target|
-          next if pod_target.target_definition.empty?
+          next if pod_target.target_definition.dependencies.empty?
           target_installer = PodTargetInstaller.new(sandbox, pod_target)
           target_installer.install!
         end
 
         aggregate_targets.sort_by(&:name).each do |target|
-          next if target.target_definition.empty?
+          next if target.target_definition.dependencies.empty?
           target_installer = AggregateTargetInstaller.new(sandbox, target)
           target_installer.install!
         end


### PR DESCRIPTION
I haven't included a test because the code that crashed was actually prefixed with the following:

``` markdown
# TODO
# Move and add specs
```

Anyone know's what's todo, move to where and what specs?
