### PR TITLE
Prepend Xcode's usr/bin to the PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
   [Kyle Fuller](https://github.com/kylef)
   [#2684](https://github.com/CocoaPods/CocoaPods/issues/2684)
 
+* Add Xcode's bin dir to the PATH, so we prefer tools like git from Apple over
+  custom user installed tools.
+  [Kyle Fuller](https://github.com/kylef)
+  [#2651](https://github.com/CocoaPods/CocoaPods/issues/2651)
+
 
 ## 0.34.2
 

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -42,6 +42,12 @@ module Pod
 
     def self.run(argv)
       help! 'You cannot run CocoaPods as root.' if Process.uid == 0
+
+      # Prepend xcode developer tools usr/bin to PATH so we prefer Xcode
+      # version of tools over custom user installed tools (#2651).
+      developer_tools_bin = Pathname.new(`/usr/bin/xcode-select --print-path`.strip) + 'usr/bin'
+      ENV['PATH'] = "#{developer_tools_bin}:#{ENV['PATH']}"
+
       super(argv)
       UI.print_warnings
     end


### PR DESCRIPTION
This ensures we will prefer Apple shipped tools over custom user tools
added to the PATH.

Fixes #2651

/cc @neonichu @alloy
