### PR TITLE
[WIP] Codesigning vendored frameworks.

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -101,6 +101,9 @@ install_resource()
       mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
       echo "rsync -av ${PODS_ROOT}/$1 ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
       rsync -av "${PODS_ROOT}/$1" "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+      if [[ -n "${CODE_SIGN_IDENTITY}" ]]; then
+        codesign --verbose --force --sign "${CODE_SIGN_IDENTITY}" "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/`basename \"$1\"`/Versions/A"
+      fi
       ;;
     *.xcdatamodel)
       echo "xcrun momc \\"${PODS_ROOT}/$1\\" \\"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$1"`.mom\\""


### PR DESCRIPTION
Building an app extension for Yosemite (OS X 10.10) or later requires a "Code Signing Entitlements" file. It requires codesigning both a host app, extensions and other embedded binaries like frameworks.

When I tried to build an host app which use a pod with a binary framework. I got an error like this.

```
CodeSign /Users/hiroshi/Library/Developer/Xcode/DerivedData/TrayOSX-awkimfsdfvtkjlfdacylyhuaysej/Build/Products/Debug/TrayOSX.app
    cd /Users/hiroshi/Desktop/wc/tray/TrayOSX
    export CODESIGN_ALLOCATE=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate
    
Signing Identity:     "-"

    /usr/bin/codesign --force --sign - /Users/hiroshi/Library/Developer/Xcode/DerivedData/TrayOSX-awkimfsdfvtkjlfdacylyhuaysej/Build/Products/Debug/TrayOSX.app

/Users/hiroshi/Library/Developer/Xcode/DerivedData/TrayOSX-awkimfsdfvtkjlfdacylyhuaysej/Build/Products/Debug/TrayOSX.app: code object is not signed at all
In subcomponent: /Users/hiroshi/Library/Developer/Xcode/DerivedData/TrayOSX-awkimfsdfvtkjlfdacylyhuaysej/Build/Products/Debug/TrayOSX.app/Contents/Frameworks/Dropbox.framework
Command /usr/bin/codesign failed with exit code 1
```

This pull request will workaround this problem. 
This is a WIP. I'm not sure this is right solution, but I hope this may help others.

References:
https://developer.apple.com/library/mac/documentation/General/Conceptual/ExtensibilityPG/ExtensionCreation.html#//apple_ref/doc/uid/TP40014214-CH5-SW10
http://furbo.org/2013/10/17/code-signing-and-mavericks/
