### PR TITLE
Fix uninitialized constant Class::YAML crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,9 @@ For more details, see :memo: [CocoaPods 0.35](http://blog.cocoapods.org/CocoaPod
   copying resources to main application bundle.  
   [Yan Rabovik](https://github.com/rabovik)
 
+* Fix uninitialized constant Class::YAML crash in some cases.
+  [Tim Shadel](https://github.com/timshadel)
+
 ##### Enhancements
 
 * `pod search`, `pod spec which`, `pod spec cat` and `pod spec edit`

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -144,6 +144,7 @@ module Pod
       def updated_search_index
         unless @updated_search_index
           if search_index_path.exist?
+            require 'yaml'
             stored_index = YAML.load(search_index_path.read)
             if stored_index && stored_index.is_a?(Hash)
               search_index = aggregate.update_search_index(stored_index)


### PR DESCRIPTION
### Report

* What did you do?

`pod search sort --full keyword`

* What did you expect to happen?

A sorted search of all the pods using their full text

* What happened instead?

A big crash, with this stack trace. Locally, adding this one line solved the problem completely.

### Stack

```
   CocoaPods : 0.35.0
        Ruby : ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-darwin14.0]
    RubyGems : 2.2.2
        Host : Mac OS X 10.10.1 (14B25)
       Xcode : 6.1.1 (6A2008a)
         Git : git version 2.2.1
Ruby lib dir : /Users/timshadel/.rbenv/versions/2.1.5/lib
Repositories : master - https://github.com/CocoaPods/Specs.git @ d4c063d7e2712deead4993a44c4ae06bc47e229d
               shadelsoftware - https://github.com/ShadelSoftware/CocoaPodSpecs.git @ 329894a10dc6722d9ca90f2bf87db69a900681ac
```

### Plugins

```
cocoapods-plugins       : 0.3.2
cocoapods-sorted-search : 0.2.3
cocoapods-trunk         : 0.4.1
cocoapods-try           : 0.4.3
```

### Error

```
NameError - uninitialized constant Class::YAML
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cocoapods-0.35.0/lib/cocoapods/sources_manager.rb:145:in `updated_search_index'
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cocoapods-0.35.0/lib/cocoapods/sources_manager.rb:106:in `search_by_name'
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cocoapods-sorted-search-0.2.3/lib/pod/command/search/sorted.rb:66:in `find_specs'
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cocoapods-sorted-search-0.2.3/lib/pod/command/search/sorted.rb:56:in `run'
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/claide-0.7.0/lib/claide/command.rb:271:in `run'
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cocoapods-0.35.0/lib/cocoapods/command.rb:45:in `run'
/Users/timshadel/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cocoapods-0.35.0/bin/pod:43:in `<top (required)>'
/Users/timshadel/.rbenv/versions/2.1.5/bin/pod:23:in `load'
/Users/timshadel/.rbenv/versions/2.1.5/bin/pod:23:in `<main>'
```