### PR TITLE
[Validator] Print the name of the attribute that has the result

### DIFF
--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -111,7 +111,7 @@ module Pod
         when :warning then type = 'WARN'
         when :note    then type = 'NOTE'
         else raise "#{result.type}" end
-        UI.puts "    - #{type.ljust(5)} | #{platform_message}#{subspecs_message}#{result.message}"
+        UI.puts "    - #{type.ljust(5)} | #{platform_message}#{subspecs_message}#{result.attribute_name}: #{result.message}"
       end
       UI.puts
     end


### PR DESCRIPTION
This means we'll actually print the part of the spec that's failing, which can be non-obvious in some cases, like when the invocation of xcodebuild fails.

\c @orta 