### PR TITLE
[PodspecSource] Evaluate :podspec dependencies in their own directory if the path is local.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dustin Clark](https://github.com/clarkda)
   [#2558](https://github.com/CocoaPods/CocoaPods/issues/2558)
 
+* Pods referenced via the `:podspec` option will have their podspecs properly
+  parsed in the local directory if the path points to a local file.  
+  [Samuel Giddins](https://github.com/segiddins)
+
+
 ## 0.36.0.beta.1
 
 [CocoaPods](https://github.com/CocoaPods/CocoaPods/compare/0.35.0...0.36.0.beta.1)

--- a/lib/cocoapods/external_sources/podspec_source.rb
+++ b/lib/cocoapods/external_sources/podspec_source.rb
@@ -10,10 +10,10 @@ module Pod
         title = "Fetching podspec for `#{name}` #{description}"
         UI.titled_section(title,  :verbose_prefix => '-> ') do
           podspec_path = Pathname(podspec_uri)
+          is_json = podspec_path.extname == '.json'
           if podspec_path.exist?
-            store_podspec(sandbox, podspec_path, podspec_path.extname == '.json')
+            store_podspec(sandbox, podspec_path, is_json)
           else
-            is_json = podspec_uri.split('.').last == 'json'
             require 'open-uri'
             begin
               open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }

--- a/lib/cocoapods/external_sources/podspec_source.rb
+++ b/lib/cocoapods/external_sources/podspec_source.rb
@@ -9,13 +9,18 @@ module Pod
       def fetch(sandbox)
         title = "Fetching podspec for `#{name}` #{description}"
         UI.titled_section(title,  :verbose_prefix => '-> ') do
-          is_json = podspec_uri.split('.').last == 'json'
-          require 'open-uri'
-          begin
-            open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
-          rescue OpenURI::HTTPError => e
-            status = e.io.status.join(' ')
-            raise Informative, "Failed to fetch podspec for `#{name}` at `#{podspec_uri}`.\n Error: #{status}"
+          podspec_path = Pathname(podspec_uri)
+          if podspec_path.exist?
+            store_podspec(sandbox, podspec_path, podspec_path.extname == '.json')
+          else
+            is_json = podspec_uri.split('.').last == 'json'
+            require 'open-uri'
+            begin
+              open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
+            rescue OpenURI::HTTPError => e
+              status = e.io.status.join(' ')
+              raise Informative, "Failed to fetch podspec for `#{name}` at `#{podspec_uri}`.\n Error: #{status}"
+            end
           end
         end
       end

--- a/spec/unit/external_sources/podspec_source_spec.rb
+++ b/spec/unit/external_sources/podspec_source_spec.rb
@@ -12,7 +12,7 @@ module Pod
 
     it 'creates a copy of the podspec' do
       @subject.fetch(config.sandbox)
-      path = config.sandbox.specifications_root + 'Reachability.podspec'
+      path = config.sandbox.specifications_root + 'Reachability.podspec.json'
       path.should.exist?
     end
 


### PR DESCRIPTION
This fixes an issue @tgoyne has been having.

@kylef, a quick merge of this would be much appreciated. The failures are in the integration spec, and are expected.