### PR TITLE
Automatically lock Pod source files after installing (#1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3433](https://github.com/CocoaPods/CocoaPods/issues/3433)
 
+* Automatically lock Pod source files after installing.  
+  [Mason Glidden](https://github.com/mglidden)
+  [#1154](https://github.com/CocoaPods/CocoaPods/issues/1154)
 
 ## 0.37.0.beta.1
 

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -44,6 +44,7 @@ module Pod
       def install!
         download_source unless predownloaded? || local?
         run_prepare_command
+        lock_files!
       end
 
       # Cleans the installations if appropriate.
@@ -87,6 +88,25 @@ module Pod
           :released => released?,
           :head => head_pod?,
         )
+      end
+
+      # Locks all of the files in this pod (source, license, etc). This will
+      # cause Xcode to warn you if you try to accidently edit one of the files.
+      #
+      # @return [void]
+      #
+      def lock_files!
+        if local?
+          return
+        end
+
+        # We don't want to lock diretories, as that forces you to override
+        # those permissions if you decide to delete the Pods folder.
+        Dir.glob(root + '**/*').each do |file|
+          unless File.directory?(file)
+            File.chmod(0444, file)
+          end
+        end
       end
 
       extend Executable

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -132,6 +132,21 @@ module Pod
       end
 
       #--------------------------------------#
+
+      describe 'Locking' do
+        it 'locks the source files for each Pod' do
+          File.expects(:chmod).at_least_once
+          @installer.install!
+        end
+
+        it "doesn't lock local pods" do
+          @installer.stubs(:local?).returns(true)
+          File.expects(:chmod).never
+          @installer.install!
+        end
+      end
+
+      #--------------------------------------#
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
🌈

Seems like this should probably be the default behavior, instead of a plugin. When this gets released, I'll deprecate the plugin and put up a note saying that it's now built in.