### PR TITLE
[Integrator] Add naive check for #included CocoaPods-generated xcconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#1241](https://github.com/CocoaPods/CocoaPods/issues/1241)
 
+* Naïvely prevent base xcconfig warnings for targets that have custom
+  config files set.
+  [Chris Brauchli](https://github.com/cbrauchli)
+  [#2633](https://github.com/CocoaPods/CocoaPods/issues/2633)
+
 ##### Bug Fixes
 
 * Do not pass code-sign arguments to xcodebuild when linting OS X targets.  


### PR DESCRIPTION
Whenever I run `pod install` I get warnings like:


> [!] CocoaPods did not set the base configuration of your project because your project already has a custom config set. In order for CocoaPods integration to work at all, please either set the base configurations of the target `TestClient` to `Pods/Target Support Files/Pods-TestClient/Pods-TestClient.debug.xcconfig` or include the `Pods/Target Support Files/Pods-TestClient/Pods-TestClient.debug.xcconfig` in your build configuration.


This is confusing, especially for people not familiar with CocoaPods.

This adds a naive check for the CocoaPods-generated xcconfig being #included into the target's actual xcconfig. It also adds the ability to have a special token (I chose `// @COCOAPODS_SILENCE_WARNINGS@ //`, but am happy to change it) in the target's xcconfig to signal that the warning should be silenced even though CocoaPods's xcconfig does not appear to be included. This is useful for test targets and cases where the naive check is not sufficient.

I believe this closes #2633. 