### PR TITLE
Flush stdin/stderr and wait a bit in `executable`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#3494](https://github.com/CocoaPods/CocoaPods/issues/3494)
   [Kyle Fuller](https://github.com/kylef)
 
+* Flush stdin/stderr and wait a bit in `executable`.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3500](https://github.com/CocoaPods/CocoaPods/issues/3500)
+
 
 ## 0.37.1
 

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -83,7 +83,13 @@ module Pod
         Thread.new { while s = o.gets; stdout << s; end }
         Thread.new { while s = e.gets; stderr << s; end }
         i.close
-        t.value
+        status = t.value
+
+        o.flush
+        e.flush
+        sleep(0.01)
+
+        status
       end
     end
 

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -87,7 +87,7 @@ module Pod
 
         o.flush
         e.flush
-        sleep(0.01)
+        sleep(0.1)
 
         status
       end

--- a/spec/unit/executable_spec.rb
+++ b/spec/unit/executable_spec.rb
@@ -22,10 +22,10 @@ module Pod
 
     it "doesn't hang when the spawned process forks a zombie process with the same STDOUT and STDERR" do
       cmd = ['-e', <<-RB]
-        Process.fork { Process.daemon(nil, true); sleep(2) }
+        Process.fork { Process.daemon(nil, true); sleep(4) }
         puts 'out'
       RB
-      Timeout.timeout(1) do
+      Timeout.timeout(2) do
         Executable.execute_command('ruby', cmd, true).should == "out\n"
       end
     end


### PR DESCRIPTION
This should make it unlikely that we don't catch the full output of
commands we are executing.