### PR TITLE
[Installer] Improve error message when using Swift in static libs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   is now a default plugin.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Improve the message shown when trying to use Swift Pods without frameworks.
+  Now it includes the offending Pods so that the user can take action to remove
+  the Pods, if they don’t want to move to frameworks yet.  
+  [#3830](https://github.com/CocoaPods/CocoaPods/pull/3830)
+  [Eloy Durán](https://github.com/alloy)
+
 ##### Bug Fixes
 
 * Ensure that the `prepare_command` is run even when skipping the download

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -411,10 +411,13 @@ module Pod
         aggregate_target.user_build_configurations.keys.each do |config|
           pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
 
-          if pod_targets.any?(&:uses_swift?)
+          swift_pods = pod_targets.select(&:uses_swift?)
+          unless swift_pods.empty?
             raise Informative, 'Pods written in Swift can only be integrated as frameworks; this ' \
               'feature is still in beta. Add `use_frameworks!` to your Podfile or target to opt ' \
-              'into using it.'
+              'into using it. ' \
+              "The Swift #{swift_pods.size == 1 ? 'Pod being used is' : 'Pods being used are'}: " +
+              swift_pods.map(&:name).to_sentence
           end
         end
       end


### PR DESCRIPTION
Now it includes the offending Pods so that the user can take action
to remove the Pods, if they don’t want to move to frameworks yet.

### Before

```
[!] Pods written in Swift can only be integrated as frameworks; this feature is still in beta. Add `use_frameworks!` to your Podfile or target to opt into using it.
```

### After

```
[!] Pods written in Swift can only be integrated as frameworks; this feature is still in beta. Add `use_frameworks!` to your Podfile or target to opt into using it. The Swift Pod being used is: FBSnapshotTestCase
```