### PR TITLE
🌈 Fix generic archives built by Xcode 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Boris Bügling](https://github.com/neonichu)
   [#3920](https://github.com/CocoaPods/CocoaPods/pull/3920)
 
+* Prevent copying resources to installation directory when `SKIP_INSTALL` is enabled.  
+  [Dominique d'Argent](https://github.com/nubbel)
+  [#3971](https://github.com/CocoaPods/CocoaPods/pull/3971)
+
 ##### Enhancements
 
 * Add `--sources` option to `push` command.

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -160,7 +160,7 @@ EOS
 
 mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
-if [[ "${ACTION}" == "install" ]]; then
+if [[ "${ACTION}" == "install" ]] && [[ "${SKIP_INSTALL}" == "NO" ]]; then
   mkdir -p "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 fi


### PR DESCRIPTION
Hi,

This PR fixes a bug that caused Xcode 7 (tested with beta 4 only) to build generic archives instead of iOS app archives.
I noticed this bug in a project that has an embedded framework. Both the app and the framework targets define pod dependencies. When the copy_resources script runs for the framework target, it copies the pod framework into the installation directory, even though `SKIP_INSTALL` is set to `YES`.

The resulting archive (before my changes) is displayed in Xcode like this:
![Xcode organiser view of the archive](https://cloud.githubusercontent.com/assets/118781/9083501/0d738fa8-3b6b-11e5-887a-72a80bf88e4c.png)

Inspecting the archive file reveals that it contains multiple products - one for the app and one for the embedded framework:
![invalid archive products](https://cloud.githubusercontent.com/assets/118781/9083536/538e3556-3b6b-11e5-8871-a1a863f5210f.png)

For some reason it worked before with Xcode 6.4.

I put together a [demo project](https://github.com/nubbel/Cococapods-Xcode7GenericArchive) that allows you to verify the issue.

It might fix #3924.