### PR TITLE
Use APPLICATION_EXTENSION_API_ONLY for watchOS 2 extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 To install release candidates run `[sudo] gem install cocoapods --pre`
 
+## Master
+
+##### Bug Fixes
+
+* Use APPLICATION_EXTENSION_API_ONLY for watchOS 2 extensions.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#3920](https://github.com/CocoaPods/CocoaPods/pull/3920)
+
+
 ## 0.38.2
 
 ##### Bug Fixes

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -603,7 +603,7 @@ module Pod
       frameworks_group = pods_project.frameworks_group
       aggregate_targets.each do |aggregate_target|
         is_app_extension = !(aggregate_target.user_targets.map(&:symbol_type) &
-          [:app_extension, :watch_extension]).empty?
+          [:app_extension, :watch_extension, :watch2_extension]).empty?
 
         aggregate_target.pod_targets.each do |pod_target|
           configure_app_extension_api_only_for_target(aggregate_target) if is_app_extension

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -576,6 +576,10 @@ module Pod
           test_extension_target(:watch_extension)
         end
 
+        it 'configures APPLICATION_EXTENSION_API_ONLY for watchOS 2 extension targets' do
+          test_extension_target(:watch2_extension)
+        end
+
         it 'does not try to set APPLICATION_EXTENSION_API_ONLY if there are no pod targets' do
           lambda do
             mock_user_target = mock('UserTarget', :symbol_type => :app_extension)


### PR DESCRIPTION
This was an oversight in the watchOS 2 support PR.