### PR TITLE
[PodspecSource] Rescue HTTPError exceptions and handle them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Hugo Tunius](https://github.com/K0nserv)
   [#2579](https://github.com/CocoaPods/CocoaPods/issues/2579)
 
+* Any errors which occur during fetching of external podspecs over HTTP
+  will now be gracefully handled.  
+  [Hugo Tunius](https://github.com/K0nserv)
+  [#2823](https://github.com/CocoaPods/CocoaPods/issues/2823)
+
 ##### Enhancements
 
 * Xcodebuild warnings will now be reported as `warning` during linting

--- a/lib/cocoapods/external_sources/podspec_source.rb
+++ b/lib/cocoapods/external_sources/podspec_source.rb
@@ -15,7 +15,7 @@ module Pod
             open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
           rescue OpenURI::HTTPError => e
             status = e.io.status.join(' ')
-            raise Informative, "Failed to fetch podspec for `#{name}` at #{podspec_uri}. Error: #{status}"
+            raise Informative, "Failed to fetch podspec for `#{name}` at `#{podspec_uri}`.\n Error: #{status}"
           end
         end
       end

--- a/lib/cocoapods/external_sources/podspec_source.rb
+++ b/lib/cocoapods/external_sources/podspec_source.rb
@@ -11,7 +11,12 @@ module Pod
         UI.titled_section(title,  :verbose_prefix => '-> ') do
           is_json = podspec_uri.split('.').last == 'json'
           require 'open-uri'
-          open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
+          begin
+            open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
+          rescue OpenURI::HTTPError => e
+            status = e.io.status.join(' ')
+            raise Informative, "Failed to fetch podspec for `#{name}` at #{podspec_uri}. Error: #{status}"
+          end
         end
       end
 


### PR DESCRIPTION
This is might suggestion for how to handle this. I am not sure about what the correct exit procedure is, but this does the job. Please correct me if there is a specific way to do it.

I haven't added tests or a changelog entry just yet in case this is not the way we wanna deal with this issue


Closes: https://github.com/CocoaPods/CocoaPods/issues/2823