### PR TITLE
Move source locking to installer, only lock source files (#3529, #3557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#3842](https://github.com/CocoaPods/CocoaPods/issues/3842)
   [Samuel Giddins](https://github.com/segiddins)
 
+* Don't lock resource files, only source files.  
+  [Mason Glidden](https://github.com/mglidden).
+  [#3557](https://github.com/CocoaPods/CocoaPods/issues/3557)
 
 ## 0.38.0
 
@@ -141,10 +144,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   as-is to the `configure` scripts.  
   [Samuel Giddins](https://github.com/segiddins)
   [#2160](https://github.com/CocoaPods/CocoaPods/issues/2160)
-  
-* Unlock source files before running hooks and lock them after.  
-  [Mason Glidden](https://github.com/mglidden).
-  [#3529](https://github.com/CocoaPods/CocoaPods/issues/3529)
 
 * Use `-analyzer-disable-all-checks` to disable static analyzer for
   pods with `inhibit_warnings` enabled (requires Xcode >= 6.1).  
@@ -181,10 +180,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   the sandbox. That allows transitive inclusion of headers from other pods.  
   [Vincent Isambart](https://github.com/vincentisambart)
   [#3161](https://github.com/CocoaPods/CocoaPods/issues/3161)
-  
-* Don't lock resource files, only source files.  
-  [Mason Glidden](https://github.com/mglidden).
-  [#3557](https://github.com/CocoaPods/CocoaPods/issues/3557)
 
 * Fixes an issue that prevented static libraries from building. `OTHER_LIBTOOLFLAGS`
   is no longer set to the value of `OTHER_LDFLAGS`. If you want to create a static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   as-is to the `configure` scripts.  
   [Samuel Giddins](https://github.com/segiddins)
   [#2160](https://github.com/CocoaPods/CocoaPods/issues/2160)
+  
+* Unlock source files before running hooks and lock them after.  
+  [Mason Glidden](https://github.com/mglidden).
+  [#3529](https://github.com/CocoaPods/CocoaPods/issues/3529)
 
 * Use `-analyzer-disable-all-checks` to disable static analyzer for
   pods with `inhibit_warnings` enabled (requires Xcode >= 6.1).  
@@ -177,6 +181,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   the sandbox. That allows transitive inclusion of headers from other pods.  
   [Vincent Isambart](https://github.com/vincentisambart)
   [#3161](https://github.com/CocoaPods/CocoaPods/issues/3161)
+  
+* Don't lock resource files, only source files.  
+  [Mason Glidden](https://github.com/mglidden).
+  [#3557](https://github.com/CocoaPods/CocoaPods/issues/3557)
 
 * Fixes an issue that prevented static libraries from building. `OTHER_LIBTOOLFLAGS`
   is no longer set to the value of `OTHER_LDFLAGS`. If you want to create a static

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -109,6 +109,7 @@ module Pod
       generate_pods_project
       integrate_user_project if config.integrate_targets?
       perform_post_install_actions
+      lock_source_files
     end
 
     def prepare
@@ -139,9 +140,9 @@ module Pod
       UI.section 'Downloading dependencies' do
         create_file_accessors
         install_pod_sources
+        unlock_source_files
         run_podfile_pre_install_hooks
         clean_pod_sources
-        lock_pod_sources
       end
     end
 
@@ -337,16 +338,6 @@ module Pod
       return unless config.clean?
       return unless @pod_installers
       @pod_installers.each(&:clean!)
-    end
-
-    # Locks the sources of the Pods if the config instructs to do so.
-    #
-    # @todo Why the @pod_installers might be empty?
-    #
-    def lock_pod_sources
-      return unless config.lock_pod_source?
-      return unless @pod_installers
-      @pod_installers.each(&:lock_files!)
     end
 
     # Determines if the dependencies need to be built as dynamic frameworks or
@@ -761,6 +752,44 @@ module Pod
       raise Informative, 'An error occurred while processing the post-install ' \
         'hook of the Podfile.' \
         "\n\n#{e.message}\n\n#{e.backtrace * "\n"}"
+    end
+
+    # Locks all of the source files in the pod. This will cause Xcode
+    # to warn you if you try to accidently edit one of the files.
+    #
+    # @return [void]
+    #
+    def lock_source_files
+      non_local_source_files do |file|
+        new_permissions = File.stat(file).mode & ~0222
+        File.chmod(new_permissions, file)
+      end
+    end
+
+    # Unlocks all of the source files in this pod, so hooks can
+    # modify them.
+    #
+    # @return [void]
+    #
+    def unlock_source_files
+      non_local_source_files do |file|
+        new_permissions = File.stat(file).mode | 0222
+        File.chmod(new_permissions, file)
+      end
+    end
+
+    def non_local_source_files
+      installer = installer_rep
+      installer.pods.each do |pod|
+        # if the pod is actually in Pods/, and not a :path linked pod
+        if pod.root.parent == installer.sandbox_root
+          pod.source_files.each do |file|
+            if File.file?(file)
+              yield(file)
+            end
+          end
+        end
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -59,17 +59,6 @@ module Pod
         clean_installation unless local?
       end
 
-      # Locks the source files if appropriate.
-      #
-      # @todo   As the pre install hooks need to run before cleaning this
-      #         method should be refactored.
-      #
-      # @return [void]
-      #
-      def lock_files!
-        lock_installation unless local?
-      end
-
       # @return [Hash] @see Downloader#checkout_options
       #
       attr_reader :specific_source
@@ -100,24 +89,6 @@ module Pod
           :released => released?,
           :head => head_pod?,
         )
-      end
-
-      # Locks all of the files in this pod (source, license, etc). This will
-      # cause Xcode to warn you if you try to accidently edit one of the files.
-      #
-      # @return [void]
-      #
-      def lock_installation
-        # We don't want to lock diretories, as that forces you to override
-        # those permissions if you decide to delete the Pods folder.
-        Dir.glob(root + '**/*').each do |file|
-          if File.file?(file)
-            # Only remove write permission, since some pods (like Crashlytics)
-            # have executable files.
-            new_permissions = File.stat(file).mode & ~0222
-            File.chmod(new_permissions, file)
-          end
-        end
       end
 
       # Removes all the files not needed for the installation according to the

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -132,23 +132,6 @@ module Pod
       end
 
       #--------------------------------------#
-
-      describe 'Locking' do
-        it 'locks the source files for each Pod' do
-          File.expects(:chmod).at_least_once
-          @installer.install!
-          @installer.lock_files!
-        end
-
-        it "doesn't lock local pods" do
-          @installer.stubs(:local?).returns(true)
-          File.expects(:chmod).never
-          @installer.install!
-          @installer.lock_files!
-        end
-      end
-
-      #--------------------------------------#
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -60,8 +60,6 @@ module Pod
         @installer.stubs(:run_plugins_post_install_hooks)
         @installer.stubs(:ensure_plugins_are_installed!)
         @installer.stubs(:perform_post_install_actions)
-        @installer.stubs(:lock_source_files)
-        @installer.stubs(:unlock_source_files)
       end
 
       it 'in runs the pre-install hooks before cleaning the Pod sources' do
@@ -770,17 +768,6 @@ module Pod
 
       it 'runs the post install hooks' do
         @installer.podfile.expects(:post_install!).with(@installer)
-        @installer.install!
-      end
-
-      it 'locks the sources files after running the hooks' do
-        locking = sequence('locking')
-
-        @installer.expects(:unlock_source_files).in_sequence(locking)
-        @installer.expects(:run_podfile_pre_install_hooks).in_sequence(locking)
-        @installer.expects(:run_plugins_post_install_hooks).in_sequence(locking)
-        @installer.expects(:lock_source_files).in_sequence(locking)
-
         @installer.install!
       end
     end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -60,6 +60,8 @@ module Pod
         @installer.stubs(:run_plugins_post_install_hooks)
         @installer.stubs(:ensure_plugins_are_installed!)
         @installer.stubs(:perform_post_install_actions)
+        @installer.stubs(:lock_source_files)
+        @installer.stubs(:unlock_source_files)
       end
 
       it 'in runs the pre-install hooks before cleaning the Pod sources' do
@@ -768,6 +770,17 @@ module Pod
 
       it 'runs the post install hooks' do
         @installer.podfile.expects(:post_install!).with(@installer)
+        @installer.install!
+      end
+
+      it 'locks the sources files after running the hooks' do
+        locking = sequence('locking')
+
+        @installer.expects(:unlock_source_files).in_sequence(locking)
+        @installer.expects(:run_podfile_pre_install_hooks).in_sequence(locking)
+        @installer.expects(:run_plugins_post_install_hooks).in_sequence(locking)
+        @installer.expects(:lock_source_files).in_sequence(locking)
+
         @installer.install!
       end
     end


### PR DESCRIPTION
Fixes #3557 by only locking source files. I couldn't figure out how to get to the source files from the Pod::Installer::PodSourceInstaller, so I had to move it to Pod::Installer. 

I also unlocked the source files before hooks run, which fixes #3529.