### PR TITLE
Require explicit use of `use_frameworks!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#2685](https://github.com/CocoaPods/CocoaPods/issues/2685)
 
+* Require explicit use of `use_frameworks!` for Pods written in Swift.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3029](https://github.com/CocoaPods/CocoaPods/issues/3029)
+
 ##### Bug Fixes
 
 * Added support for .tpp C++ header files in specs (previously were getting

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -380,7 +380,7 @@ module Pod
           if pod_targets.any?(&:uses_swift?)
             raise Informative, 'Pods written in Swift can only be integrated as frameworks; this ' \
               'feature is still in beta. Add `use_frameworks!` to your Podfile or target to opt ' \
-              'in to using it.'
+              'into using it.'
           end
         end
       end

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -91,13 +91,8 @@ module Pod
     # @return [Boolean] whether the generated target needs to be implemented
     #         as a framework
     #
-    # @note This applies either if Swift was used by the host, which was checked
-    #       eagerly by the analyzer before, or in the given target or its
-    #       dependents, which can only be checked after the specs were been
-    #       fetched.
-    #
     def requires_frameworks?
-      host_requires_frameworks? || uses_swift?
+      host_requires_frameworks? || false
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -123,6 +123,10 @@ module Pod
             fixture_spec('orange-framework/OrangeFramework.podspec')
           end
 
+          before do
+            Target.any_instance.stubs(:requires_frameworks?).returns(true)
+          end
+
           behaves_like 'AggregateXCConfig'
 
           it 'sets the PODS_FRAMEWORK_BUILD_PATH build variable' do

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -51,6 +51,7 @@ module Pod
         @installer.stubs(:determine_dependency_product_types)
         @installer.stubs(:verify_no_duplicate_framework_names)
         @installer.stubs(:verify_no_static_framework_transitive_dependencies)
+        @installer.stubs(:verify_framework_usage)
         @installer.stubs(:generate_pods_project)
         @installer.stubs(:integrate_user_project)
         @installer.stubs(:run_plugins_post_install_hooks)
@@ -125,6 +126,7 @@ module Pod
         podfile = Pod::Podfile.new do
           platform :ios, '8.0'
           xcodeproj 'SampleProject/SampleProject'
+          use_frameworks!
           pod 'BananaLib',       :path => (fixture_path + 'banana-lib').to_s
           pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
           pod 'monkey',          :path => (fixture_path + 'monkey').to_s
@@ -177,6 +179,7 @@ module Pod
         podfile = Pod::Podfile.new do
           platform :ios, '8.0'
           xcodeproj 'SampleProject/SampleProject'
+          use_frameworks!
           pod 'BananaLib',       :path => (fixture_path + 'banana-lib').to_s
           pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
           pod 'monkey',          :path => (fixture_path + 'monkey').to_s

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -194,6 +194,25 @@ module Pod
 
     #-------------------------------------------------------------------------#
 
+    describe '#verify_framework_usage' do
+      it 'raises when Swift pods are used without explicit `use_frameworks!`' do
+        fixture_path = ROOT + 'spec/fixtures'
+        config.repos_dir = fixture_path + 'spec-repos'
+        podfile = Pod::Podfile.new do
+          platform :ios, '8.0'
+          xcodeproj 'SampleProject/SampleProject'
+          pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
+        end
+        lockfile = generate_lockfile
+        config.integrate_targets = false
+
+        @installer = Installer.new(config.sandbox, podfile, lockfile)
+        should.raise(Informative) { @installer.install! }.message.should.match /use_frameworks/
+      end
+    end
+
+    #-------------------------------------------------------------------------#
+
     describe 'Dependencies Resolution' do
       describe '#analyze' do
         it 'prints a warning if the version of the Lockfile is higher than the one of the executable' do

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -202,6 +202,7 @@ module Pod
         before do
           @pod_target = fixture_pod_target('orange-framework/OrangeFramework.podspec', :ios, Podfile::TargetDefinition.new('iOS Example', nil))
           @target = AggregateTarget.new(@pod_target.target_definition, config.sandbox)
+          @target.stubs(:requires_frameworks?).returns(true)
           @target.pod_targets = [@pod_target]
         end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -178,6 +178,7 @@ module Pod
       describe 'With frameworks' do
         before do
           @pod_target = fixture_pod_target('orange-framework/OrangeFramework.podspec')
+          @pod_target.host_requires_frameworks = true
         end
 
         it 'returns that it uses swift' do

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -448,6 +448,7 @@ module Pod
         podspec.gsub!(/.*license.*$/, '"license": "Public Domain",')
         file = write_podspec(podspec)
 
+        Podfile::TargetDefinition.any_instance.stubs(:uses_frameworks?).returns(true)
         Pod::Sandbox::FileAccessor.any_instance.stubs(:source_files).returns([Pathname.new('/Foo.swift')])
         validator = Validator.new(file, SourcesManager.master.map(&:url))
         validator.stubs(:build_pod)


### PR DESCRIPTION
Looks like this right now:

```
Analyzing dependencies
Downloading dependencies
Using Alamofire (1.1.4)
[!] Pods written in Swift can only be integrated as frameworks; this feature is still 
in beta. Add `use_frameworks!` to your Podfile or target to opt in to using it.
```
