### PR TITLE
[Gemfile] Remove libxml2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,11 +30,6 @@ group :development do
   gem 'diffy'
   gem 'clintegracon'
   gem 'rubocop'
-
-  if RUBY_PLATFORM.include?('darwin')
-    # Make Xcodeproj faster
-    gem 'libxml-ruby'
-  end
 end
 
 group :debugging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,6 @@ GEM
     kicker (3.0.0)
       listen (~> 1.3.0)
       notify (~> 0.5.2)
-    libxml-ruby (2.7.0)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -175,7 +174,6 @@ DEPENDENCIES
   cocoapods-try!
   diffy
   kicker
-  libxml-ruby
   mocha
   mocha-on-bacon
   molinillo!


### PR DESCRIPTION
This has no longer been a dependency of Xcodeproj.

@alloy please confirm I haven't missed anything.
