### PR TITLE
[Config] Add environment variable COCOAPODS_SKIP_NEW_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3101](https://github.com/CocoaPods/CocoaPods/issues/3101)
 
+* Add environment variable `COCOAPODS_SKIP_NEW_VERSION` to disable new
+  version message
+  [Andrea Mazzini](https://github.com/andreamazz)
+  [#3364](https://github.com/CocoaPods/CocoaPods/issues/3364)
 
 ## 0.37.0.beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3101](https://github.com/CocoaPods/CocoaPods/issues/3101)
 
+
 ## 0.37.0.beta.1
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3101](https://github.com/CocoaPods/CocoaPods/issues/3101)
 
-* Add environment variable `COCOAPODS_SKIP_NEW_VERSION` to disable new
+* Add environment variable `COCOAPODS_SKIP_UPDATE_MESSAGE` to disable new
   version message
   [Andrea Mazzini](https://github.com/andreamazz)
   [#3364](https://github.com/CocoaPods/CocoaPods/issues/3364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Enhancements
+
+* Add environment variable `COCOAPODS_SKIP_UPDATE_MESSAGE` to disable new
+  version message.  
+  [Andrea Mazzini](https://github.com/andreamazz)
+  [#3364](https://github.com/CocoaPods/CocoaPods/issues/3364)
+
 ##### Bug Fixes
 
 * Don't crash when the downloader can't find an appropriate podspec in a `git`
@@ -21,11 +28,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   process lifetime and not allowing I/O to block completion of the task.  
   [Samuel Giddins](https://github.com/segiddins)
   [#3101](https://github.com/CocoaPods/CocoaPods/issues/3101)
-
-* Add environment variable `COCOAPODS_SKIP_UPDATE_MESSAGE` to disable new
-  version message
-  [Andrea Mazzini](https://github.com/andreamazz)
-  [#3364](https://github.com/CocoaPods/CocoaPods/issues/3364)
 
 ## 0.37.0.beta.1
 

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -19,7 +19,7 @@ module Pod
 
       :clean               => true,
       :integrate_targets   => true,
-      :new_version_message => !ENV['COCOAPODS_SKIP_NEW_VERSION'].nil?,
+      :new_version_message => ENV['COCOAPODS_SKIP_NEW_VERSION'].nil?,
 
       :cache_root          => Pathname.new(Dir.home) + 'Library/Caches/CocoaPods',
     }

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -19,7 +19,7 @@ module Pod
 
       :clean               => true,
       :integrate_targets   => true,
-      :new_version_message => true,
+      :new_version_message => !ENV['COCOAPODS_SKIP_NEW_VERSION'].nil?,
 
       :cache_root          => Pathname.new(Dir.home) + 'Library/Caches/CocoaPods',
     }

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -19,7 +19,7 @@ module Pod
 
       :clean               => true,
       :integrate_targets   => true,
-      :new_version_message => ENV['COCOAPODS_SKIP_NEW_VERSION'].nil?,
+      :new_version_message => ENV['COCOAPODS_SKIP_UPDATE_MESSAGE'].nil?,
 
       :cache_root          => Pathname.new(Dir.home) + 'Library/Caches/CocoaPods',
     }

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -268,6 +268,13 @@ module Pod
         UI.output.should.match /CocoaPods 999.0 is available/
       end
 
+      it 'skips the update message if the user disabled the notification' do
+        config.new_version_message = false
+        SourcesManager.stubs(:version_information).returns('last' => '999.0')
+        SourcesManager.check_version_information(temporary_directory)
+        UI.output.should.not.match /CocoaPods 999.0 is available/
+      end
+
       it 'raises while asked to version information of a source if it is not compatible' do
         SourcesManager.stubs(:version_information).returns('min' => '999.0')
         e = lambda { SourcesManager.check_version_information(temporary_directory) }.should.raise Informative


### PR DESCRIPTION
This adds `COCOAPODS_SKIP_NEW_VERSION` env var to skip the new version message, as mentioned in #3364 