### PR TITLE
[Cache] Fix the cache to handle re-downloads properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* [Cache] Fixes a bug that caused that a pod, which was cached once is not updated
+  correctly when needed e.g. for `pod spec lint`.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#3498](https://github.com/CocoaPods/CocoaPods/issues/3498)
+
 * Only add the "Embed Pods Frameworks" script for application and unit test targets.  
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#3440](https://github.com/CocoaPods/CocoaPods/issues/3440)

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -184,6 +184,7 @@ module Pod
       def copy_and_clean(source, destination, spec)
         specs_by_platform = group_subspecs_by_platform(spec)
         destination.parent.mkpath
+        FileUtils.rm_rf(destination)
         FileUtils.cp_r(source, destination)
         Pod::Installer::PodSourcePreparer.new(spec, destination).prepare!
         Sandbox::PodDirCleaner.new(destination, specs_by_platform).clean!


### PR DESCRIPTION
If `destination` exists already, `source` is not copied directly `destination` but instead to `copy+source.basename`.