### PR TITLE
Fix static binaries check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3212](https://github.com/CocoaPods/CocoaPods/issues/3212)
 
+* Limit the check for transitive static binaries to those which are directly linked to the user target.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3194](https://github.com/CocoaPods/CocoaPods/issues/3194)
+
 
 ## 0.36.0.rc.1
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -355,7 +355,7 @@ module Pod
           pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
 
           dependencies = pod_targets.flat_map(&:dependencies)
-          dependended_upon_targets = pod_targets.select { |t| dependencies.include?(t.pod_name) }
+          dependended_upon_targets = pod_targets.select { |t| dependencies.include?(t.pod_name) && !t.should_build? }
 
           static_libs = dependended_upon_targets.flat_map(&:file_accessors).flat_map do |fa|
             static_frameworks = fa.vendored_frameworks.reject { |fw| `file #{fw + fw.basename('.framework')} 2>&1` =~ /dynamically linked/ }


### PR DESCRIPTION
This limits our check for static transitive dependencies to those which are known to not work.

Reasoning:
- `should_build? == false` means the static library or framework will be linked directly to the user target
- Linking a pod target which depends transitively on the same static library or framework will fail because of missing symbols
- Linking both targets against the static library or framework will likely result in duplicated symbols

=> this kind of dependency cannot be fulfilled if the integration is done via frameworks.

This fixes #3194