### PR TITLE
Add a command to check if dependencies are up to date

### DIFF
--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -15,6 +15,7 @@ module Pod
 
   class Command < CLAide::Command
     require 'cocoapods/command/inter_process_communication'
+    require 'cocoapods/command/check'
     require 'cocoapods/command/lib'
     require 'cocoapods/command/list'
     require 'cocoapods/command/outdated'

--- a/lib/cocoapods/command/check.rb
+++ b/lib/cocoapods/command/check.rb
@@ -1,0 +1,30 @@
+module Pod
+  class Command
+    class Check < Command
+      self.summary = 'Quickly check if pods are installed'
+      self.description = <<-DESC
+Determine whether the requirements for your application are satisfied.
+The `check` command will quickly compare the installed Pods against the
+dependencies specified in Podfile.lock. The `check` command will exit with
+status 0 when the pods are up to date and status 1 otherwise.
+The `check` can be chained with the install command in the following way to
+determine if installation is necessary.
+
+    $ pod check || pod install
+DESC
+
+
+      def run
+        unless config.lockfile
+          raise Informative, 'No `Podfile.lock` found in the project directory, run `pod install`.'
+        end
+
+        unless config.lockfile == config.sandbox.manifest
+          raise Informative, 'Some dependencies are not met. Run `pod install` or update your CocoaPods installation.'
+        end
+        UI.notice('The applications\'s dependencies are satisfied.')
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
:rainbow: :sunglasses: 

# Rational

At [CircleCi](https://circleci.com/mobile/ios) we automatically detect and run `pod install` when we detect a that contains a `Podfile` and an empty `Pods` directory. We cache the generated `Pods` folder from build to build, but we still need to run `pod install` to ensure that all dependencies are met. This call can take several minutes on every build. I want to add a command `pod check` that will exit with success when the Podfile.lock's manifest is satisfied, to allow us to run `pod check || pod install`, which should cut minutes off every build.

I've been writing an internal system to perform the same test, but I would like to push the changes back upstream so that others may benefit.

# Feature

Add a command `pod check` that returns success when the
pods specified in the lockfile are installed. This command
is designed to mirror the `bundle check` command provided
by bundler.

The expected use-case is to prevent having to run `pod install`
on every build in a CI scenario. The user should be able to
run `pod check || pod install` rather than pod install. This
can save minutes off CI builds.

http://bundler.io/v1.1/bundle_check.html

# TODO:

I wanted to open this PR for discussion and feedback before I spend any more time polishing. Here is a list of tasks that are needed to finish this:

- [ ] Write code docs
- [ ] Write tests
- [ ] Run linting tools

# Example

### Using `pod check` on an app with/without up-to-date pods 

Here is some example usage:
```
marc@skywarp ~/dev/KiwiTester $ rm Podfile.lock
marc@skywarp ~/dev/KiwiTester $ pod check
[!] No `Podfile.lock` found in the project directory, run `pod install`.
marc@skywarp ~/dev/KiwiTester $ pod install > /dev/null
marc@skywarp ~/dev/KiwiTester $ pod check

[!] The applications's dependencies are satisfied.
marc@skywarp ~/dev/KiwiTester $ rm -r Pods
marc@skywarp ~/dev/KiwiTester $ pod check
[!] Some dependencies are not met. Run `pod install` or update your CocoaPods installation.
marc@skywarp ~/dev/KiwiTester $ pod install > /dev/null
marc@skywarp ~/dev/KiwiTester $ pod check

[!] The applications's dependencies are satisfied.
marc@skywarp ~/dev/KiwiTester $ sed -i -e '3d' Pods/Manifest.lock # Delete line 3 of Manifest.lock
marc@skywarp ~/dev/KiwiTester $ pod check
[!] Some dependencies are not met. Run `pod install` or update your CocoaPods installation.
marc@skywarp ~/dev/KiwiTester $ pod install > /dev/null
marc@skywarp ~/dev/KiwiTester $ pod check

[!] The applications's dependencies are satisfied.
```

### Running `pod install` on an app with dependencies that all already specified.
```
marc@skywarp ~/dev/KiwiTester $ pod install > /dev/null  && /usr/bin/time pod install > /dev/null
        6.46 real         3.72 user         0.70 sys
marc@skywarp ~/dev/KiwiTester $ pod install > /dev/null  && /usr/bin/time ../CocoaPods/bin/pod check || pod install

[!] The applications's dependencies are satisfied.
        0.51 real         0.44 user         0.07 sys
```
