### PR TITLE
[Cache] Recognize incomplete cache for released pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Boris Bügling](https://github.com/neonichu)
   [#3600](https://github.com/CocoaPods/CocoaPods/issues/3600)
 
+* Recognizes incomplete cache when the original download of a pod was
+  interrupted.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#3561](https://github.com/CocoaPods/CocoaPods/issues/3561)
+
 * Allow opting out of pod source locking, meaning `pod try` yields editable
   projects.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -76,10 +76,10 @@ module Pod
       #         was found in the download cache.
       #
       def cached_pod(request)
+        cached_spec = cached_spec(request)
         path = path_for_pod(request)
-        spec_path = path_for_spec(request)
-        spec = request.spec || cached_spec(request)
-        return unless spec && path.directory? && spec_path.file?
+        return unless cached_spec && path.directory?
+        spec = request.spec || cached_spec
         Response.new(path, spec, request.params)
       end
 
@@ -92,6 +92,8 @@ module Pod
       def cached_spec(request)
         path = path_for_spec(request)
         path.file? && Specification.from_file(path)
+      rescue JSON::ParserError
+        nil
       end
 
       # @param  [Request] request

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -77,8 +77,9 @@ module Pod
       #
       def cached_pod(request)
         path = path_for_pod(request)
+        spec_path = path_for_spec(request)
         spec = request.spec || cached_spec(request)
-        return unless spec && path.directory?
+        return unless spec && path.directory? && spec_path.file?
         Response.new(path, spec, request.params)
       end
 

--- a/spec/unit/downloader/cache_spec.rb
+++ b/spec/unit/downloader/cache_spec.rb
@@ -75,6 +75,24 @@ module Pod
     end
 
     describe 'when the cache is incomplete' do
+      shared 'it falls back to download the pod' do
+        describe 'when downloading a released pod' do
+          it 'does download the source' do
+            Downloader::Git.any_instance.expects(:download).never
+            @cache.expects(:uncached_pod).once
+            @cache.download_pod(@request)
+          end
+        end
+
+        describe 'when downloading an unreleased pod' do
+          it 'does download the source' do
+            Downloader::Git.any_instance.expects(:download).never
+            @cache.expects(:uncached_pod).once
+            @cache.download_pod(@unreleased_request)
+          end
+        end
+      end
+
       before do
         [@request, @unreleased_request].each do |request|
           path_for_pod = @cache.send(:path_for_pod, request)
@@ -86,20 +104,20 @@ module Pod
         end
       end
 
-      describe 'when downloading a released pod' do
-        it 'does download the source' do
-          Downloader::Git.any_instance.expects(:download).never
-          @cache.expects(:uncached_pod).once
-          @cache.download_pod(@request)
-        end
+      describe 'because the spec is missing' do
+        behaves_like 'it falls back to download the pod'
       end
 
-      describe 'when downloading an unreleased pod' do
-        it 'does download the source' do
-          Downloader::Git.any_instance.expects(:download).never
-          @cache.expects(:uncached_pod).once
-          @cache.download_pod(@unreleased_request)
+      describe 'because the spec is invalid' do
+        before do
+          [@request, @unreleased_request].each do |request|
+            path_for_spec = @cache.send(:path_for_spec, request)
+            path_for_spec.dirname.mkpath
+            path_for_spec.open('w') { |f| f << '{' }
+          end
         end
+
+        behaves_like 'it falls back to download the pod'
       end
     end
 

--- a/spec/unit/downloader/cache_spec.rb
+++ b/spec/unit/downloader/cache_spec.rb
@@ -74,6 +74,35 @@ module Pod
       end
     end
 
+    describe 'when the cache is incomplete' do
+      before do
+        [@request, @unreleased_request].each do |request|
+          path_for_pod = @cache.send(:path_for_pod, request)
+          path_for_pod.mkpath
+          Dir.chdir(path_for_pod) do
+            FileUtils.mkdir_p 'Classes'
+            File.open('Classes/a.m', 'w') {}
+          end
+        end
+      end
+
+      describe 'when downloading a released pod' do
+        it 'does download the source' do
+          Downloader::Git.any_instance.expects(:download).never
+          @cache.expects(:uncached_pod).once
+          @cache.download_pod(@request)
+        end
+      end
+
+      describe 'when downloading an unreleased pod' do
+        it 'does download the source' do
+          Downloader::Git.any_instance.expects(:download).never
+          @cache.expects(:uncached_pod).once
+          @cache.download_pod(@unreleased_request)
+        end
+      end
+    end
+
     describe 'when the download is cached' do
       before do
         [@request, @unreleased_request].each do |request|


### PR DESCRIPTION
If the execution of `pod install` is interrupted, this could happen while the cache is being prepared or files are copied. That a pod is already downloaded was indicated before just by the existence of the file directory. With this PR, the cache is valid first, if the podspec is also present in the cache, regardless whether a podspec is associated with the request or not. That has the advantage that the podspec is written to the cache in the last phase of the download and this process is in comparison "more atomic".

/c @segiddins 