### PR TITLE
Update spec and lib commands to use all sources by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Update `spec` and `lib` commands to use all sources by default.
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#3938](https://github.com/CocoaPods/CocoaPods/pull/3938)
+  
 * Add `--sources` option to `push` command.
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#3912](https://github.com/CocoaPods/CocoaPods/issues/3912)

--- a/lib/cocoapods/command/lib.rb
+++ b/lib/cocoapods/command/lib.rb
@@ -123,7 +123,7 @@ module Pod
            ['--fail-fast', 'Lint stops on the first failing platform or subspec'],
            ['--use-libraries', 'Lint uses static libraries to install the spec'],
            ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependant pods ' \
-            '(defaults to https://github.com/CocoaPods/Specs.git). '\
+            '(defaults to all available repos). '\
             'Multiple sources must be comma-delimited.']].concat(super)
         end
 
@@ -135,7 +135,7 @@ module Pod
           @subspecs        = argv.flag?('subspecs', true)
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
-          @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @source_urls     = argv.option('sources', SourcesManager.all.map(&:url).join(',')).split(',')
           @podspecs_paths  = argv.arguments!
           super
         end

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -23,7 +23,7 @@ module Pod
            ['--fail-fast', 'Lint stops on the first failing platform or subspec'],
            ['--use-libraries', 'Lint uses static libraries to install the spec'],
            ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependant pods ' \
-            '(defaults to https://github.com/CocoaPods/Specs.git). '\
+            '(defaults to all available repos). '\
             'Multiple sources must be comma-delimited.']].concat(super)
         end
 
@@ -35,7 +35,7 @@ module Pod
           @subspecs        = argv.flag?('subspecs', true)
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
-          @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @source_urls     = argv.option('sources', SourcesManager.all.map(&:url).join(',')).split(',')
           @podspecs_paths  = argv.arguments!
           super
         end


### PR DESCRIPTION
re: https://github.com/CocoaPods/CocoaPods/pull/3932

It seems to me that all commands that deal with `--sources` should be unified and the behavior should be consistent.

Feel free to reject if I am missing some reason why these commands shouldn't default to all repos.