### PR TITLE
Shares schemes of any development pods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Schemes of development pods will now be shared.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3600](https://github.com/CocoaPods/CocoaPods/issues/3600)
+
 * Allow opting out of pod source locking, meaning `pod try` yields editable
   projects.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -136,6 +136,7 @@ module Pod
         set_target_dependencies
         run_podfile_post_install_hooks
         write_pod_project
+        share_development_pod_schemes
         write_lockfiles
       end
     end
@@ -601,6 +602,20 @@ module Pod
         pods_project.sort(:groups_position => :below)
         pods_project.recreate_user_schemes(false)
         pods_project.save
+      end
+    end
+
+    # Shares schemes of development Pods.
+    #
+    # @return [void]
+    #
+    def share_development_pod_schemes
+      development_pod_targets = sandbox.development_pods.keys.map do |pod|
+        pods_project.targets.select { |target| target.name =~ /^Pods-.*-#{pod}$/ }
+      end.flatten
+
+      development_pod_targets.each do |pod_target|
+        Xcodeproj::XCScheme.share_scheme(pods_project.path, pod_target.name, ENV['USER'])
       end
     end
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -615,7 +615,7 @@ module Pod
       end.flatten
 
       development_pod_targets.each do |pod_target|
-        Xcodeproj::XCScheme.share_scheme(pods_project.path, pod_target.name, ENV['USER'])
+        Xcodeproj::XCScheme.share_scheme(pods_project.path, pod_target.name)
       end
     end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -590,6 +590,22 @@ module Pod
           @installer.send(:write_pod_project)
         end
 
+        it 'shares schemes of development pods' do
+          spec = fixture_spec('banana-lib/BananaLib.podspec')
+          target_definition = Podfile::TargetDefinition.new(:default, @installer.podfile)
+          pod_target = PodTarget.new([spec], target_definition, config.sandbox)
+
+          @installer.pods_project.stubs(:targets).returns([pod_target])
+          @installer.sandbox.stubs(:development_pods).returns('BananaLib' => nil)
+
+          Xcodeproj::XCScheme.expects(:share_scheme).with(
+            @installer.pods_project.path,
+            'Pods-default-BananaLib',
+            ENV['USER'])
+
+          @installer.send(:share_development_pod_schemes)
+        end
+
         it "uses the user project's object version for the pods project" do
           tmp_directory = Pathname(Dir.tmpdir) + 'CocoaPods'
           FileUtils.mkdir_p(tmp_directory)

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -600,8 +600,7 @@ module Pod
 
           Xcodeproj::XCScheme.expects(:share_scheme).with(
             @installer.pods_project.path,
-            'Pods-default-BananaLib',
-            ENV['USER'])
+            'Pods-default-BananaLib')
 
           @installer.send(:share_development_pod_schemes)
         end


### PR DESCRIPTION
This makes it easier to individually build the product of a development pod from a checked-in project, e.g. when using the pod-template, allowing for improved sharing with non-CocoaPods users.