### PR TITLE
[Linter] Split linter messages from attribute names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'json', '1.7.7'
 
 group :development do
   cp_gem 'claide',               'CLAide'
-  cp_gem 'cocoapods-core',       'Core', 'linter-result-attribute-name'
+  cp_gem 'cocoapods-core',       'Core'
   cp_gem 'cocoapods-downloader', 'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',    'cocoapods-plugins'
   cp_gem 'cocoapods-trunk',      'cocoapods-trunk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: f50b14701c2d323d07271ca1fbc01ac2ccba86c8
-  branch: linter-result-attribute-name
+  revision: 49a91acc2b1b9812352fa3605141215fbcc1e466
+  branch: master
   specs:
     cocoapods-core (0.35.0)
       activesupport (>= 3.2.15)


### PR DESCRIPTION
Related to https://github.com/CocoaPods/Core/issues/199. Makes linter messages more modular and informative. 
