### PR TITLE
Drop support for Ruby 1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 ##### Breaking
 
+* Support of older versions of Ruby has been dropped and CocoaPods now depends
+  on Ruby 2.0.0 or greater. This is due to the release of Xcode 6.0 which has
+  dropped support for OS X 10.8 which results in the minimum version of
+  Ruby pre-installed on OS X is now 2.0.0.
+
+  If you are using a custom installation of Ruby which is older than 2.0.0, you
+  will need to update. Or even better, migrate to system Ruby.  
+  [Kyle Fuller](https://github.com/kylef)
+
 * Attempts to resolve circular dependencies will now raise an exception.  
   [Samuel Giddins](https://github.com/segiddins)
   [Molinillo#6](https://github.com/CocoaPods/Molinillo/issues/6)
+
 
 ##### Enhancements
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,7 @@ group :development do
   # Integration tests
   gem 'diffy'
   gem 'clintegracon'
-
-  if RUBY_VERSION >= '1.9.3'
-    gem 'rubocop'
-  end
+  gem 'rubocop'
 
   if RUBY_PLATFORM.include?('darwin')
     # Make Xcodeproj faster
@@ -48,10 +45,3 @@ group :debugging do
   gem 'ruby-prof'
 end
 
-group :ruby_1_8_7 do
-  # Lock the current lowest requirement for ActiveSupport 3 to ensure we don't
-  # re-introduce https://github.com/CocoaPods/CocoaPods/issues/1950
-  gem 'i18n', '0.6.4'
-  gem 'mime-types', '< 2.0'
-  gem 'activesupport', '< 4'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
       rb-kqueue (>= 0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (1.25.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
@@ -163,7 +162,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 4)
   awesome_print
   bacon
   bundler (~> 1.3)
@@ -176,10 +174,8 @@ DEPENDENCIES
   cocoapods-trunk!
   cocoapods-try!
   diffy
-  i18n (= 0.6.4)
   kicker
   libxml-ruby
-  mime-types (< 2.0)
   mocha
   mocha-on-bacon
   molinillo!

--- a/bin/pod
+++ b/bin/pod
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-if RUBY_VERSION > '1.8.7' && Encoding.default_external != Encoding::UTF_8
+if Encoding.default_external != Encoding::UTF_8
   puts "\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding."
   if ENV['TRAVIS']
     puts <<-DOC

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |s|
   ## Make sure you can build the gem on older versions of RubyGems too:
   s.rubygems_version = "1.6.2"
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 2.0.0'
   s.specification_version = 3 if s.respond_to? :specification_version
 end

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -66,15 +66,10 @@ CLIntegracon.configure do |c|
   # Register special handling for YAML files
   paths = [%r{Podfile\.lock}, %r{Manifest\.lock$}, %r{xcodeproj\.yaml$}]
   c.has_special_handling_for(*paths) do |path|
-    if RUBY_VERSION < '1.9'
-      nil # CP is not sorting array derived from hashes whose order is
-    # undefined in 1.8.7
-    else
-      # Remove CocoaPods version
-      yaml = File.open(path) { |f| YAML.load(f) }
-      yaml.delete('COCOAPODS')
-      YAML.dump(yaml)
-    end
+    # Remove CocoaPods version
+    yaml = File.open(path) { |f| YAML.load(f) }
+    yaml.delete('COCOAPODS')
+    YAML.dump(yaml)
   end
 
   # So we don't need to compare them directly


### PR DESCRIPTION
Since Xcode 6.1 is now out, I think it's about time to finally do this.

Any objections?

/cc @alloy @fabiopelosin
