### PR TITLE
Configure as extension only for app extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Set the APPLICATION_EXTENSION_API_ONLY build setting if integrating with an app extension target.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#2980](https://github.com/CocoaPods/CocoaPods/issues/2980)
+
 * Xcodebuild warnings will now be reported as `warning` during linting
   instead of `note`.  
   [Hugo Tunius](https://github.com/K0nserv)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -467,8 +467,8 @@ module Pod
     def set_target_dependencies
       frameworks_group = pods_project.frameworks_group
       aggregate_targets.each do |aggregate_target|
-        app_extension = aggregate_target.user_targets.map { |t| t.symbol_type }.include?(:app_extension)
-        set_app_extension_api_only_for_target(aggregate_target) if app_extension
+        app_extension = aggregate_target.user_targets.map(&:symbol_type).include?(:app_extension)
+        configure_app_extension_api_only_for_target(aggregate_target) if app_extension
 
         aggregate_target.pod_targets.each do |pod_target|
           unless pod_target.should_build?
@@ -480,7 +480,7 @@ module Pod
           end
 
           aggregate_target.native_target.add_dependency(pod_target.native_target)
-          set_app_extension_api_only_for_target(pod_target) if app_extension
+          configure_app_extension_api_only_for_target(pod_target) if app_extension
 
           pod_target.dependencies.each do |dep|
             unless dep == pod_target.pod_name
@@ -492,7 +492,7 @@ module Pod
 
               next unless pod_dependency_target.should_build?
               pod_target.native_target.add_dependency(pod_dependency_target.native_target)
-              set_app_extension_api_only_for_target(pod_dependency_target) if app_extension
+              configure_app_extension_api_only_for_target(pod_dependency_target) if app_extension
 
               if pod_target.requires_frameworks?
                 product_ref = frameworks_group.files.find { |f| f.path == pod_dependency_target.product_name } ||
@@ -703,7 +703,7 @@ module Pod
     # Sets the APPLICATION_EXTENSION_API_ONLY build setting to YES for all
     # configurations of the given target
     #
-    def set_app_extension_api_only_for_target(target)
+    def configure_app_extension_api_only_for_target(target)
       target.native_target.build_configurations.each do |config|
         config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'YES'
       end

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -467,8 +467,8 @@ module Pod
     def set_target_dependencies
       frameworks_group = pods_project.frameworks_group
       aggregate_targets.each do |aggregate_target|
-        app_extension = aggregate_target.user_targets.map(&:symbol_type).include?(:app_extension)
-        configure_app_extension_api_only_for_target(aggregate_target) if app_extension
+        is_app_extension = aggregate_target.user_targets.map(&:symbol_type).include?(:app_extension)
+        configure_app_extension_api_only_for_target(aggregate_target) if is_app_extension
 
         aggregate_target.pod_targets.each do |pod_target|
           unless pod_target.should_build?
@@ -480,7 +480,7 @@ module Pod
           end
 
           aggregate_target.native_target.add_dependency(pod_target.native_target)
-          configure_app_extension_api_only_for_target(pod_target) if app_extension
+          configure_app_extension_api_only_for_target(pod_target) if is_app_extension
 
           pod_target.dependencies.each do |dep|
             unless dep == pod_target.pod_name
@@ -492,7 +492,7 @@ module Pod
 
               next unless pod_dependency_target.should_build?
               pod_target.native_target.add_dependency(pod_dependency_target.native_target)
-              configure_app_extension_api_only_for_target(pod_dependency_target) if app_extension
+              configure_app_extension_api_only_for_target(pod_dependency_target) if is_app_extension
 
               if pod_target.requires_frameworks?
                 product_ref = frameworks_group.files.find { |f| f.path == pod_dependency_target.product_name } ||

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -55,7 +55,7 @@ module Pod
     #         will be integrated by this target.
     #
     def user_targets(project = nil)
-      return [] if user_project_path.nil?
+      return [] unless user_project_path
       project ||= Xcodeproj::Project.open(user_project_path)
       user_target_uuids.map do |uuid|
         native_target = project.objects_by_uuid[uuid]

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -55,6 +55,7 @@ module Pod
     #         will be integrated by this target.
     #
     def user_targets(project = nil)
+      return [] if user_project_path.nil?
       project ||= Xcodeproj::Project.open(user_project_path)
       user_target_uuids.map do |uuid|
         native_target = project.objects_by_uuid[uuid]


### PR DESCRIPTION
 Set the APPLICATION_EXTENSION_API_ONLY build setting if integrating with an app extension target.

This gets rid of warnings inside Xcode and also better ensures that one only uses Pods which are safe for App Store approval in app extension targets.

Closes #2980