### PR TITLE
[CopyResourcesScript] Do not discard `.xcassets` from the main project if there are any pods containing `.xcassets`.

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -169,6 +169,7 @@ then
       TARGET_DEVICE_ARGS="--target-device mac"
       ;;
   esac
+  while read line; do XCASSET_FILES="$XCASSET_FILES '$line'"; done <<<$(find "$PWD" -name "*.xcassets" | egrep -v "^$PODS_ROOT")
   echo $XCASSET_FILES | xargs actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${IPHONEOS_DEPLOYMENT_TARGET}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi
 EOS


### PR DESCRIPTION
If there are any pods being used containing `.xcassets` (for example, [1PasswordExtension](https://github.com/AgileBits/onepassword-app-extension)), while the main project also has a `.xcassets`, the one from the main project will be unexpectedly discarded.