### PR TITLE
[TargetIntegrator] Ensure to reset the contents of the Manifest.lock Script Phase

### DIFF
--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -209,9 +209,10 @@ module Pod
         def add_check_manifest_lock_script_phase
           phase_name = 'Check Pods Manifest.lock'
           native_targets_to_integrate.each do |native_target|
-            next if native_target.shell_script_build_phases.any? { |phase| phase.name == phase_name }
-            phase = native_target.project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
-            native_target.build_phases.unshift(phase)
+            phase = native_target.shell_script_build_phases.find { |phase| phase.name == phase_name }
+            phase ||= native_target.project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase).tap do |phase|
+              native_target.build_phases.unshift(phase)
+            end
             phase.name = phase_name
             phase.shell_script = <<-EOS.strip_heredoc
               diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null


### PR DESCRIPTION
I found that a while ago while reviewing the `TargetIntegrator`, but it staled locally.
Do we want to allow user changes to the script or ensure at this place that updates to the script are applied, if needed?
Meanwhile there is still a bigger issue, that existing targets are not re-integrated on changes to the integration process, which is to a certain extent blocked by CocoaPods/Xcodeproj#202.