### PR TITLE
[Analyzer] Only update git sourced spec repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Hugo Tunius](https://github.com/K0nserv)
   [#2823](https://github.com/CocoaPods/CocoaPods/issues/2823)
 
+* When updating spec repositories only update the git sourced repos.  
+  [Dustin Clark](https://github.com/clarkda)
+  [#2558](https://github.com/CocoaPods/CocoaPods/issues/2558)
 
 ## 0.36.0.beta.1
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -163,12 +163,12 @@ module Pod
         end
       end
 
-      # Updates the source repositories unless the config indicates to skip it.
+      # Updates the git source repositories unless the config indicates to skip it.
       #
       def update_repositories_if_needed
         unless config.skip_repo_update?
           UI.section 'Updating spec repositories' do
-            sources.each { |source| SourcesManager.update(source.name) }
+            sources.each { |source| SourcesManager.update(source.name) if SourcesManager.git_repo?(source.repo) }
           end
         end
       end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -172,7 +172,7 @@ module Pod
               if SourcesManager.git_repo?(source.repo)
                 SourcesManager.update(source.name)
               else
-                UI.warn "Skipping `#{source.name}` update because the repository is not a git source repository."
+                UI.message "Skipping `#{source.name}` update because the repository is not a git source repository."
               end
             end
           end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -168,7 +168,13 @@ module Pod
       def update_repositories_if_needed
         unless config.skip_repo_update?
           UI.section 'Updating spec repositories' do
-            sources.each { |source| SourcesManager.update(source.name) if SourcesManager.git_repo?(source.repo) }
+            sources.each do |source|
+              if SourcesManager.git_repo?(source.repo)
+                SourcesManager.update(source.name)
+              else
+                UI.warn "Skipping `#{source.name}` update because the repository is not a git source repository."
+              end
+            end
           end
         end
       end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -71,6 +71,27 @@ module Pod
         @analyzer.analyze
       end
 
+      it 'does not update non-git repositories' do
+        tmp_directory = '/private/tmp/CocoaPods/'
+        FileUtils.mkdir_p(tmp_directory)
+        FileUtils.cp_r(ROOT + 'spec/fixtures/spec-repos/test_repo/', tmp_directory)
+        non_git_repo = tmp_directory + 'test_repo'
+
+        podfile = Podfile.new do
+          platform :ios, '8.0'
+          xcodeproj 'SampleProject/SampleProject'
+          pod 'BananaLib', '1.0'
+        end
+        config.skip_repo_update = false
+
+        SourcesManager.expects(:update).never
+        analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
+        analyzer.stubs(:sources).returns([Source.new(non_git_repo)])
+        analyzer.analyze
+
+        FileUtils.rm_rf(non_git_repo)
+      end
+
       #--------------------------------------#
 
       it 'generates the libraries which represent the target definitions' do

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -83,11 +83,16 @@ module Pod
           pod 'BananaLib', '1.0'
         end
         config.skip_repo_update = false
+        config.verbose = true
+
+        source = Source.new(non_git_repo)
 
         SourcesManager.expects(:update).never
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
-        analyzer.stubs(:sources).returns([Source.new(non_git_repo)])
+        analyzer.stubs(:sources).returns([source])
         analyzer.analyze
+
+        UI.output.should.match /Skipping `#{source.name}` update because the repository is not a git source repository./
 
         FileUtils.rm_rf(non_git_repo)
       end


### PR DESCRIPTION
Updated Analyzer::update_repositories_if_needed to only update a spec repository if it is a git sourced repository.

This is a proposed fix for #2558

/cc: @neonichu @kylef 