### PR TITLE
When integrating Pods as frameworks, only link public headers in the sandbox for static Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#3869](https://github.com/CocoaPods/CocoaPods/issues/3869)
   [Samuel Giddins](https://github.com/segiddins)
 
+* Only link public headers in the sandbox for Pods that are not being built
+  into dynamic frameworks, when integrating Pods as frameworks
+  [#3867](https://github.com/CocoaPods/CocoaPods/issues/3867)
+  [Jonathan MacMillan](https://github.com/perotinus)
 
 ## 0.38.0
 

--- a/spec/fixtures/monkey/monkey.podspec
+++ b/spec/fixtures/monkey/monkey.podspec
@@ -8,4 +8,5 @@ Pod::Spec.new do |s|
   s.source           = { :git => "http://monkey.local/monkey.git", :tag => s.version.to_s }
   s.license          = 'MIT'
   s.vendored_library = 'monkey.a'
+  s.public_header_files = 'monkey.h'
 end

--- a/spec/unit/installer/file_references_installer_spec.rb
+++ b/spec/unit/installer/file_references_installer_spec.rb
@@ -70,6 +70,22 @@ module Pod
         framework_header.should.exist
         framework_subdir_header.should.exist
       end
+
+      it 'links the public headers meant for the user, but only for Pods that are not built' do
+        Target.any_instance.stubs(:requires_frameworks?).returns(true)
+        pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec')
+        pod_target_two = fixture_pod_target('monkey/monkey.podspec')
+        project = Project.new(config.sandbox.project_path)
+        project.add_pod_group('BananaLib', fixture('banana-lib'))
+        project.add_pod_group('monkey', fixture('monkey'))
+        installer = Installer::FileReferencesInstaller.new(config.sandbox, [pod_target_one, pod_target_two], project)
+        installer.install!
+        headers_root = config.sandbox.public_headers.root
+        banana_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
+        banana_headers.each { |banana_header| banana_header.should.not.exist }
+        monkey_header = headers_root + 'monkey/monkey.h'
+        monkey_header.should.exist
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
When integrating Pods as frameworks, only link public headers into the sandbox if those headers are from a Pod that is not being built (that is, a static library Pod that's being statically linked into the user target).

Addresses #3867.

Depends on https://github.com/CocoaPods/cocoapods-integration-specs/pull/41