### PR TITLE
Unique the resources by config

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -16,7 +16,10 @@ module Pod
       # @param  [Platform] platform @see platform
       #
       def initialize(resources_by_config, platform)
-        @resources_by_config = resources_by_config
+        @resources_by_config = {}
+        resources_by_config.each do |config, resources|
+          @resources_by_config[config] = resources.uniq
+        end
         @platform = platform
       end
 

--- a/spec/unit/generator/copy_resources_script_spec.rb
+++ b/spec/unit/generator/copy_resources_script_spec.rb
@@ -39,5 +39,13 @@ module Pod
         fi
       eos
     end
+
+    it 'uniques resources by group' do
+      duplicated_resources = { 'Release' => ['path/to/resource.png', 'path/to/resource.png'] }
+      uniqued_resources = { 'Release' => ['path/to/resource.png'] }
+
+      generator = Pod::Generator::CopyResourcesScript.new(duplicated_resources, Platform.new(:ios, '6.0'))
+      generator.send(:resources_by_config).should.equal uniqued_resources
+    end
   end
 end


### PR DESCRIPTION
This helps generate a slimmer script when Pods define the same resources in their subspecs.

This is a diff of the generated scripts for the pod "FormatterKit":
https://www.diffchecker.com/z5ja4cve