### PR TITLE
[pod repo list] Fix issue showing the URL for git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#3145](https://github.com/CocoaPods/CocoaPods/issues/3145)
 
+* Show the source URI for local Pod specification repositories in
+  `pod repo list`.  
+  [Kyle Fuller](https://github.com/kylef)
+
 ##### Bug Fixes
 
 * Do not pass code-sign arguments to xcodebuild when linting OS X targets.  
   [Boris Bügling](https://github.com/neonichu)
   [#3310](https://github.com/CocoaPods/CocoaPods/issues/3310)
+
+* Fixes an issue showing the URL to remote resources in `pod repo list`.  
+  [Kyle Fuller](https://github.com/kylef)
 
 
 ## 0.36.3

--- a/lib/cocoapods/command/repo.rb
+++ b/lib/cocoapods/command/repo.rb
@@ -24,37 +24,6 @@ module Pod
       def dir
         config.repos_dir + @name
       end
-
-      # Returns the branch name (i.e. master).
-      #
-      # @return [String] The name of the current branch.
-      #
-      def branch_name
-        `git name-rev --name-only HEAD`.strip
-      end
-
-      # Returns the branch remote name (i.e. origin).
-      #
-      # @param  [#to_s] branch_name
-      #         The branch name to look for the remote name.
-      #
-      # @return [String] The given branch's remote name.
-      #
-      def branch_remote_name(branch_name)
-        `git config branch.#{branch_name}.remote`.strip
-      end
-
-      # Returns the url of the given remote name
-      # (i.e. git@github.com:CocoaPods/Specs.git).
-      #
-      # @param  [#to_s] remote_name
-      #         The branch remote name to look for the url.
-      #
-      # @return [String] The URL of the given remote.
-      #
-      def url_of_git_repo(remote_name)
-        `git config remote.#{remote_name}.url`.strip
-      end
     end
   end
 end

--- a/spec/functional/command/repo/list_spec.rb
+++ b/spec/functional/command/repo/list_spec.rb
@@ -26,5 +26,43 @@ module Pod
       output.should.include? 'repo'
       output.should.not.include? '- Type:'
     end
+
+    it 'shows the path to the spec repository' do
+      output = run_command('repo', 'list')
+      output.should.include? "- Path: #{repo_path('master')}"
+    end
+
+    it 'shows unknown as the branch when there is no branch for git repositories' do
+      path = repo_path(name)
+      path.mkpath
+      Dir.chdir(path) do
+        `git init`
+      end
+
+      output = run_command('repo', 'list')
+      output.should.include? 'git (unknown)'
+    end
+
+    describe 'with a git based spec repository with a remote' do
+      extend SpecHelper::TemporaryRepos
+
+      before do
+        config.repos_dir = tmp_repos_path
+
+        Dir.chdir(repo_make('apiary')) do
+          `git remote add origin https://github.com/apiaryio/Specs`
+        end
+      end
+
+      it 'shows the current git branch configuration' do
+        output = run_command('repo', 'list')
+        output.should.include? '- Type: git (master)'
+      end
+
+      it 'shows the git URL (when an upstream is not configured)' do
+        output = run_command('repo', 'list')
+        output.should.include? '- URL:  https://github.com/apiaryio/Specs'
+      end
+    end
   end
 end


### PR DESCRIPTION
I noticed a couple of bugs / nonsensical things with `pod repo list`. Here’s a pull request making this sane.

This pull request addresses does following:

- Use `source.url` instead of determining the git remote manually
- Show the branch instead of remote for git repositories, it makes no sense to show the remote since 1) it can only ever be origin according to `source.url` an 2) we’re printing the value of the remote anyway
- Always show the URI for local repositories (so people know what they can put in `source ‘’` in a Podfile

    Before
    
    ```
    b
    - Type: git ()
    - URL:
    - Path: /Users/kyle/.cocoapods/repos/b
    ```
    After
    ```
    b
    - Type: git (master)
    - URL:  file:///Users/kyle/.cocoapods/repos/b/.git
    - Path: /Users/kyle/.cocoapods/repos/b
    - Add tests around existing behaviour and the changes.
    ```

It fixes the following bugs:

- Fixes the output of git spec repositories which have a git remote, but does not have the upstream for the current branch configured to it.

    Before:
    
    ```
    test
    - Type: git ()
    - URL:
    - Path: /Users/kyle/.cocoapods/repos/test
    ```

    After:

    ```
    test
    - Type: git (master)
    - URL:  git@git.oschina.net:congni/IOSFrameLibrary.git
    - Path: /Users/kyle/.cocoapods/repos/test
    ```

- Suppresses git error output when failing to determine git branch (i.e, there is no commits yet)

    ```
    foo
    Could not get sha1 for HEAD. Skipping.
    - Type: git ()
    - URL:
    - Path: /Users/kyle/.cocoapods/repos/foo
    ```
    
    After:
    
    ```
    foo
    - Type: git (unknown)
    - URL:  file:///Users/kyle/.cocoapods/repos/foo/.git
    - Path: /Users/kyle/.cocoapods/repos/foo
    ```
