### PR TITLE
[Frameworks] Fail lint for Swift on iOS < 8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   `/tmp`.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Let lint fail for Swift pods supporting deployment targets below iOS 8.0.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#2963](https://github.com/CocoaPods/CocoaPods/issues/2963)
+
 ##### Bug Fixes
 
 * Added support for .tpp C++ header files in specs (previously were getting

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -508,7 +508,7 @@ module Pod
     def parse_xcodebuild_output(output)
       lines = output.split("\n")
       selected_lines = lines.select do |l|
-        l.include?('error: ') &&
+        l.include?('error: ') && (l !~ /frameworks only run on iOS 8/) &&
           (l !~ /errors? generated\./) && (l !~ /error: \(null\)/)  ||
           l.include?('warning: ') && (l !~ /warnings? generated\./) ||
           l.include?('note: ') && (l !~ /expanded from macro/)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -310,7 +310,8 @@ module Pod
       installer.install!
 
       file_accessors = installer.aggregate_targets.map do |target|
-        if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios && deployment_target.to_f < 8.0
+        if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&
+            (deployment_target.nil? || Version.new(deployment_target).major < 8)
           error('swift', 'Swift support uses dynamic frameworks and is therefore only supported on iOS > 8.')
         end
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -310,6 +310,10 @@ module Pod
       installer.install!
 
       file_accessors = installer.aggregate_targets.map do |target|
+        if target.pod_targets.any?(&:uses_swift?) && deployment_target.to_f < 8.0
+          error('swift', 'Swift support uses dynamic frameworks and is therefore only supported on iOS > 8.')
+        end
+
         target.pod_targets.map(&:file_accessors)
       end.flatten
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -310,7 +310,7 @@ module Pod
       installer.install!
 
       file_accessors = installer.aggregate_targets.map do |target|
-        if target.pod_targets.any?(&:uses_swift?) && deployment_target.to_f < 8.0
+        if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios && deployment_target.to_f < 8.0
           error('swift', 'Swift support uses dynamic frameworks and is therefore only supported on iOS > 8.')
         end
 


### PR DESCRIPTION
Have to use dynamic frameworks for Swift and they are unsupported on iOS 7.

Fixes #2963