### PR TITLE
Copy Swift libraries using `rsync -u`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#2926](https://github.com/CocoaPods/CocoaPods/issues/2926)
 
+* Do not copy Swift standard libraries multiple times.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3131](https://github.com/CocoaPods/CocoaPods/issues/3131)
+
 ##### Bug Fixes
 
 * Added support for .tpp C++ header files in specs (previously were getting

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -76,8 +76,8 @@ module Pod
             local swift_runtime_libs
             swift_runtime_libs=$(xcrun otool -LX "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/$1/${basename}" | grep --color=never @rpath/libswift | sed -E s/@rpath\\\\/\\(.+dylib\\).*/\\\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
             for lib in $swift_runtime_libs; do
-              echo "rsync -av \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
-              rsync -av "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+              echo "rsync -auv \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
+              rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
               if [ "${CODE_SIGNING_REQUIRED}" == "YES" ]; then
                 code_sign "${destination}/${lib}"
               fi


### PR DESCRIPTION
This should ensure that they're not recopied if unchanged, because the
destination will be newer if they changed due to code-signing.

Supersedes #3149