### PR TITLE
copy xcasset resources with PODS_ROOT path

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -128,7 +128,7 @@ install_resource()
       xcrun mapc "${PODS_ROOT}/$1" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$1" .xcmappingmodel`.cdm"
       ;;
     *.xcassets)
-      XCASSET_FILES="$XCASSET_FILES '$1'"
+      XCASSET_FILES="$XCASSET_FILES '${PODS_ROOT}/$1'"
       ;;
     /*)
       echo "$1"


### PR DESCRIPTION
Today I switched to cocoapods version 0.36.0 and discovered that my project successfully compiles but Xcode still shows errors in the "Copy Bundle Resources" build step. My project contains the 1Password pod which included a 1Password.xcassets catalogue file:

```
sent 251309 bytes  received 1210 bytes  505038.00 bytes/sec
total size is 247404  speedup is 0.98
/* com.apple.actool.notices */
/Users/cmittendorf/Developer/MyApp/1PasswordExtension/1Password.xcassets: warning: Failed to read file attributes for "/Users/cmittendorf/Developer/MyApp/1PasswordExtension/1Password.xcassets"
    Failure Reason: No such file or directory
/* com.apple.actool.compilation-results */

Command /bin/sh emitted errors but did not return a nonzero exit code to indicate failure
``` 

The copy resources script and how it is handling xcassets files was changed in  https://github.com/CocoaPods/CocoaPods/commit/91dfebfd1367c729830ed6a0c02197434772e034.

I think that the script should - when copying *.xcassets resources - prefix the path with the ```${PODS_ROOT}``` directory. 

Patching the created ```Pods/Target Support Files/Pods/Pods-resources.sh```script with the changes from this pull request does fix the "Copy Bundle Resources" build step for my project.
