### PR TITLE
[pod] Write the UTF-8 warning to stderr, rather than stdout.

### DIFF
--- a/bin/pod
+++ b/bin/pod
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 if Encoding.default_external != Encoding::UTF_8
-  puts <<-DOC
+  STDERR.puts <<-DOC
 \e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
 Consider adding the following to ~/.profile:
 


### PR DESCRIPTION
🌈
This means operations like:

   POD_VERSION="`pod --version`"

Work correctly even if LANG isn't set (e.g. within Jenkins).