### PR TITLE
Fix for issue #3008 Swift Pod causes runtime failure in Obj-C host app o...

### DIFF
--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -78,6 +78,9 @@ module Pod
             for lib in $swift_runtime_libs; do
               echo "rsync -av \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
               rsync -av "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+              if [ "${CODE_SIGNING_REQUIRED}" == "YES" ]; then
+                code_sign "${destination}/${lib}"
+              fi
             done
           }
 


### PR DESCRIPTION
Fix for issue #3008 Swift Pod causes runtime failure in Obj-C host app on device (codesign issue)