### PR TITLE
[Generator] use absolute xcasset file path in copy resource script

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -128,7 +128,7 @@ install_resource()
       xcrun mapc "${PODS_ROOT}/$1" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$1" .xcmappingmodel`.cdm"
       ;;
     *.xcassets)
-      XCASSET_FILES="$XCASSET_FILES '$1'"
+      XCASSET_FILES="$XCASSET_FILES '${PODS_ROOT}/$1'"
       ;;
     /*)
       echo "$1"


### PR DESCRIPTION
Wrong `xcassets` path in generated `Pods-resources.sh` file. This bug can be reproduced by adding [1PasswordExtension spec](https://github.com/CocoaPods/Specs/blob/master/Specs/1PasswordExtension/1.1.2/1PasswordExtension.podspec.json) to demo app.