### PR TITLE
[Validator] Allows Swift pods to have a deployment target under iOS 8.0 ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Enhancements
+
+* Allows Swift pods to have a deployment target under iOS 8.0 if they use
+  XCTest.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#3225](https://github.com/CocoaPods/CocoaPods/issues/3225)
+
 ##### Bug Fixes
 
 * Correctly filter Xcode warnings about the use of dynamic frameworks.  

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -313,7 +313,8 @@ module Pod
       file_accessors = installer.aggregate_targets.map do |target|
         if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&
             (deployment_target.nil? || Version.new(deployment_target).major < 8)
-          error('swift', 'Swift support uses dynamic frameworks and is therefore only supported on iOS > 8.')
+          uses_xctest = target.spec_consumers.any? { |c| (c.frameworks + c.weak_frameworks).include? 'XCTest' }
+          error('swift', 'Swift support uses dynamic frameworks and is therefore only supported on iOS > 8.') unless uses_xctest
         end
 
         target.pod_targets.map(&:file_accessors)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -523,6 +523,13 @@ module Pod
         validator.result_type.should == :error
       end
 
+      it 'succeeds on deployment target < iOS 8 for Swift Pods using XCTest' do
+        Specification::Consumer.any_instance.stubs(:frameworks).returns(%w(XCTest))
+
+        validator = test_swiftpod
+        validator.results.count.should == 0
+      end
+
       it 'succeeds on deployment targets >= iOS 8 for Swift Pods' do
         Specification.any_instance.stubs(:deployment_target).returns('9.0')
 


### PR DESCRIPTION
...if they use XCTest.

Closes https://github.com/CocoaPods/CocoaPods/issues/3225.

\c @kylef @neonichu @orta 