### PR TITLE
Fix Issue #3893

### DIFF
--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -109,7 +109,7 @@ module Pod
               # Make library headers discoverale by `#import "…"`
               library_header_search_paths = target.sandbox.public_headers.search_paths(target.platform)
               build_settings['HEADER_SEARCH_PATHS'] = XCConfigHelper.quote(library_header_search_paths)
-              build_settings['OTHER_CFLAGS'] += XCConfigHelper.quote(library_header_search_paths, '-isystem')
+              build_settings['OTHER_CFLAGS'] += ' ' + XCConfigHelper.quote(library_header_search_paths, '-isystem')
             end
             if pod_targets.any? { |t| t.should_build? && t.scoped? }
               build_settings['FRAMEWORK_SEARCH_PATHS'] = '$(inherited) "$PODS_FRAMEWORK_BUILD_PATH"'


### PR DESCRIPTION
The missing space causes clang to produce `Cannot specify -o when generating multiple output files` errors in some cases.

Closes #3893