### PR TITLE
No pod target if `source_files` only has headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3101](https://github.com/CocoaPods/CocoaPods/issues/3101)
 
+* Do not create pod target if `source_files` only contains headers.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3106](https://github.com/CocoaPods/CocoaPods/issues/3106)
+
 
 ## 0.37.0.beta.1
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -52,7 +52,9 @@ module Pod
     # A target should not be build if it has no source files.
     #
     def should_build?
-      !file_accessors.flat_map(&:source_files).empty?
+      source_files = file_accessors.flat_map(&:source_files)
+      source_files -= file_accessors.flat_map(&:headers)
+      !source_files.empty?
     end
 
     # @return [Array<Specification::Consumer>] the specification consumers for

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -63,6 +63,22 @@ module Pod
         end.message
         message.should.match /subspecs across different build configurations/
       end
+
+      it 'builds a pod target if there are actual source files' do
+        fa = Sandbox::FileAccessor.new(nil, @pod_target)
+        fa.stubs(:source_files).returns([Pathname.new('foo.m')])
+        @pod_target.stubs(:file_accessors).returns([fa])
+
+        @pod_target.should_build?.should == true
+      end
+
+      it 'does not build a pod target if there are only header files' do
+        fa = Sandbox::FileAccessor.new(nil, @pod_target)
+        fa.stubs(:source_files).returns([Pathname.new('foo.h')])
+        @pod_target.stubs(:file_accessors).returns([fa])
+
+        @pod_target.should_build?.should == false
+      end
     end
 
     describe 'Support files' do


### PR DESCRIPTION
This allows "fake" frameworks and static libraries to be linked directly against the user target, avoiding symbol reexport problems when integrating as frameworks. It also applies to integration as static libraries to reduce build times by not creating unnecessary targets.

Fixes #3106