### PR TITLE
Ensure private headers are declared as such in a framework's generated module map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Chris Brauchli](https://github.com/cbrauchli)
   [#2633](https://github.com/CocoaPods/CocoaPods/issues/2633)
 
+* Ensure private headers are declared as such in a framework's generated module
+  map.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#2974](https://github.com/CocoaPods/CocoaPods/issues/2974)
+
 ##### Bug Fixes
 
 * Do not pass code-sign arguments to xcodebuild when linting OS X targets.  

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -10,10 +10,15 @@ module Pod
       #
       attr_reader :target
 
+      # @return [Array] the private headers of the module
+      #
+      attr_accessor :private_headers
+
       # @param  [Target] target @see target
       #
       def initialize(target)
         @target = target
+        @private_headers = []
       end
 
       # Generates and saves the Info.plist to the given path.
@@ -35,14 +40,24 @@ module Pod
       # @return [String]
       #
       def generate
-        <<-eos.strip_heredoc
+        result = <<-eos.strip_heredoc
           framework module #{target.product_module_name} {
             umbrella header "#{target.umbrella_header_path.basename}"
 
             export *
             module * { export * }
-          }
         eos
+
+        result << "\n#{generate_private_header_exports}" unless private_headers.empty?
+        result << "}\n"
+      end
+
+      private
+
+      def generate_private_header_exports
+        private_headers.reduce('') do |string, header|
+          string << %(  private header "#{header}\n")
+        end
       end
     end
   end

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -56,7 +56,7 @@ module Pod
 
       def generate_private_header_exports
         private_headers.reduce('') do |string, header|
-          string << %(  private header "#{header}\n")
+          string << %(  private header "#{header}"\n)
         end
       end
     end

--- a/lib/cocoapods/installer/target_installer.rb
+++ b/lib/cocoapods/installer/target_installer.rb
@@ -107,12 +107,16 @@ module Pod
       # Creates the module map file which ensures that the umbrella header is
       # recognized with a customized path
       #
+      # @yield_param [Generator::ModuleMap]
+      #              yielded once to configure the private headers
+      #
       # @return [void]
       #
       def create_module_map
         path = target.module_map_path
         UI.message "- Generating module map file at #{UI.path(path)}" do
           generator = Generator::ModuleMap.new(target)
+          yield generator if block_given?
           generator.save_as(path)
           add_file_to_support_group(path)
 

--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -22,7 +22,9 @@ module Pod
           create_xcconfig_file
           if target.requires_frameworks?
             create_info_plist_file
-            create_module_map
+            create_module_map do |generator|
+              generator.private_headers += target.file_accessors.flat_map(&:private_headers).map(&:basename)
+            end
             create_umbrella_header do |generator|
               generator.imports += target.file_accessors.flat_map(&:public_headers).map(&:basename)
             end

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -21,5 +21,19 @@ module Pod
         }
       EOS
     end
+
+    it 'correctly adds private headers' do
+      @gen.stubs(:private_headers).returns(['Private.h'])
+      @gen.generate.should == <<-EOS.strip_heredoc
+        framework module BananaLib {
+          umbrella header "Pods-default-BananaLib-umbrella.h"
+
+          export *
+          module * { export * }
+
+          private header "Private.h"
+        }
+      EOS
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/2974.

\c @mrackwitz @kylef 