### PR TITLE
[Analyzer] Only update git sourced spec repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Enhancements
+
+* Xcodebuild warnings will now be reported as `warning` during linting
+  instead of `note`.  
+  [Hugo Tunius](https://github.com/K0nserv)
+
 ##### Bug Fixes
 
 * Ensure that linting fails if xcodebuild doesn't successfully build your Pod.  
@@ -17,16 +23,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dustin Clark](https://github.com/clarkda)
   [#2558](https://github.com/CocoaPods/CocoaPods/issues/2558)
 
-* Xcodebuild warnings with the string `error` in them will no longer be 
+* Xcodebuild warnings with the string `error` in them will no longer be
   linted as errors if they are in fact warnings.  
   [Hugo Tunius](https://github.com/K0nserv)
   [#2579](https://github.com/CocoaPods/CocoaPods/issues/2579)
 
-##### Enhancements
-
-* Xcodebuild warnings will now be reported as `warning` during linting
-  instead of `note`.  
-  [Hugo Tunius](https://github.com/K0nserv)
 
 ## 0.36.0.beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#2981](https://github.com/CocoaPods/CocoaPods/issues/2981)
   [cocoapods-trunk#33](https://github.com/CocoaPods/cocoapods-trunk/issues/33)
 
+* Only update the git sourced spec repositories for repo updates.  
+  [Dustin Clark](https://github.com/clarkda)
+  [#2558](https://github.com/CocoaPods/CocoaPods/issues/2558)
+
 * Xcodebuild warnings with the string `error` in them will no longer be 
   linted as errors if they are in fact warnings.  
   [Hugo Tunius](https://github.com/K0nserv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dustin Clark](https://github.com/clarkda)
   [#2558](https://github.com/CocoaPods/CocoaPods/issues/2558)
 
-* Xcodebuild warnings with the string `error` in them will no longer be
+* Xcodebuild warnings with the string `error` in them will no longer be 
   linted as errors if they are in fact warnings.  
   [Hugo Tunius](https://github.com/K0nserv)
   [#2579](https://github.com/CocoaPods/CocoaPods/issues/2579)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,9 @@ For more details, see :memo: [CocoaPods 0.35](http://blog.cocoapods.org/CocoaPod
   copying resources to main application bundle.  
   [Yan Rabovik](https://github.com/rabovik)
 
+* Fix uninitialized constant Class::YAML crash in some cases.
+  [Tim Shadel](https://github.com/timshadel)
+
 ##### Enhancements
 
 * `pod search`, `pod spec which`, `pod spec cat` and `pod spec edit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   instead of `note`.  
   [Hugo Tunius](https://github.com/K0nserv)
 
+* Copy only the resources required for the current build configuration.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#2391](https://github.com/CocoaPods/CocoaPods/issues/2391)
+
 ##### Bug Fixes
 
 * Ensure that linting fails if xcodebuild doesn't successfully build your Pod.  

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -70,11 +70,13 @@ module Pod
       def script
         script = install_resources_function
         resources_by_config.each do |config, resources|
-          script += %(if [[ "$CONFIGURATION" == "#{config}" ]]; then\n)
-          resources.each do |resource|
-            script += "  install_resource '#{resource}'\n"
+          unless resources.empty?
+            script += %(if [[ "$CONFIGURATION" == "#{config}" ]]; then\n)
+            resources.each do |resource|
+              script += "  install_resource '#{resource}'\n"
+            end
+            script += "fi\n"
           end
-          script += "fi\n"
         end
         script += RSYNC_CALL
         script += XCASSETS_COMPILE

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -59,9 +59,9 @@ module Pod
       #
       def install_resources_function
         if use_external_strings_file?
-          INSTALL_RESOURCES_FUCTION
+          INSTALL_RESOURCES_FUNCTION
         else
-          INSTALL_RESOURCES_FUCTION.gsub(' --reference-external-strings-file', '')
+          INSTALL_RESOURCES_FUNCTION.gsub(' --reference-external-strings-file', '')
         end
       end
 
@@ -83,7 +83,7 @@ module Pod
         script
       end
 
-      INSTALL_RESOURCES_FUCTION = <<EOS
+      INSTALL_RESOURCES_FUNCTION = <<EOS
 #!/bin/sh
 set -e
 

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -68,7 +68,10 @@ module Pod
       # @return [String] The contents of the copy resources script.
       #
       def script
+        # Define install function
         script = install_resources_function
+
+        # Call function for each configuration-dependent resource
         resources_by_config.each do |config, resources|
           unless resources.empty?
             script += %(if [[ "$CONFIGURATION" == "#{config}" ]]; then\n)
@@ -78,6 +81,7 @@ module Pod
             script += "fi\n"
           end
         end
+
         script += RSYNC_CALL
         script += XCASSETS_COMPILE
         script

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -1,21 +1,22 @@
 module Pod
   module Generator
     class CopyResourcesScript
-      # @return [Array<#to_s>] A list of files relative to the project pods
-      #         root.
+      # @return [Hash{String, Array{String}] A list of files relative to the
+      #         project pods root, keyed by build configuration.
       #
-      attr_reader :resources
+      attr_reader :resources_by_config
 
       # @return [Platform] The platform of the library for which the copy
       #         resources script is needed.
       #
       attr_reader :platform
 
-      # @param  [Array<#to_s>] resources @see resources
+      # @param  [Hash{String, Array{String}]
+      #         resources_by_config @see resources_by_config
       # @param  [Platform] platform @see platform
       #
-      def initialize(resources, platform)
-        @resources = resources
+      def initialize(resources_by_config, platform)
+        @resources_by_config = resources_by_config
         @platform = platform
       end
 
@@ -68,8 +69,12 @@ module Pod
       #
       def script
         script = install_resources_function
-        resources.each do |resource|
-          script += %(          install_resource "#{resource}"\n          )
+        resources_by_config.each do |config, resources|
+          script += %(if [[ "$CONFIGURATION" == "#{config}" ]]; then\n)
+          resources.each do |resource|
+            script += "  install_resource '#{resource}'\n"
+          end
+          script += "fi\n"
         end
         script += RSYNC_CALL
         script += XCASSETS_COMPILE

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -163,12 +163,12 @@ module Pod
         end
       end
 
-      # Updates the source repositories unless the config indicates to skip it.
+      # Updates the git source repositories unless the config indicates to skip it.
       #
       def update_repositories_if_needed
         unless config.skip_repo_update?
           UI.section 'Updating spec repositories' do
-            sources.each { |source| SourcesManager.update(source.name) }
+            sources.each { |source| SourcesManager.update(source.name) if SourcesManager.git_repo?(source.repo) }
           end
         end
       end

--- a/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
@@ -114,7 +114,6 @@ module Pod
         library_targets = target.pod_targets.reject do |pod_target|
           pod_target.should_build? && pod_target.requires_frameworks?
         end
-        file_accessors = library_targets.flat_map(&:file_accessors)
         resources_by_config = {}
         target.user_build_configurations.keys.each do |config|
           file_accessors = library_targets.select { |t| t.include_in_build_config?(config) }.flat_map(&:file_accessors)

--- a/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
@@ -115,13 +115,15 @@ module Pod
           pod_target.should_build? && pod_target.requires_frameworks?
         end
         file_accessors = library_targets.flat_map(&:file_accessors)
-        resource_paths = file_accessors.flat_map { |accessor| accessor.resources.flat_map { |res| res.relative_path_from(project.path.dirname) } }
-        resource_bundles = file_accessors.flat_map { |accessor| accessor.resource_bundles.keys.map { |name| "${BUILT_PRODUCTS_DIR}/#{name}.bundle" } }
-        resources = []
-        resources.concat(resource_paths)
-        resources.concat(resource_bundles)
-        resources << bridge_support_file if bridge_support_file
-        generator = Generator::CopyResourcesScript.new(resources, target.platform)
+        resources_by_config = {}
+        target.user_build_configurations.keys.each do |config|
+          file_accessors = library_targets.select { |t| t.include_in_build_config?(config) }.flat_map(&:file_accessors)
+          resource_paths = file_accessors.flat_map { |accessor| accessor.resources.flat_map { |res| res.relative_path_from(project.path.dirname) } }
+          resource_bundles = file_accessors.flat_map { |accessor| accessor.resource_bundles.keys.map { |name| "${BUILT_PRODUCTS_DIR}/#{name}.bundle" } }
+          resources_by_config[config] = resource_paths + resource_bundles
+          resources_by_config[config] << bridge_support_file if bridge_support_file
+        end
+        generator = Generator::CopyResourcesScript.new(resources_by_config, target.platform)
         generator.save_as(path)
         add_file_to_support_group(path)
       end

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -179,7 +179,7 @@ module Pod
         def add_copy_resources_script_phase
           phase_name = 'Copy Pods Resources'
           native_targets_to_integrate.each do |native_target|
-            phase = native_target.shell_script_build_phases.select { |bp| bp.name == phase_name }.first
+            phase = native_target.shell_script_build_phases.find { |bp| bp.name == phase_name }
             phase ||= native_target.new_shell_script_build_phase(phase_name)
             script_path = target.copy_resources_script_relative_path
             phase.shell_script = %("#{script_path}"\n)

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -144,6 +144,7 @@ module Pod
       def updated_search_index
         unless @updated_search_index
           if search_index_path.exist?
+            require 'yaml'
             stored_index = YAML.load(search_index_path.read)
             if stored_index && stored_index.is_a?(Hash)
               search_index = aggregate.update_search_index(stored_index)

--- a/spec/unit/generator/copy_resources_script_spec.rb
+++ b/spec/unit/generator/copy_resources_script_spec.rb
@@ -17,5 +17,16 @@ module Pod
       generator_1.send(:script).should.not.include '--reference-external-strings-file'
       generator_2.send(:script).should.include '--reference-external-strings-file'
     end
+
+    it 'adds configuration dependent resources with a call wrapped in an if statement' do
+      resources = { 'Debug' => %w(Lookout.framework) }
+      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
+      script = generator.send(:script)
+      script.should.include <<-eos.strip_heredoc
+        if [[ "$CONFIGURATION" == "Debug" ]]; then
+          install_resource 'Lookout.framework'
+        fi
+      eos
+    end
   end
 end

--- a/spec/unit/generator/copy_resources_script_spec.rb
+++ b/spec/unit/generator/copy_resources_script_spec.rb
@@ -3,14 +3,14 @@ require File.expand_path('../../../spec_helper', __FILE__)
 module Pod
   describe Generator::CopyResourcesScript do
     it 'returns the copy resources script' do
-      resources = ['path/to/resource.png']
+      resources = { 'Release' => ['path/to/resource.png'] }
       generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
       generator.send(:script).should.include 'path/to/resource.png'
       generator.send(:script).should.include 'storyboard'
     end
 
     it 'instructs ibtool to use the --reference-external-strings-file if set to do so' do
-      resources = ['path/to/resource.png']
+      resources = { 'Release' => ['path/to/resource.png'] }
       generator_1 = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '4.0'))
       generator_2 = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -71,6 +71,27 @@ module Pod
         @analyzer.analyze
       end
 
+      it 'does not update non-git repositories' do
+        tmp_directory = '/private/tmp/CocoaPods/'
+        FileUtils.mkdir_p(tmp_directory)
+        FileUtils.cp_r(ROOT + 'spec/fixtures/spec-repos/test_repo/', tmp_directory)
+        non_git_repo = tmp_directory + 'test_repo'
+
+        podfile = Podfile.new do
+          platform :ios, '8.0'
+          xcodeproj 'SampleProject/SampleProject'
+          pod 'BananaLib', '1.0'
+        end
+        config.skip_repo_update = false
+
+        SourcesManager.expects(:update).never
+        analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
+        analyzer.stubs(:sources).returns([Source.new(non_git_repo)])
+        analyzer.analyze
+
+        FileUtils.rm_rf(non_git_repo)
+      end
+
       #--------------------------------------#
 
       it 'generates the libraries which represent the target definitions' do


### PR DESCRIPTION
I've updated `Analyzer::update_repositories_if_needed` to only update a spec repository if it is a git sourced repository -- seems pretty simple and I can't really see a reason to go any further for a non-git repo. 

Edit: This is a proposed fix for #2558

Do you all see any issue with this, maybe something I'm missing? 

/cc: @neonichu @kylef 