### PR TITLE
WIP: Fix bitcode issues due to weak linking

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -602,13 +602,17 @@ module Pod
 
           unless pod_target.should_build?
             pod_target.resource_bundle_targets.each do |resource_bundle_target|
-              aggregate_target.native_target.add_dependency(resource_bundle_target)
+              unless aggregate_target.requires_frameworks?
+                aggregate_target.native_target.add_dependency(resource_bundle_target)
+              end
             end
 
             next
           end
 
-          aggregate_target.native_target.add_dependency(pod_target.native_target)
+          unless aggregate_target.requires_frameworks?
+            aggregate_target.native_target.add_dependency(pod_target.native_target)
+          end
           configure_app_extension_api_only_for_target(pod_target) if is_app_extension
 
           pod_target.dependencies.each do |dep|


### PR DESCRIPTION
This changes the `use_frameworks!` integration so that we directly link to the concrete pod frameworks, without having an aggregate framework in between. Currently, the aggregate targets are still installed, e.g. because of their XCConfigs. Ideally, the aggregate targets wouldn't exist at all.

What's missing:

- [ ] Changelog
- [ ] Update integration specs
- [ ] Create dedicated specs for this change?
- [ ] Evaluate how feasible it is to get rid of running the `AggregateTargetInstaller` at all
- [ ] Enable bitcode by default for pod targets, to match Xcode 7 behaviour