### PR TITLE
Add modules support for static libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add modules support for static libraries.  
+  [Tomas Linhart](https://github.com/TomasLinhart)
+
 * The resolver will now take supported platform deployment targets into account
   when resolving dependencies.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -42,8 +42,9 @@ module Pod
       # @return [String]
       #
       def generate
+        header = target.requires_frameworks? ? "framework module" : "module"
         result = <<-eos.strip_heredoc
-          framework module #{target.product_module_name} {
+          #{header} #{target.product_module_name} {
             umbrella header "#{target.umbrella_header_path.basename}"
 
             export *

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -42,9 +42,9 @@ module Pod
       # @return [String]
       #
       def generate
-        header = target.requires_frameworks? ? "framework module" : "module"
+        module_declaration_qualifier = target.requires_frameworks? ? "framework " : ""
         result = <<-eos.strip_heredoc
-          #{header} #{target.product_module_name} {
+          #{module_declaration_qualifier}module #{target.product_module_name} {
             umbrella header "#{target.umbrella_header_path.basename}"
 
             export *

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -71,17 +71,8 @@ module Pod
       # @return [Array<Pathname>]
       #
       def add_files(namespace, relative_header_paths, platform)
-        add_search_path(namespace, platform)
-        namespaced_path = root + namespace
-        namespaced_path.mkpath unless File.exist?(namespaced_path)
-
         relative_header_paths.map do |relative_header_path|
-          absolute_source = (sandbox.root + relative_header_path)
-          source = absolute_source.relative_path_from(namespaced_path)
-          Dir.chdir(namespaced_path) do
-            FileUtils.ln_sf(source, relative_header_path.basename)
-          end
-          namespaced_path + relative_header_path.basename
+          add_file(namespace, relative_header_path, relative_header_path.basename, platform)
         end
       end
 

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -85,6 +85,37 @@ module Pod
         end
       end
 
+      # Adds a header to the directory under different name.
+      #
+      # @param  [Pathname] namespace
+      #         the path where the header file should be stored relative to the
+      #         headers directory.
+      #
+      # @param  [Pathname] relative_header_path
+      #         the path of the header file relative to the Pods project
+      #         (`PODS_ROOT` variable of the xcconfigs).
+      #
+      # @param  [String] final_name
+      #         the name under which the file should be available in the
+      #         headers directory.
+      #
+      # @note   This method adds the file to the search paths.
+      #
+      # @return [Pathname]
+      #
+      def add_file(namespace, relative_header_path, final_name, platform)
+        add_search_path(namespace, platform)
+        namespaced_path = root + namespace
+        namespaced_path.mkpath unless File.exist?(namespaced_path)
+
+        absolute_source = (sandbox.root + relative_header_path)
+        source = absolute_source.relative_path_from(namespaced_path)
+        Dir.chdir(namespaced_path) do
+          FileUtils.ln_sf(source, final_name)
+        end
+        namespaced_path + relative_header_path.basename
+      end
+
       # Adds an header search path to the sandbox.
       #
       # @param  [Pathname] path

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -9,8 +9,9 @@ module Pod
       @gen = Generator::ModuleMap.new(@pod_target)
     end
 
-    it 'writes the module map to the disk' do
+    it 'writes the framework module map to the disk' do
       path = temporary_directory + 'BananaLib.modulemap'
+      @pod_target.stubs(:requires_frameworks? => true)
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
         framework module BananaLib {
@@ -22,8 +23,23 @@ module Pod
       EOS
     end
 
+    it 'writes the module map to the disk' do
+      path = temporary_directory + 'BananaLib.modulemap'
+      @pod_target.stubs(:requires_frameworks? => false)
+      @gen.save_as(path)
+      path.read.should == <<-EOS.strip_heredoc
+        module BananaLib {
+          umbrella header "BananaLib-umbrella.h"
+
+          export *
+          module * { export * }
+        }
+      EOS
+    end
+
     it 'correctly adds private headers' do
       @gen.stubs(:private_headers).returns(['Private.h'])
+      @pod_target.stubs(:requires_frameworks? => true)
       @gen.generate.should == <<-EOS.strip_heredoc
         framework module BananaLib {
           umbrella header "BananaLib-umbrella.h"

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -23,7 +23,7 @@ module Pod
       EOS
     end
 
-    it 'writes the module map to the disk' do
+    it 'writes the library module map to the disk' do
       path = temporary_directory + 'BananaLib.modulemap'
       @pod_target.stubs(:requires_frameworks? => false)
       @gen.save_as(path)

--- a/spec/unit/installer/target_installer/pod_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/pod_target_installer_spec.rb
@@ -103,6 +103,7 @@ module Pod
             'Pods-BananaLib-Private.xcconfig',
             'Pods-BananaLib-dummy.m',
             'Pods-BananaLib-prefix.pch',
+            'Pods-BananaLib.modulemap',
             'Pods-BananaLib.xcconfig',
           ]
         end
@@ -145,6 +146,7 @@ module Pod
             'BananaLib-Private.xcconfig',
             'BananaLib-dummy.m',
             'BananaLib-prefix.pch',
+            'BananaLib.modulemap',
             'BananaLib.xcconfig',
           ]
         end


### PR DESCRIPTION
I have added support for modules for static libraries that allows nice usage of static libraries from Obj-C and Swift and easier switching between frameworks and static libraries because you use ```@import XXX;``` or ```import XXX``` in Swift.

You had already code for generating module maps so I enabled this code also for static libraries and put the module map next to headers.

Please review my changes and let me know what you would like to improve. It is my first contribution and it takes time to feel comfortable in CocoaPods codebase so I could miss something.

I will add specs later once we agree on implementation details. :smiley: 