### PR TITLE
[Installer] Add support for source provider plugin hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   is now a default plugin.  
   [Samuel Giddins](https://github.com/segiddins)
 
-* Added a `:source_provider` hook to allow plugins to provide their own sources
-  [Eric Amorde](https://github.com/amorde)
-  [#3792](https://github.com/CocoaPods/CocoaPods/pull/3792)
-
 ##### Bug Fixes
 
 * Ensure that the `prepare_command` is run even when skipping the download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   is now a default plugin.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Added a `:source_provider` hook to allow plugins to provide their own sources
+  [Eric Amorde](https://github.com/amorde)
+  [#3792](https://github.com/CocoaPods/CocoaPods/pull/3792)
+
 ##### Bug Fixes
 
 * Ensure that the `prepare_command` is run even when skipping the download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3926](https://github.com/CocoaPods/CocoaPods/issues/3926)
 
+* Add `:source_provider` hook to allow plugins to provide sources
+  [Eric Amorde](https://github.com/amorde)
+  [#3190](https://github.com/CocoaPods/CocoaPods/issues/3190)
+  [#3792](https://github.com/CocoaPods/CocoaPods/pull/3792)
+
 
 ## 0.38.2
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -127,7 +127,7 @@ module Pod
       analyzer = create_analyzer
 
       plugin_sources = run_source_provider_hooks
-      analyzer.sources.push(*plugin_sources)
+      analyzer.sources.insert(0, *plugin_sources)
 
       UI.section 'Updating local specs repositories' do
         analyzer.update_repositories

--- a/lib/cocoapods/installer/source_provider_hooks_context.rb
+++ b/lib/cocoapods/installer/source_provider_hooks_context.rb
@@ -1,0 +1,32 @@
+module Pod
+  class Installer
+    # Context object designed to be used with the HooksManager which describes
+    # the context of the installer before spec sources have been created
+    #
+    class SourceProviderHooksContext
+      # @return [Array<Source>] The source objects to send to the installer
+      #
+      attr_reader :sources
+
+      # @return [SourceProviderHooksContext] Convenience class method to generate the
+      #         static context.
+      #
+      def self.generate
+        result = new
+        result
+      end
+
+      def initialize
+        @sources = []
+      end
+
+      # @param [Source] Source object to be added to the installer
+      #
+      def add_source(source)
+        unless source.nil?
+          @sources << source
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/installer/source_provider_hooks_context_spec.rb
+++ b/spec/unit/installer/source_provider_hooks_context_spec.rb
@@ -1,0 +1,12 @@
+
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  describe Installer::SourceProviderHooksContext do
+    it 'offers a convenience method to be generated' do
+      result = Installer::SourceProviderHooksContext.generate
+      result.class.should == Installer::SourceProviderHooksContext
+      result.sources.should == []
+    end
+  end
+end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -93,6 +93,51 @@ module Pod
         @installer.install!
       end
 
+      it 'runs source provider hooks before analyzing' do
+        config.skip_repo_update = true
+        @installer.unstub(:resolve_dependencies)
+        @installer.stubs(:validate_build_configurations)
+        @installer.stubs(:prepare_for_legacy_compatibility)
+        @installer.stubs(:clean_sandbox)
+        def @installer.run_source_provider_hooks
+          @hook_called = true
+        end
+        def @installer.analyze(*)
+          @hook_called.should.be.true
+        end
+        @installer.install!
+      end
+
+      it 'includes sources from source provider plugins' do
+        plugin_name = 'test-plugin'
+        Pod::HooksManager.register(plugin_name, :source_provider) do |context, options|
+          source_url = options['sources'].first
+          return unless source_url
+          source = Pod::Source.new(source_url)
+          context.add_source(source)
+        end
+
+        test_source_name = 'https://github.com/artsy/Specs.git'
+        plugins_hash = Installer::DEFAULT_PLUGINS.merge(plugin_name => { 'sources' => [test_source_name] })
+        @installer.podfile.stubs(:plugins).returns(plugins_hash)
+        @installer.unstub(:resolve_dependencies)
+        @installer.stubs(:validate_build_configurations)
+        @installer.stubs(:prepare_for_legacy_compatibility)
+        @installer.stubs(:clean_sandbox)
+        @installer.stubs(:ensure_plugins_are_installed!)
+        @installer.stubs(:analyze)
+        config.skip_repo_update = true
+
+        analyzer = Installer::Analyzer.new(config.sandbox, @installer.podfile, @installer.lockfile)
+        analyzer.stubs(:analyze)
+        @installer.stubs(:create_analyzer).returns(analyzer)
+        @installer.install!
+
+        source = Pod::Source.new(test_source_name)
+        names = analyzer.sources.map(&:name)
+        names.should.include(source.name)
+      end
+
       it 'integrates the user targets if the corresponding config is set' do
         config.integrate_targets = true
         @installer.expects(:integrate_user_project)
@@ -724,6 +769,14 @@ module Pod
         Installer::PostInstallHooksContext.expects(:generate).returns(context)
         HooksManager.expects(:run).with(:post_install, context, Installer::DEFAULT_PLUGINS)
         @installer.send(:run_plugins_post_install_hooks)
+      end
+
+      it 'runs plugins source provider hook' do
+        context = stub
+        context.stubs(:sources).returns([])
+        Installer::SourceProviderHooksContext.expects(:generate).returns(context)
+        HooksManager.expects(:run).with(:source_provider, context, Installer::DEFAULT_PLUGINS)
+        @installer.send(:run_source_provider_hooks)
       end
 
       it 'only runs the podfile-specified hooks' do


### PR DESCRIPTION
This PR provides an initial/example implementation for the source provider plugin api described in #3190

I very much welcome suggestions for improvements - still new to both Ruby and the CocoaPods code base so it is very likely I am missing something.

The API would allow plugins to supply their own sources, whether they be un-versioned or using an unsupported VCS such as CVS, Hg, SVN, etc.

Example:

```ruby
# in a Podfile
plugin 'cocoapods-repo-svn', {
    :sources => [
        'https://svn.myrepository.com'
    ]
}

# Now in the plugin's cocoapods_plugin.rb file:
Pod::HooksManager.register('cocoapods-repo-svn', :source_provider) do |context, options|
    # options contains the hash defined in the Podfile
    source_names = options['sources']
    source_names.each do |name|
        source = MyCustomCreateSourceFunction(name)
        # Add any number of Pod::Source objects to the context
        context.add_source(source)
    end
end
```
