### PR TITLE
Set FRAMEWORK_SEARCH_PATHS only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Correctly filter Xcode warnings about the use of dynamic frameworks.  
   [Boris Bügling](https://github.com/neonichu)
 
+* Fixes warnings, when the aggregate target doesn't contain any pod target, which is build,
+  because `PODS_FRAMEWORK_BUILD_PATH` was added to `FRAMEWORK_SEARCH_PATHS`, but never created.
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#3217](https://github.com/CocoaPods/CocoaPods/issues/3217)
+
 
 ## 0.36.0.rc.1
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -60,10 +60,12 @@ module Pod
             header_search_paths = pod_targets.map { |target| "$PODS_FRAMEWORK_BUILD_PATH/#{target.product_name}/Headers" }
             build_settings = {
               'PODS_FRAMEWORK_BUILD_PATH' => target.configuration_build_dir,
-              'FRAMEWORK_SEARCH_PATHS' => '"$PODS_FRAMEWORK_BUILD_PATH"',
               # Make headers discoverable by `import "…"`
               'OTHER_CFLAGS' => '$(inherited) ' + XCConfigHelper.quote(header_search_paths, '-iquote'),
             }
+            if target.pod_targets.any?(&:should_build?)
+              build_settings['FRAMEWORK_SEARCH_PATHS'] = '"$PODS_FRAMEWORK_BUILD_PATH"'
+            end
             config.merge!(build_settings)
           else
             # Make headers discoverable from $PODS_ROOT/Headers directory

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -129,6 +129,16 @@ module Pod
 
           behaves_like 'AggregateXCConfig'
 
+          describe 'with a vendored-library pod' do
+            def spec
+              fixture_spec('monkey/monkey.podspec')
+            end
+
+            it 'does not add the framework build path to the xcconfig' do
+              @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.be.nil?
+            end
+          end
+
           it 'sets the PODS_FRAMEWORK_BUILD_PATH build variable' do
             @xcconfig.to_hash['PODS_FRAMEWORK_BUILD_PATH'].should == '$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Pods'
           end


### PR DESCRIPTION
We don't need to add $PODS_FRAMEWORK_BUILD_PATH, if there is no pod target, which should be build.
Fixes #3213.