### PR TITLE
Homebrew distribution

### DIFF
--- a/homebrew.rb
+++ b/homebrew.rb
@@ -1,0 +1,124 @@
+# Homebrew
+# -----
+
+require "rake/packagetask"
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
+
+GEMS_DIR = "vendor/gems"
+GH_PAGES_DIR = "gh-pages"
+HOMEBREW_FORMULAE_DIR = "homebrew-formulae"
+
+namespace :gems do
+  desc "Vendorize dependencies"
+  task :vendorize do
+    system("vendor/vendorize", GEMS_DIR)
+  end
+
+  desc "Remove vendorized dependencies"
+  task :clean do
+    FileUtils.rm_r(GEMS_DIR) if Dir.exist?(GEMS_DIR)
+  end
+end
+
+desc "Push new release"
+task homebrewrelease: ["release:build", "release:push", "release:clean"]
+
+namespace :release do
+  desc "Build a new release"
+  task build: ["tarball:build", "homebrew:build"]
+
+  desc "Push sub-repositories"
+  task push: ["tarball:push", "homebrew:push"]
+
+  desc "Clean all build artifacts"
+  task clean: ["gems:clean", "tarball:clean", "homebrew:clean"]
+end
+
+namespace :homebrew do
+  desc "Generate homebrew formula and add it to the repo"
+  task build: ["checkout", "formula:build", "commit"]
+
+  desc "Checkout homebrew repo locally"
+  task :checkout do
+    `git clone https://github.com/Keithbsmiley/homebrew-formulae.git #{ HOMEBREW_FORMULAE_DIR }`
+  end
+
+  desc "Check in the new Homebrew formula"
+  task :commit do
+    Dir.chdir(HOMEBREW_FORMULAE_DIR) do
+      `git add Formula/cocoapods.rb`
+      `git commit -m "cocoapods: Release version #{ gem_version }"`
+    end
+  end
+
+  desc "Push homebrew repo"
+  task :push do
+    Dir.chdir(HOMEBREW_FORMULAE_DIR) do
+      `git push`
+    end
+  end
+
+  desc "Remove Homebrew repo"
+  task :clean do
+    FileUtils.rm_rf(HOMEBREW_FORMULAE_DIR) if Dir.exist?(HOMEBREW_FORMULAE_DIR)
+  end
+
+  namespace :formula do
+    desc "Build homebrew formula"
+    task :build do
+      formula = File.read("homebrew/cocoapods.rb")
+      formula.gsub!("__VERSION__", gem_version)
+      formula.gsub!(
+        "__SHA__",
+        `shasum #{ GH_PAGES_DIR }/cocoapods-#{ gem_version }.tar.gz`
+          .split.first)
+      File.write("#{ HOMEBREW_FORMULAE_DIR }/Formula/cocoapods.rb", formula)
+    end
+  end
+end
+
+namespace :tarball do
+  desc "Build the tarball"
+  task build: ["checkout", "package", "move", "commit"]
+
+  desc "Checkout gh-pages"
+  task :checkout do
+    `git clone --branch gh-pages https://github.com/Keithbsmiley/cocoapods.git #{ GH_PAGES_DIR }`
+  end
+
+  desc "Move tarball into gh-pages"
+  task :move do
+    FileUtils.mv("pkg/cocoapods-#{ gem_version }.tar.gz", GH_PAGES_DIR)
+  end
+
+  desc "Check in the new tarball"
+  task :commit do
+    Dir.chdir(GH_PAGES_DIR) do
+      `git add cocoapods-#{ gem_version }.tar.gz`
+      `git commit -m "Release version #{ gem_version }"`
+    end
+  end
+
+  desc "Push the gh-pages branch"
+  task :push do
+    Dir.chdir(GH_PAGES_DIR) do
+      `git push`
+    end
+  end
+
+  desc "Remove gh-pages and pkg directories"
+  task :clean do
+    FileUtils.rm_rf(GH_PAGES_DIR) if Dir.exist?(GH_PAGES_DIR)
+    FileUtils.rm_rf("pkg") if Dir.exist?("pkg")
+  end
+
+  # :package task
+  Rake::PackageTask.new("cocoapods", gem_version) do |p|
+    p.need_tar_gz = true
+    p.package_files.include("src/**/*")
+    p.package_files.include("lib/**/*")
+    p.package_files.include("vendor/**/*")
+    p.package_files.include("LICENSE")
+  end
+end

--- a/homebrew.rb
+++ b/homebrew.rb
@@ -41,13 +41,13 @@ namespace :homebrew do
 
   desc "Checkout homebrew repo locally"
   task :checkout do
-    `git clone https://github.com/Keithbsmiley/homebrew-formulae.git #{ HOMEBREW_FORMULAE_DIR }`
+    `git clone https://github.com/CocoaPods/homebrew.git #{ HOMEBREW_FORMULAE_DIR }`
   end
 
   desc "Check in the new Homebrew formula"
   task :commit do
     Dir.chdir(HOMEBREW_FORMULAE_DIR) do
-      `git add Formula/cocoapods.rb`
+      `git add Library/Formula/cocoapods.rb`
       `git commit -m "cocoapods: Release version #{ gem_version }"`
     end
   end
