### PR TITLE
[Command] Don't check for git >= 1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#2768](https://github.com/CocoaPods/CocoaPods/issues/2768)
 
+* We no longer require git version 1.7.5 or greater.  
+  [Kyle Fuller](https://github.com/kylef)
+
 
 ## 0.35.0.rc1
 

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -41,7 +41,6 @@ module Pod
 
     def self.run(argv)
       help! 'You cannot run CocoaPods as root.' if Process.uid == 0
-      verify_git_version!
 
       super(argv)
       UI.print_warnings
@@ -120,19 +119,6 @@ module Pod
     def verify_lockfile_exists!
       unless config.lockfile
         raise Informative, "No `Podfile.lock' found in the project directory, run `pod install'."
-      end
-    end
-
-    def self.verify_git_version!
-      begin
-        git_version = `git version`.strip
-      rescue Errno::ENOENT
-        help! 'CocoaPods requires you to have `git` installed.'
-      end
-
-      git_version = Version.new(git_version.split[2])
-      if git_version < Pod::Version.new('1.7.5')
-        help! 'CocoaPods requires git version 1.7.5 or newer. Please update git.'
       end
     end
   end

--- a/spec/functional/command_spec.rb
+++ b/spec/functional/command_spec.rb
@@ -17,15 +17,5 @@ module Pod
       Process.stubs(:uid).returns(0)
       lambda { Pod::Command.run(['--version']) }.should.raise CLAide::Help
     end
-
-    it "doesn't let you run without git installed" do
-      Pod::Command.expects(:`).with('git version').raises(Errno::ENOENT)
-      lambda { Pod::Command.run(['--version']) }.should.raise CLAide::Help
-    end
-
-    it "doesn't let you run with git version < 1.7.5" do
-      Pod::Command.expects(:`).with('git version').returns('git version 1.7.4.1 (Apple Git-50)')
-      lambda { Pod::Command.run(['--version']) }.should.raise CLAide::Help
-    end
   end
 end


### PR DESCRIPTION
This is no longer required due to https://github.com/CocoaPods/Core/commit/99748b5b9fa8fe6541218f1752c0379589c7a6ee.
