### PR TITLE
Adding $(inherited) to "FRAMEWORK_SEARCH_PATHS" build setting in xcconfi...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Adding `$(inherited)` to `FRAMEWORK_SEARCH_PATHS` build setting in xcconfig for aggregate.
+  [Tomohiro Kumagai](https://github.com/EZ-NET)
+  [#3429](https://github.com/CocoaPods/CocoaPods/pull/3429)
+
 * Don't crash when the downloader can't find an appropriate podspec in a `git`
   pod.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -64,7 +64,7 @@ module Pod
               'OTHER_CFLAGS' => '$(inherited) ' + XCConfigHelper.quote(header_search_paths, '-iquote'),
             }
             if target.pod_targets.any?(&:should_build?)
-              build_settings['FRAMEWORK_SEARCH_PATHS'] = '"$PODS_FRAMEWORK_BUILD_PATH"'
+              build_settings['FRAMEWORK_SEARCH_PATHS'] = '$(inherited) "$PODS_FRAMEWORK_BUILD_PATH"'
             end
             config.merge!(build_settings)
           else

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -144,7 +144,7 @@ module Pod
           end
 
           it 'adds the framework build path to the xcconfig, with quotes, as framework search paths' do
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '"$PODS_FRAMEWORK_BUILD_PATH"'
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "$PODS_FRAMEWORK_BUILD_PATH"'
           end
 
           it 'adds the framework header paths to the xcconfig, with quotes, as local headers' do


### PR DESCRIPTION
When "FRAMEWORK_SEARCH_PATHS" was set in build settings for Project, this setting is inherited to build settings for Target.