### PR TITLE
Validate that a specification's `public_header_files` and `private_header_files` file patterns only match header files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#2623](https://github.com/CocoaPods/CocoaPods/issues/2623)
 
+* Validate that a specification's `public_header_files` and
+  `private_header_files` file patterns only match header files.
+  Also, validate that all file patterns, if given, match at least one file.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#2914](https://github.com/CocoaPods/CocoaPods/issues/2914)
+
 ##### Bug Fixes
 
 * Fix updating a pod that has subspec dependencies.  

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -113,8 +113,8 @@ module Pod
       # @return [Array<Pathname>] the public headers of the specification.
       #
       def public_headers(include_frameworks = false)
-        public_headers = paths_for_attribute(:public_header_files)
-        private_headers = paths_for_attribute(:private_header_files)
+        public_headers = public_header_files
+        private_headers = private_header_files
         if public_headers.nil? || public_headers.empty?
           header_files = headers
         else
@@ -204,6 +204,26 @@ module Pod
         else
           path_list.glob([GLOB_PATTERNS[:license]]).first
         end
+      end
+
+      #-----------------------------------------------------------------------#
+
+      private
+
+      # @!group Private paths
+
+      # @return [Array<Pathname>] The paths of the user-specified public header
+      #         files.
+      #
+      def public_header_files
+        paths_for_attribute(:public_header_files)
+      end
+
+      # @return [Array<Pathname>] The paths of the user-specified public header
+      #         files.
+      #
+      def private_header_files
+        paths_for_attribute(:private_header_files)
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -337,14 +337,36 @@ module Pod
         sut.results.count.should == 0
       end
 
-      it 'checks for file patterns' do
-        file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "wrong_paht.*",'))
-        sut = Validator.new(file, SourcesManager.master.map(&:url))
-        sut.stubs(:build_pod)
-        sut.stubs(:validate_url)
-        sut.validate
-        sut.results.map(&:to_s).first.should.match /source_files.*did not match/
-        sut.result_type.should == :error
+      describe 'file pattern validation' do
+        it 'checks for file patterns' do
+          file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "wrong_paht.*",'))
+          sut = Validator.new(file, SourcesManager.master.map(&:url))
+          sut.stubs(:build_pod)
+          sut.stubs(:validate_url)
+          sut.validate
+          sut.results.map(&:to_s).first.should.match /source_files.*did not match/
+          sut.result_type.should == :error
+        end
+
+        it 'checks private_header_files matches only headers' do
+          file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "JSONKit.*", "private_header_files": "JSONKit.m",'))
+          sut = Validator.new(file, SourcesManager.master.map(&:url))
+          sut.stubs(:build_pod)
+          sut.stubs(:validate_url)
+          sut.validate
+          sut.results.map(&:to_s).first.should.match /matches non-header files \(JSONKit\.m\)/
+          sut.result_type.should == :error
+        end
+
+        it 'checks public_header_files matches only headers' do
+          file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "JSONKit.*", "public_header_files": "JSONKit.m",'))
+          sut = Validator.new(file, SourcesManager.master.map(&:url))
+          sut.stubs(:build_pod)
+          sut.stubs(:validate_url)
+          sut.validate
+          sut.results.map(&:to_s).first.should.match /matches non-header files \(JSONKit\.m\)/
+          sut.result_type.should == :error
+        end
       end
 
       it 'validates a podspec with dependencies' do


### PR DESCRIPTION
Also, validate that all file patterns, if given, match at least one file.

Closes https://github.com/CocoaPods/CocoaPods/issues/2914.
