### PR TITLE
[UI] Disambiguate gem and pod updates

### DIFF
--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -24,9 +24,9 @@ module Pod
       #
       def run
         if updates.empty?
-          UI.puts 'No updates are available.'.yellow
+          UI.puts 'No pod updates are available.'.yellow
         else
-          UI.section 'The following updates are available:' do
+          UI.section 'The following pod updates are available:' do
             updates.each do |(name, from_version, matching_version, to_version)|
               UI.puts "- #{name} #{from_version} -> #{matching_version} " \
                 "(latest version #{to_version})"


### PR DESCRIPTION
```bash
bundle exec pod outdated --project-directory=src
Updating spec repositories

CocoaPods 0.37.0.rc.2 is available.
To update use: `sudo gem install cocoapods --pre`
[!] This is a test version we'd love you to try.

For more information see http://blog.cocoapods.org
and the CHANGELOG for this version http://git.io/BaH8pQ.

No updates are available.
```

In this output, there is simultaneously an update available (CocoaPods gem) and no updates available (CocoaPods libraries). I've updated the latter message to "No pod updates are available." to hopefully disambiguate these states and clarify CocoaPods (gem) vs pod (libraries).