### PR TITLE
Reject adding a source file twice in the compile source build phase 

### DIFF
--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -63,7 +63,10 @@ module Pod
           }.each do |arc, files|
             files = files - headers - other_source_files
             flags = compiler_flags_for_consumer(consumer, arc)
-            regular_file_refs = files.map { |sf| project.reference_for_path(sf) }
+            regular_file_refs = files.map { |sf| project.reference_for_path(sf) }.reject do | file_ref|
+              native_target.source_build_phase.include? file_ref
+            end
+
             native_target.add_file_references(regular_file_refs, flags)
           end
 


### PR DESCRIPTION
This happens to me when it has come in through two different subspecs. I think with static libs it would ignore this but with frameworks it's a different matter. 

Demoable by adding this to a podspec
```
pod 'ARAnalytics', :subspecs => ["Mixpanel", "HockeyApp", "DSL"]
```

Looking at tests etc now.