@@ -73,7 +73,7 @@ namespace :homebrew do
         "__SHA__",
         `shasum #{ GH_PAGES_DIR }/cocoapods-#{ gem_version }.tar.gz`
           .split.first)
-      File.write("#{ HOMEBREW_FORMULAE_DIR }/Formula/cocoapods.rb", formula)
+      File.write("#{ HOMEBREW_FORMULAE_DIR }/Library/Formula/cocoapods.rb", formula)
     end
   end
 end
@@ -84,7 +84,7 @@ namespace :tarball do
 
   desc "Checkout gh-pages"
   task :checkout do
-    `git clone --branch gh-pages https://github.com/Keithbsmiley/cocoapods.git #{ GH_PAGES_DIR }`
+    `git clone --branch gh-pages https://github.com/CocoaPods/CocoaPods.git #{ GH_PAGES_DIR }`
   end
 
   desc "Move tarball into gh-pages"

--- a/homebrew/cocoapods.rb
+++ b/homebrew/cocoapods.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Cocoapods < Formula
-  homepage "https://github.com/Keithbsmiley/cocoapods/"
-  url "http://keithbsmiley.github.io/CocoaPods/cocoapods-__VERSION__.tar.gz"
+  homepage "https://github.com/CocoaPods/cocoapods/"
+  url "http://CocoaPods.github.io/CocoaPods/cocoapods-__VERSION__.tar.gz"
   sha1 "__SHA__"
 
   depends_on "xcproj" => :recommended

--- a/homebrew/cocoapods.rb
+++ b/homebrew/cocoapods.rb
@@ -1,0 +1,20 @@
+require "formula"
+
+class Cocoapods < Formula
+  homepage "https://github.com/Keithbsmiley/cocoapods/"
+  url "http://keithbsmiley.github.io/CocoaPods/cocoapods-__VERSION__.tar.gz"
+  sha1 "__SHA__"
+
+  depends_on "xcproj" => :recommended
+
+  def install
+    prefix.install "vendor"
+    prefix.install "lib" => "rubylib"
+
+    bin.install "src/pod"
+  end
+
+  test do
+    system "#{bin}/cocoapods", "--version"
+  end
+end

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+rake gems:vendorize && rake homebrewrelease

--- a/src/pod
+++ b/src/pod
@@ -1,0 +1,33 @@
+#!/usr/bin/ruby --disable-gems
+
+require "pathname"
+
+file_path = Pathname.new(__FILE__).realpath
+gems_setup = File.expand_path("../../vendor/gems/setup.rb", file_path)
+
+require gems_setup
+
+$LOAD_PATH.unshift(File.expand_path("../../rubylib", file_path))
+
+
+if RUBY_VERSION > '1.8.7' && Encoding.default_external != Encoding::UTF_8
+  puts "\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding."
+  if ENV['TRAVIS']
+    puts <<-DOC
+Consider adding the following settings to .travis.yml
+
+before_script:
+  - export LANG=en_US.UTF-8\e[0m\n
+    DOC
+  else
+    puts <<-DOC
+See https://github.com/CocoaPods/guides.cocoapods.org/issues/26 for
+possible solutions.\e[0m\n
+    DOC
+  end
+end
+
+STDOUT.sync = true if ENV['CP_STDOUT_SYNC'] == 'TRUE'
+
+require 'cocoapods'
+Pod::Command.run(ARGV)

--- a/src/pod
+++ b/src/pod
@@ -10,7 +10,7 @@ require gems_setup
 $LOAD_PATH.unshift(File.expand_path("../../rubylib", file_path))
 
 
-if RUBY_VERSION > '1.8.7' && Encoding.default_external != Encoding::UTF_8
+if RUBY_VERSION > '2.0.0' && Encoding.default_external != Encoding::UTF_8
   puts "\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding."
   if ENV['TRAVIS']
     puts <<-DOC

--- a/vendor/vendorize
+++ b/vendor/vendorize
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require "bundler"
+
+EX_USAGE = 64
+
+unless ARGV.length == 1
+  $stderr.puts "usage: vendorize path-to-gems"
+  exit EX_USAGE
+end
+
+TARGET_PATH = ARGV.first
+SETUP_PATH = File.join(TARGET_PATH, "setup.rb")
+
+FileUtils.mkdir_p(TARGET_PATH)
+
+File.open(SETUP_PATH, "w") do |setup_file|
+  Bundler.definition.specs_for([:default]).each do |gem|
+    if gem.name != "bundler"
+      system(
+        "/usr/bin/env", "gem", "unpack",
+        "--target", TARGET_PATH,
+        "--version", gem.version.to_s,
+        gem.name
+      )
+
+      gem.require_paths.each do |path|
+        setup_file << "$LOAD_PATH.unshift(File.expand_path(%s, __FILE__))\n" % [
+          "../#{gem.name}-#{gem.version}/#{path}".inspect
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the initial setup to officially support homebrew installations. As discussed [here](https://github.com/CocoaPods/CocoaPods/issues/2238#issuecomment-68763291) CocoaPods should be in the official homebrew repo. Without this setup it will be much more difficult to make this happen while pulling from the official CocoaPods repos. Some small things need to be changed here but as it currently stands you can release to homebrew by running `./release.sh`. Then the only other step will be submitting the PR to the homebrew repo.