### PR TITLE
Build for iOS simulator only during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Build for iOS simulator only during validation. This allows validation without having 
+  provisioning profiles set up.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3083](https://github.com/CocoaPods/CocoaPods/issues/3083)
+  [#13](https://github.com/CocoaPods/swift/issues/13)
+
 * Explicitly inform the user to close existing project when switching to
   a workspace for the first time.  
   [Kyle Fuller](https://github.com/kylef)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   provisioning profiles set up.  
   [Boris Bügling](https://github.com/neonichu)
   [#3083](https://github.com/CocoaPods/CocoaPods/issues/3083)
-  [#13](https://github.com/CocoaPods/swift/issues/13)
+  [Swift#13](https://github.com/CocoaPods/swift/issues/13)
 
 * Explicitly inform the user to close existing project when switching to
   a workspace for the first time.  

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -519,8 +519,11 @@ module Pod
     #         returns its output (both STDOUT and STDERR).
     #
     def xcodebuild
-      UI.puts 'xcodebuild clean build -target Pods' if config.verbose?
-      output = `xcodebuild clean build -target Pods 2>&1`
+      command = 'xcodebuild clean build -target Pods CODE_SIGN_IDENTITY=-'
+      command << ' -sdk iphonesimulator' if consumer.platform_name == :ios
+
+      UI.puts command if config.verbose?
+      output = `#{command} 2>&1`
 
       unless $?.success?
         message = 'Returned a unsuccessful exit code.'

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -371,6 +371,18 @@ module Pod
         validator.result_type.should == :error
       end
 
+      it 'runs xcodebuild with correct arguments for code signing' do
+        Validator.any_instance.unstub(:xcodebuild)
+        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator.stubs(:check_file_patterns)
+        validator.stubs(:validate_url)
+        validator.expects(:`).with('which xcodebuild').twice.returns('/usr/bin/xcodebuild')
+        command = 'xcodebuild clean build -target Pods CODE_SIGN_IDENTITY=-'
+        validator.expects(:`).with("#{command} 2>&1").once.returns('')
+        validator.expects(:`).with("#{command} -sdk iphonesimulator 2>&1").once.returns('')
+        validator.validate
+      end
+
       it 'does filter InputFile errors completely' do
         validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
         validator.stubs(:check_file_patterns)


### PR DESCRIPTION
No code signing identity needed anymore :key: 

Fixes CocoaPods/swift#13