### PR TITLE
[Validator] Fix detection of errors in xcodebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#2981](https://github.com/CocoaPods/CocoaPods/issues/2981)
   [cocoapods-trunk#33](https://github.com/CocoaPods/cocoapods-trunk/issues/33)
 
+* Xcodebuild warnings with the string `error` in them will no longer be 
+  linted as errors if they are in fact warnings.  
+  [Hugo Tunius](https://github.com/K0nserv)
+  [#2579](https://github.com/CocoaPods/CocoaPods/issues/2579)
+
+##### Enhancements
+
+* Xcodebuild warnings will now be reported as `warning` during linting
+  instead of `note`.  
+  [Hugo Tunius](https://github.com/K0nserv)
 
 ## 0.36.0.beta.1
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -345,8 +345,10 @@ module Pod
               next
             end
 
-            if message.include?('error: ')
+            if message =~ /\S+:\d+:\d+: error:/
               error('xcodebuild', message)
+            elsif message =~ /\S+:\d+:\d+: warning:/
+              warning('xcodebuild', message)
             else
               note('xcodebuild', message)
             end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -334,10 +334,21 @@ module Pod
         podfile.sources.should == sources
       end
 
-      it 'uses xcodebuild to generate notes and warnings' do
+      it 'uses xcodebuild to generate warnings' do
         validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
         validator.stubs(:check_file_patterns)
-        validator.stubs(:xcodebuild).returns("file.m:1:1: warning: direct access to objective-c's isa is deprecated")
+        validator.stubs(:xcodebuild).returns("file.m:1:1: warning: 'dataFromPropertyList:format:errorDescription:' is deprecated: first deprecated in iOS 8.0 - Use dataWithPropertyList:format:options:error: instead. [-Wdeprecated-declarations]")
+        validator.stubs(:validate_url)
+        validator.validate
+        first = validator.results.map(&:to_s).first
+        first.should.include '[xcodebuild]'
+        validator.result_type.should == :warning
+      end
+
+      it 'users xcodebuild to generate notes' do
+        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator.stubs(:check_file_patterns)
+        validator.stubs(:xcodebuild).returns("file.m:1:1: note: 'dataFromPropertyList:format:errorDescription:' has been explicitly marked deprecated here")
         validator.stubs(:validate_url)
         validator.validate
         first = validator.results.map(&:to_s).first


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/2579. 

I also changed the validator to correctly report warnings from xcodebuild as warnings rather than notes