### PR TITLE
Add a flag in the git attributes to do union merges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
From [GitLab's Blog](https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders) / https://github.com/artsy/eigen/pull/656

> ayufan suggested a much better solution in the comments of this article. If you add CHANGELOG merge=union to the .gitattributes file in the root of the repo you should not have any conflicts. Instead of leaving conflicts the [union merge](http://git-scm.com/docs/git-merge-file) option will resolve conflicts favouring both side of the lines. An example of such a setting change is in the endgamesingularity repo. Thanks ayufan, we’ll try this instead.
