### PR TITLE
[Executable] Use popen3 instead of open4 to execute commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Mason Glidden](https://github.com/mglidden)
   [#1154](https://github.com/CocoaPods/CocoaPods/issues/1154)
 
+* Handle subprocesses leaking STDOUT/STDERR pipes by more strictly managing
+  process lifetime and not allowing I/O to block completion of the task.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#3101](https://github.com/CocoaPods/CocoaPods/issues/3101)
+
+
 ## 0.37.0.beta.1
 
 ##### Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ PATH
       escape (~> 0.0.4)
       molinillo (~> 0.2.3)
       nap (~> 0.8)
-      open4 (~> 1.3)
       xcodeproj (~> 0.24.0)
 
 GEM
@@ -124,7 +123,6 @@ GEM
     nap (0.8.0)
     netrc (0.7.8)
     notify (0.5.2)
-    open4 (1.3.4)
     parser (2.2.0.3)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'colored',       '~> 1.2'
   s.add_runtime_dependency 'escape',        '~> 0.0.4'
-  s.add_runtime_dependency 'open4',         '~> 1.3'
   s.add_runtime_dependency 'activesupport', '>= 3.2.15'
   s.add_runtime_dependency 'nap',           '~> 0.8'
 

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -64,7 +64,7 @@ module Pod
       end
 
       status = popen3(bin, command, stdout, stderr)
-      output  = stdout.join("\n") + stderr.join("\n")
+      output = stdout.join("\n") + stderr.join("\n")
       unless status.success?
         if raise_on_failure
           raise Informative, "#{full_command}\n\n#{output}"

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -68,7 +68,7 @@ module Pod
         out_reader = Thread.new { while s = o.gets; stdout << s; end }
         err_reader = Thread.new { while s = e.gets; stderr << s; end }
         i.close
-        [out_reader, err_reader].each(&:join)
+        [out_reader, err_reader].each(&:run)
         t.value
       end
       output  = stdout.join("\n") + stderr.join("\n")

--- a/spec/unit/executable_spec.rb
+++ b/spec/unit/executable_spec.rb
@@ -16,7 +16,7 @@ module Pod
       result = mock
       result.stubs(:success?).returns(true)
 
-      Open4.expects(:spawn).with('/Spa ces/are"/fun/false', [], :stdout => [], :stderr => [], :status => true).once.returns(result)
+      Open3.expects(:popen3).with('/Spa ces/are"/fun/false').once.returns(result)
       Executable.execute_command(cmd, [], true)
     end
   end

--- a/spec/unit/executable_spec.rb
+++ b/spec/unit/executable_spec.rb
@@ -19,5 +19,15 @@ module Pod
       Open3.expects(:popen3).with('/Spa ces/are"/fun/false').once.returns(result)
       Executable.execute_command(cmd, [], true)
     end
+
+    it "doesn't hang when the spawned process forks a zombie process with the same STDOUT and STDERR" do
+      cmd = ['-e', <<-RB]
+        Process.fork { Process.daemon(nil, true); sleep(2) }
+        puts 'out'
+      RB
+      Timeout.timeout(1) do
+        Executable.execute_command('ruby', cmd, true).should == "out\n"
+      end
+    end
   end
 end


### PR DESCRIPTION
Potentially closes #3101.
It also gets rid of the `open4` dependency entirely, and isn't that many lines of code more.

\c @alloy @kylef 