### PR TITLE
Remove link from UTF-8 warning

### DIFF
--- a/bin/pod
+++ b/bin/pod
@@ -1,19 +1,13 @@
 #!/usr/bin/env ruby
 
 if Encoding.default_external != Encoding::UTF_8
-  puts "\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding."
-  if ENV['TRAVIS']
-    puts <<-DOC
-Consider adding the following settings to .travis.yml
+  puts <<-DOC
+\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
+Consider adding the following to ~/.profile:
 
-before_script:
-  - export LANG=en_US.UTF-8\e[0m\n
-    DOC
-  else
-    puts <<-DOC
+export LANG=en_US.UTF-8
 \e[0m
-    DOC
-  end
+DOC
 end
 
 if $PROGRAM_NAME == __FILE__ && !ENV['COCOAPODS_NO_BUNDLER']


### PR DESCRIPTION
The link in the warning about using UTF-8 points to the wrong issue. This simply removes the link entirely.
I'd happily update it to point to another issue that _does_ explain solutions, but unfortunately I couldn't find the actual issue.
