### PR TITLE
Cache globbing in PathList to speed up pod install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dieter Komendera](https://github.com/kommen)
   [#2402](https://github.com/CocoaPods/CocoaPods/issues/2402)
 
+* Cache globbing in `PathList` to speed up `pod install`.
+  [Vincent Isambart](https://github.com/vincentisambart)
+
 ##### Bug Fixes
 
 * Added recursive support to the public headers of vendored frameworks

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -39,7 +39,6 @@ module Pod
           @path_list = PathList.new(path_list)
         end
         @spec_consumer = spec_consumer
-        @paths_for_attribute = { false => {}, true => {} }
 
         unless @spec_consumer
           raise Informative, 'Attempt to initialize File Accessor without a specification consumer.'
@@ -277,14 +276,13 @@ module Pod
       # @return [Array<Pathname>] the paths.
       #
       def paths_for_attribute(attribute, include_dirs = false)
-        return @paths_for_attribute[include_dirs][attribute] if @paths_for_attribute[include_dirs][attribute]
         file_patterns = spec_consumer.send(attribute)
         options = {
           :exclude_patterns => spec_consumer.exclude_files,
           :dir_pattern => GLOB_PATTERNS[attribute],
           :include_dirs => include_dirs,
         }
-        @paths_for_attribute[include_dirs][attribute] = expanded_paths(file_patterns, options)
+        expanded_paths(file_patterns, options)
       end
 
       # Matches the given patterns to the file present in the root of the path

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -39,6 +39,7 @@ module Pod
           @path_list = PathList.new(path_list)
         end
         @spec_consumer = spec_consumer
+        @paths_for_attribute = { false => {}, true => {} }
 
         unless @spec_consumer
           raise Informative, 'Attempt to initialize File Accessor without a specification consumer.'
@@ -276,13 +277,14 @@ module Pod
       # @return [Array<Pathname>] the paths.
       #
       def paths_for_attribute(attribute, include_dirs = false)
+        return @paths_for_attribute[include_dirs][attribute] if @paths_for_attribute[include_dirs][attribute]
         file_patterns = spec_consumer.send(attribute)
         options = {
           :exclude_patterns => spec_consumer.exclude_files,
           :dir_pattern => GLOB_PATTERNS[attribute],
           :include_dirs => include_dirs,
         }
-        expanded_paths(file_patterns, options)
+        @paths_for_attribute[include_dirs][attribute] = expanded_paths(file_patterns, options)
       end
 
       # Matches the given patterns to the file present in the root of the path


### PR DESCRIPTION
I'm not sure if caching paths_for_attribute is wise or not, but in my test it makes `pod install` on our app much faster: 140 sec → 20 sec. All specs still pass.

It might be problematic if the content on the file system changes during the run, that's why it's more of an experiment that anything else.

What do you think?

