### PR TITLE
[Installer] Reject installation if a static library is used as a transit...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Boris Bügling](https://github.com/neonichu)
   [#2963](https://github.com/CocoaPods/CocoaPods/issues/2963)
 
+* Reject installation if a static library is used as a transitive dependency
+  while integrating Pods as frameworks.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#2926](https://github.com/CocoaPods/CocoaPods/issues/2926)
+
 ##### Bug Fixes
 
 * Added support for .tpp C++ header files in specs (previously were getting


### PR DESCRIPTION
...ive dependency while integrating Pods as frameworks.

Closes https://github.com/CocoaPods/CocoaPods/issues/2926.

Is there a better way to do this than using `file`?

\c @neonichu @samdmarshall