### PR TITLE
Tweak transitive deps check for working cases

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -366,7 +366,7 @@ module Pod
         aggregate_target.user_build_configurations.keys.each do |config|
           pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
 
-          dependencies = pod_targets.flat_map(&:dependencies)
+          dependencies = pod_targets.reject { |t| !t.should_build? }.flat_map(&:dependencies)
           dependended_upon_targets = pod_targets.select { |t| dependencies.include?(t.pod_name) && !t.should_build? }
 
           static_libs = dependended_upon_targets.flat_map(&:file_accessors).flat_map do |fa|

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -366,7 +366,7 @@ module Pod
         aggregate_target.user_build_configurations.keys.each do |config|
           pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
 
-          dependencies = pod_targets.reject { |t| !t.should_build? }.flat_map(&:dependencies)
+          dependencies = pod_targets.select(&:should_build?).flat_map(&:dependencies)
           dependended_upon_targets = pod_targets.select { |t| dependencies.include?(t.pod_name) && !t.should_build? }
 
           static_libs = dependended_upon_targets.flat_map(&:file_accessors).flat_map do |fa|

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -199,6 +199,13 @@ module Pod
         @installer = Installer.new(config.sandbox, @podfile, @lockfile)
         should.not.raise(Informative) { @installer.install! }
       end
+
+      it 'allows transitive static dependencies when both dependencies are linked against the user target' do
+        PodTarget.any_instance.stubs(:should_build? => false)
+        Sandbox::FileAccessor.any_instance.stubs(:vendored_libraries).returns([Pathname('/libThing.a')])
+        @installer = Installer.new(config.sandbox, @podfile, @lockfile)
+        should.not.raise(Informative) { @installer.install! }
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
If both the parent and the transitive dependency are linked directly to the user target (`should_build? == false` for both of them), we can let transitive static libraries pass as everything will work just fine.