### PR TITLE
Add header search paths for static library pods to the user target when integrating Pods as frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   least one of them fails linting.  
   [#3869](https://github.com/CocoaPods/CocoaPods/issues/3869)
   [Samuel Giddins](https://github.com/segiddins)
+* Set header search paths properly on the user target when `vendored_libraries`
+  Pods are used while integrating Pods as frameworks.
+  [#3857](https://github.com/CocoaPods/CocoaPods/issues/3857)
+  [Jonathan MacMillan](https://github.com/perotinus)
 
 
 ## 0.38.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   least one of them fails linting.  
   [#3869](https://github.com/CocoaPods/CocoaPods/issues/3869)
   [Samuel Giddins](https://github.com/segiddins)
+
 * Set header search paths properly on the user target when `vendored_libraries`
   Pods are used while integrating Pods as frameworks.
   [#3857](https://github.com/CocoaPods/CocoaPods/issues/3857)

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -157,6 +157,21 @@ module Pod
             it 'configures the project to load all members that implement Objective-c classes or categories' do
               @xcconfig.to_hash['OTHER_LDFLAGS'].should.include '-ObjC'
             end
+
+            it 'does not include framework header paths as local headers for pods that are linked statically' do
+              monkey_headers = '-iquote "$CONFIGURATION_BUILD_DIR/monkey.framework/Headers"'
+              @xcconfig.to_hash['OTHER_CFLAGS'].should.not.include monkey_headers
+            end
+
+            it 'includes the public header paths as system headers' do
+              expected = '-isystem "${PODS_ROOT}/Headers/Public"'
+              @xcconfig.to_hash['OTHER_CFLAGS'].should.include expected
+            end
+
+            it 'includes the public header paths as user headers' do
+              expected = '${PODS_ROOT}/Headers/Public'
+              @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include expected
+            end
           end
 
           it 'sets the PODS_FRAMEWORK_BUILD_PATH build variable' do


### PR DESCRIPTION
Ensure that the header search paths include the public headers in the sandbox, if there are any pods that are statically compiled into the user target, when integrating Pods as frameworks.

Fixes #3857.