### PR TITLE
[Installer] Check for regular file on lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * C++ source files with `.cc` extension now have their compiler flags set correctly.  
   [Chongyu Zhu](https://github.com/lembacon)
 
+* Handle broken symlinks when installing a Pod.  
+  [Daniel Barden](https://github.com/dbarden)
+  [#3515](https://github.com/cocoapods/cocoapods/issues/3515)
 
 ## 0.37.0
 

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -103,7 +103,7 @@ module Pod
         # We don't want to lock diretories, as that forces you to override
         # those permissions if you decide to delete the Pods folder.
         Dir.glob(root + '**/*').each do |file|
-          unless File.directory?(file)
+          if File.file?(file)
             File.chmod(0444, file)
           end
         end


### PR DESCRIPTION
This patch check if a file is a regular file instead of checking if the file is a
directory.

It fixes a crash when the file being installed is a broken symbolic link.

I didn't know exactly where to put this modification in the changelog.

Let me know what you think.

------
### Command

```
/Users/dbarden/.gem/ruby/2.1.2/bin/pod install
```

### Report

* What did you do?
I ran into a pod file that contains a broken symbolic link and when trying to install the crash below happened

* What did you expect to happen?
That the dependency would be successfully installed

* What happened instead?
CocoaPods crashed with the log below

### Stack

```
   CocoaPods : 0.37.0
        Ruby : ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin14.0]
    RubyGems : 2.2.2
        Host : Mac OS X 10.10.3 (14D136)
       Xcode : 6.3.1 (6D1002)
         Git : git version 2.3.5
Ruby lib dir : /Users/dbarden/.rubies/ruby-2.1.2/lib
Repositories : artsy - https://github.com/artsy/Specs.git @ 0ac451b4b5ad3b6251c77663014b51a0048dde7e
               master - https://github.com/CocoaPods/Specs.git @ b69d5b43cefc22093bcdaa8d483dad68c2ed915f
               sponsorpay - git@github.com:SponsorPay/cocoapods-private.git @ 7607029fb79b1626ce430f7ec0c9ccb1e8612a64
```

### Plugins

```
cocoapods-dependencies : 0.4.0
cocoapods-plugins      : 0.4.2
cocoapods-trunk        : 0.6.0
cocoapods-try          : 0.4.3
```

### Podfile

```ruby
source 'https://github.com/CocoaPods/Specs.git'
source 'git@github.com:SponsorPay/cocoapods-private.git'

platform :ios, "6.0"
inhibit_all_warnings!

workspace 'SponsorPaySDK'

xcodeproj 'TestApp/SponsorPayTestApp.xcodeproj'
xcodeproj 'SponsorPaySDK/SponsorPaySDK.xcodeproj'


target "SponsorPayTestApp" do
  pod 'FyberAdapters', '~> 2.0.0'
  # just one specific adapter can be installed using
  # pod 'FyberAdapters/AdColony', '~> 2.0.0'


  pod 'CrashlyticsFramework', '~> 2.2.5.2'
  xcodeproj 'TestApp/SponsorPayTestApp.xcodeproj'
end

target "SponsorPayTestAppTests" do
  pod 'Specta', '~> 0.3.2'
  pod 'Expecta', '~> 0.3.2'
  pod 'OHHTTPStubs', '~> 3.1.0'
  pod 'OCMock', '~> 3.1.1'
  xcodeproj 'TestApp/SponsorPayTestApp.xcodeproj'
end

target "SponsorPaySDK Tests" do
  pod 'FBSnapshotTestCase', '~> 1.5'
  pod 'Specta', '~> 0.3.2'
  pod 'Expecta', '~> 0.3.2'
  pod 'Expecta+Snapshots', '~> 1.3.1'
  pod 'OHHTTPStubs', '~> 3.1.0'
  pod 'OCMock', '~> 3.1.1'
  pod 'Aspects', '~> 1.4.1'
  xcodeproj 'SponsorPaySDK/SponsorPaySDK.xcodeproj'
end

# Workaround for XCtest.h that isn't found on Xcode 6
post_install do |installer|
    targets = installer.project.targets.find_all { |t| t.to_s.start_with?  "Pods-" }
    targets.each do |target|
        target.build_configurations.each do |config|
            s = config.build_settings['FRAMEWORK_SEARCH_PATHS']
            s = [ '$(inherited)' ] if s == nil;
            s.push('$(PLATFORM_DIR)/Developer/Library/Frameworks')
            config.build_settings['FRAMEWORK_SEARCH_PATHS'] = s
        end
    end
end
```

### Error

```
Errno::ENOENT - No such file or directory @ chmod_internal - /Users/dbarden/projects/sponsorpay/sdk/Pods/FyberAdapters/Facebook/lib/FBAudienceNetwork.framework/Resources
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer/pod_source_installer.rb:109:in `chmod'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer/pod_source_installer.rb:109:in `block in lock_files!'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer/pod_source_installer.rb:106:in `each'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer/pod_source_installer.rb:106:in `lock_files!'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer/pod_source_installer.rb:48:in `install!'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:304:in `install_source_of_pod'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:279:in `block (2 levels) in install_pod_sources'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/user_interface.rb:70:in `titled_section'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:278:in `block in install_pod_sources'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:270:in `each'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:270:in `install_pod_sources'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:122:in `block in download_dependencies'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/user_interface.rb:49:in `section'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:120:in `download_dependencies'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/installer.rb:92:in `install!'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/command/project.rb:71:in `run_install_with_update'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/command/project.rb:101:in `run'
/Users/dbarden/.gem/ruby/2.1.2/gems/claide-0.8.1/lib/claide/command.rb:312:in `run'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/lib/cocoapods/command.rb:46:in `run'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.37.0/bin/pod:44:in `<top (required)>'
/Users/dbarden/.gem/ruby/2.1.2/bin/pod:23:in `load'
/Users/dbarden/.gem/ruby/2.1.2/bin/pod:23:in `<main>'
```