### PR TITLE
[PrivatePodXCConfig] Public Headers are not needed to build the target itself

### DIFF
--- a/lib/cocoapods/generator/xcconfig/private_pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/private_pod_xcconfig.rb
@@ -45,9 +45,7 @@ module Pod
         # @return [Xcodeproj::Config]
         #
         def generate
-          target_search_paths = target.build_headers.search_paths(target.platform)
-          sandbox_search_paths = target.sandbox.public_headers.search_paths(target.platform)
-          search_paths = target_search_paths.concat(sandbox_search_paths).uniq
+          search_paths = target.build_headers.search_paths(target.platform)
 
           config = {
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),

--- a/spec/unit/generator/xcconfig/private_pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/private_pod_xcconfig_spec.rb
@@ -42,11 +42,11 @@ module Pod
             @xcconfig.to_hash['PODS_ROOT'].should.not.nil?
           end
 
-          it 'adds the library build headers and public headers search paths to the xcconfig, with quotes' do
+          it 'adds the library build headers search paths to the xcconfig, with quotes' do
             private_headers = "\"#{@pod_target.build_headers.search_paths(:ios).join('" "')}\""
             public_headers = "\"#{config.sandbox.public_headers.search_paths(:ios).join('" "')}\""
             @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include private_headers
-            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include public_headers
+            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.not.include public_headers
           end
 
           it 'adds the COCOAPODS macro definition' do


### PR DESCRIPTION
The build headers are always given as a superset of the public headers. To build the target itself all headers are needed typically, not only the public headers. The public headers are needed for other targets (pod targets + user targets) depending on a target.

/c @neonichu 