### PR TITLE
bugfix for pods containing swift frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Vincent Isambart](https://github.com/vincentisambart)
   [#3161](https://github.com/CocoaPods/CocoaPods/issues/3161)
 
+* Added a fix for a bug where some Pods containing Swift frameworks were not
+  being written to the expected directory. Alamofire seems to be a victim in many
+  circumstances. This is a temporary fix, and will be
+  removed when [#3550](https://github.com/CocoaPods/CocoaPods/pull/3550) is merged in.
+  [Tim Rosenblatt](https://github.com/timrosenblatt)
+
 
 ## 0.37.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Added a fix for a bug where some Pods containing Swift frameworks were not
   being written to the expected directory. Alamofire seems to be a victim in many
-  circumstances. This is a temporary fix, and will be
-  removed when [#3550](https://github.com/CocoaPods/CocoaPods/pull/3550) is merged in.
+  circumstances.
   [Tim Rosenblatt](https://github.com/timrosenblatt)
+  [#3675](https://github.com/CocoaPods/CocoaPods/pull/3675)
 
 
 ## 0.37.2

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -54,7 +54,12 @@ module Pod
 
           install_framework()
           {
-            local source="${BUILT_PRODUCTS_DIR}/#{target_definition.label}/$1"
+            if [ -r "${BUILT_PRODUCTS_DIR}/#{target_definition.label}/$1" ]; then
+              local source="${BUILT_PRODUCTS_DIR}/#{target_definition.label}/$1"
+            else
+              local source="${BUILT_PRODUCTS_DIR}/$1"
+            fi
+
             local destination="${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 
             if [ -L "${source}" ]; then


### PR DESCRIPTION
🌈

This a bugfix for an issue that seems to come up when running builds from the command line (although not from Xcode UI?). I work at Ship.io and we see this issue come up in a bunch of customer builds. I've also seen it reported by many other users. 

The issue manifests as an rsync error 23 during the Embed Pods Frameworks phase. For some reason, the target_definition.label seems to be blank, and it results in the framework being placed up a directory.

I'm not 100% sure of the root cause. I arrived at this fix thanks to some other posters who have posted about the issue. I've patched our local copies of the gem and have validated that this does solve the problem.

I've looked at #3550 and when it is merged in, it will overwrite this fix, and will also solve the root cause.

Old copies of the generated shell script may need to be fixed manually. This can be done by basically copy and pasting this fix into place, and manually replacing the variable. This fix does solve the issue as new Pods are installed.

I'd like to thank my company, [Ship.io](https://ship.io) for sponsoring this fix. They let me spend a bunch of time researching this at the company's expense, and gave me permission to share it back with the community. Also, they make a pretty darn good hosted CI system for iOS. :)
