### PR TITLE
[Podfile] Change the default spec repository to the master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Breaking
+
+* Changes the default spec repositories used from all configured spec
+  repositories, to the master spec repository when no spec repositories
+  are explicitly configured in a Podfile.  
+  [Kyle Fuller](https://github.com/kylef)
+  [#2946](https://github.com/CocoaPods/CocoaPods/issues/2946)
+
 ##### Enhancements
 
 * Xcodebuild warnings will now be reported as `warning` during linting
@@ -22,6 +30,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Kyle Fuller](https://github.com/kylef)
   [#2981](https://github.com/CocoaPods/CocoaPods/issues/2981)
   [cocoapods-trunk#33](https://github.com/CocoaPods/cocoapods-trunk/issues/33)
+
+* Clone the master spec repository when no spec repositories are explicitly
+  defined in the Podfile. This fixes problems using CocoaPods for the first
+  time without any explicit spec repositories.  
+  [Kyle Fuller](https://github.com/kylef)
+  [#2946](https://github.com/CocoaPods/CocoaPods/issues/2946)
 
 * Xcodebuild warnings with the string `error` in them will no longer be
   linted as errors if they are in fact warnings.  

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -465,7 +465,8 @@ module Pod
 
       # Returns the sources used to query for specifications
       #
-      # When no explicit Podfile sources are defined, this defaults to all
+      # When no explicit Podfile sources are defined, this defaults to the
+      # master spec repository.
       # available sources ({SourcesManager.all}).
       #
       # @return [Array<Source>] the sources to be used in finding
@@ -475,7 +476,8 @@ module Pod
         @sources ||= begin
           sources = podfile.sources
           if sources.empty?
-            SourcesManager.all
+            url = 'https://github.com/CocoaPods/Specs.git'
+            [SourcesManager.find_or_create_source_with_url(url)]
           else
             sources.map do |url|
               SourcesManager.find_or_create_source_with_url(url)

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -54,7 +54,7 @@ module Pod
 
       it 'updates the repositories by default' do
         config.skip_repo_update = false
-        SourcesManager.expects(:update).twice
+        SourcesManager.expects(:update).once
         @analyzer.analyze
       end
 
@@ -552,9 +552,9 @@ module Pod
 
         describe '#sources' do
           describe 'when there are no explicit sources' do
-            it 'defaults to all sources' do
+            it 'defaults to the master spec repository' do
               @analyzer.send(:sources).map(&:url).should ==
-                SourcesManager.all.map(&:url)
+                ['https://github.com/CocoaPods/Specs.git']
             end
           end
 


### PR DESCRIPTION
Along with fixing #2946, I think it makes more sense if by default. That only the master spec repository is used. If a user wants a custom repository they should have to explicitly specified this in their Podfile.

This change means that a Podfile on one system will have the exact same dependencies on another. Currently you could consume another Podfile and have different dependencies since by default, the Podfile would pick up all sources which might change the dependencies.

