### PR TITLE
Use `-analyzer-disable-all-checks` for disabling static analysis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Enhancements
+
+* Use `-analyzer-disable-all-checks` to disable static analyzer for
+  for pods with inhibits_warnings on. (requires Xcode >= 6.1)  
+  [Dieter Komendera](https://github.com/kommen)
+  [#2402](https://github.com/CocoaPods/CocoaPods/issues/2402)
+
 ##### Bug Fixes
 
 * Show a helpful error message if the old resolver incorrectly activated a

--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -164,7 +164,7 @@ module Pod
           end
         end
         if target_definition.inhibits_warnings_for_pod?(consumer.spec.root.name)
-          flags << '-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode'
+          flags << '-w -Xanalyzer -analyzer-disable-all-checks'
         end
         flags * ' '
       end

--- a/spec/unit/installer/target_installer/pod_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/pod_target_installer_spec.rb
@@ -185,12 +185,12 @@ module Pod
           @installer.target.target_definition.stubs(:inhibits_warnings_for_pod?).returns(true)
           flags = @installer.send(:compiler_flags_for_consumer, @spec.consumer(:ios))
 
-          flags.should.include?('-Xanalyzer -analyzer-disable-checker')
+          flags.should.include?('-Xanalyzer -analyzer-disable-all-checks')
         end
 
         it "doesn't inhibit analyzer warnings by default" do
           flags = @installer.send(:compiler_flags_for_consumer, @spec.consumer(:ios))
-          flags.should.not.include?('-Xanalyzer -analyzer-disable-checker')
+          flags.should.not.include?('-Xanalyzer -analyzer-disable-all-checks')
         end
 
         describe 'concerning ARC before and after iOS 6.0 and OS X 10.8' do


### PR DESCRIPTION
`-analyzer-disable-checker` without arguments causes an error in the
static analyzer, but due to a bug in Xcode < 6.0 it was silently
ignored. As of Xcode 6.1 `-analyzer-disable-all-checks` can be used
to disable static analysis for specfic files.

rdar://18907351
https://github.com/CocoaPods/CocoaPods/issues/2402