### PR TITLE
[Project] Legacy Build Location Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#2639](https://github.com/CocoaPods/CocoaPods/issues/2639)
 
-* Adding Xcode Legacy build location support for default Pods.xcodeproj
+* Adding Xcode Legacy build location support for default Pods.xcodeproj.
   [Sam Marshall](https://github.com/samdmarshall)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#2639](https://github.com/CocoaPods/CocoaPods/issues/2639)
 
+* Adding Xcode Legacy build location support for default Pods.xcodeproj
+  [Sam Marshall](https://github.com/samdmarshall)
+
 ##### Bug Fixes
 
 * Fix updating a pod that has subspec dependencies.  

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -18,7 +18,7 @@ module Pod
       @pods = new_group('Pods')
       @development_pods = new_group('Development Pods')
       configs = root_object.build_configuration_list.build_configurations
-      settings_for_all_configs = configs.map { |c| c.build_settings }
+      settings_for_all_configs = configs.map(&:build_settings)
       settings_for_all_configs.each { |settings| settings['SYMROOT'] = '${SRCROOT}/../build' }
     end
 

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -17,6 +17,9 @@ module Pod
       @refs_by_absolute_path = {}
       @pods = new_group('Pods')
       @development_pods = new_group('Development Pods')
+      configs = root_object.build_configuration_list.build_configurations
+      settings_for_all_configs = configs.map { |c| c.build_settings }
+      settings_for_all_configs.each { |settings| settings['SYMROOT'] = '${SRCROOT}/../build' }
     end
 
     # @return [PBXGroup] The group for the support files of the aggregate


### PR DESCRIPTION
Submitting fix to modify the Pods.xcodeproj PBXProject default build path ("SYMROOT") so that when dependencies get built to the correct locations in a standard configuration.

**Background:**
By default Xcode configures itself to be set to creating unique build directories in the ~/Library/Developer/Xcode/DerivedData/ based on the project/workspace file. This setting can be changed by opening Xcode's Preferences > Locations, then clicking the button "Advanced..." listed under the "Derived Data" setting. Here one can set the default build location behavior for Xcode to use. When selecting "Legacy" this will have each project's targets get built to "SYMROOT", relative to the "SRCROOT" or "PROJECT_DIR" for that project. 

Due to the default configuration for cocoapods, the Pods.xcodeproj file is stored in a subdirectory "Pods" that is (typically) listed along-side the user's Xcode project file and the newly created xcworkspace file. As a result, this means that all of the targets in Pods.xcodeproj will be built to a separate build folder and the aggregate target will have linker errors because it cannot find the library targets from Pods.xcodeproj.

**Fix:**
To resolve this in the common case, setting the build path ("SYMROOT") of the Pods.xcodeproj to be set to "SRCROOT/../build" which will correctly deposit the built products from Pods.xcodeproj into the same build directory as the user's xcodeproj targets.

**Notes:**
This setting doesn't impact any usage outside of the Legacy or Custom Project based build settings, where the build directory of the user's xcodeproj wouldn't be the same directory as the one used by Pods.xcodeproj.

This could use additional work, specifically the "SYMROOT" of the Pods.xcodeproj file should be set instead to "SRCROOT/RELATIVE_PATH_TO_USERS_XCODEPROJ_DIR/SYMROOT_FROM_USERS_XCODEPROJ". However resolving these paths correctly is far outside of my skill right now.

Existing users that use Custom or Legacy build locations in the common case (where the podfile is stored in the same directory as the user's xcodeproj file) will see an extra step removed. Users that store the podfile in a location that is not along-side their xcodeproj file will still have to manually adjust the build location paths as they have had to do so far.