### PR TITLE
Use mkdir_p to make directory

### DIFF
--- a/lib/cocoapods/installer/target_installer.rb
+++ b/lib/cocoapods/installer/target_installer.rb
@@ -83,7 +83,7 @@ module Pod
       # Creates the directory where to store the support files of the target.
       #
       def create_support_files_dir
-        target.support_files_dir.mkdir
+        FileUtils.mkdir_p target.support_files_dir
       end
 
       # Creates the Info.plist file which sets public framework attributes


### PR DESCRIPTION
I got an error below while I install some libraries.

```
### Error

Errno::EEXIST - File exists @ dir_s_mkdir - /Users/dtaniwaki/Documents/Dev/bugsnag/bugsnag/Pods/Target Support Files/Pods-bugsnag-JSONJoy-Swift
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer/target_installer.rb:86:in `mkdir'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer/target_installer.rb:86:in `mkdir'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer/target_installer.rb:86:in `create_support_files_dir'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer/target_installer/pod_target_installer.rb:19:in `block in install!'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/user_interface.rb:110:in `message'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer/target_installer/pod_target_installer.rb:17:in `install!'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:499:in `block (2 levels) in install_libraries'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:496:in `each'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:496:in `block in install_libraries'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/user_interface.rb:110:in `message'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:495:in `install_libraries'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:131:in `block in generate_pods_project'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/user_interface.rb:49:in `section'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:128:in `generate_pods_project'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:96:in `install!'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/command/project.rb:71:in `run_install_with_update'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/command/project.rb:101:in `run'
/Users/dtaniwaki/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/claide-0.8.1/lib/claide/command.rb:312:in `run'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/lib/cocoapods/command.rb:46:in `run'
/Users/dtaniwaki/.gem/ruby/2.2.0/gems/cocoapods-0.36.0/bin/pod:44:in `<top (required)>'
/Users/dtaniwaki/.rbenv/versions/2.2.1/bin/pod:23:in `load'
/Users/dtaniwaki/.rbenv/versions/2.2.1/bin/pod:23:in `<main>'

――― TEMPLATE END ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

[!] Oh no, an error occurred.
```

I found it was because my `Podfile` has duplicate `pod` line for the same library. However, I think we don't necessarily use `mkdir` here to avoid the error on mkdir command.