### PR TITLE
No colors when grepping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3038](https://github.com/CocoaPods/CocoaPods/issues/3038)
 
+* Removing grep color mark up in embed frameworks script.
+  [Adriano Bonat](https://github.com/tanob)
+  [#3117](https://github.com/CocoaPods/CocoaPods/issues/3117)
 
 ## 0.36.0.beta.2
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -74,7 +74,7 @@ module Pod
             local basename
             basename=$(echo $1 | sed -E s/\\\\..+// && exit ${PIPESTATUS[0]})
             local swift_runtime_libs
-            swift_runtime_libs=$(xcrun otool -LX "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/$1/${basename}" | grep @rpath/libswift | sed -E s/@rpath\\\\/\\(.+dylib\\).*/\\\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
+            swift_runtime_libs=$(xcrun otool -LX "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/$1/${basename}" | grep --color=never @rpath/libswift | sed -E s/@rpath\\\\/\\(.+dylib\\).*/\\\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
             for lib in $swift_runtime_libs; do
               echo "rsync -av \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
               rsync -av "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"


### PR DESCRIPTION
Explicitly specifying `--color=never` to avoid ASCII color codes getting into the file path:

![screen shot 2015-02-07 at 23 03 21](https://cloud.githubusercontent.com/assets/5013/6094715/539e59ec-af1e-11e4-9b4f-809163a17f25.png)
