### PR TITLE
[Sandbox::FileAccessor] Add missing `.cc` extension for C++ to `SOURCE_FILE_EXTENSIONS`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#3440](https://github.com/CocoaPods/CocoaPods/issues/3440)
 
+* C++ source files with `.cc` extension now have their compiler flags set correctly.  
+  [Chongyu Zhu](https://github.com/lembacon)
+
 
 ## 0.37.0
 

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -8,7 +8,7 @@ module Pod
     #
     class FileAccessor
       HEADER_EXTENSIONS = Xcodeproj::Constants::HEADER_FILES_EXTENSIONS
-      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .c .cpp .swift) + HEADER_EXTENSIONS).uniq.freeze
+      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .c .cc .cpp .swift) + HEADER_EXTENSIONS).uniq.freeze
 
       GLOB_PATTERNS = {
         :readme              => 'readme{*,.*}'.freeze,

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -211,7 +211,7 @@ module Pod
           file_patterns = ['Classes/*.{h,m,d}', 'Vendor']
           options = {
             :exclude_patterns => ['Classes/**/osx/**/*', 'Resources/**/osx/**/*'],
-            :dir_pattern => '*{.m,.mm,.c,.cpp,.swift,.h,.hh,.hpp,.ipp,.tpp}',
+            :dir_pattern => '*{.m,.mm,.c,.cc,.cpp,.swift,.h,.hh,.hpp,.ipp,.tpp}',
             :include_dirs => false,
           }
           @spec.exclude_files = options[:exclude_patterns]


### PR DESCRIPTION
Some Pods may include C++ source files with `.cc` extension (for example, `Objective-LevelDB 2.1.0`).

Without this patch, `inhibit_all_warnings!` will lose its functionality on `.cc` files.