### PR TITLE
fix copy multiple .xcassets resource error

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -169,7 +169,7 @@ then
       TARGET_DEVICE_ARGS="--target-device mac"
       ;;
   esac
-  while read line; do XCASSET_FILES="$XCASSET_FILES '$line'"; done <<<$(find "$PWD" -name "*.xcassets" | egrep -v "^$PODS_ROOT")
+  while read -d $'\n' line; do XCASSET_FILES="$XCASSET_FILES '$line'"; done <<<$(find "$PWD" -name "*.xcassets" | egrep -v "^$PODS_ROOT")
   echo $XCASSET_FILES | xargs actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${IPHONEOS_DEPLOYMENT_TARGET}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi
 EOS


### PR DESCRIPTION
if a project has multiple .xcassets folder, the copy_resources.sh will occur a error. 

like this:
`error: Failed to read file attributes for "/Users/Candyan/Joyshare/Mobile/Arrietty/Arrietty/Images.xcassets /Users/Candyan/Joyshare/Mobile/Arrietty/Arrietty/test.xcassets"
    Failure Reason: No such file or directory`

i found the problem in copy_resources.sh

'while read line' commond will read all result rather than one line of result.