### PR TITLE
Removing explicit header paths being added when including files.

### DIFF
--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -71,7 +71,6 @@ module Pod
       # @return [Array<Pathname>]
       #
       def add_files(namespace, relative_header_paths, platform)
-        add_search_path(namespace, platform)
         namespaced_path = root + namespace
         namespaced_path.mkpath unless File.exist?(namespaced_path)
 


### PR DESCRIPTION
Right now folders are added recursively for each subdirectory if
preserve_paths is set (which many frameworks, such as j2objc, need).  They
require something like java/util/Time.h.  So if you preserve the paths,
cocoapods automatically adds each subdirectory to the include path.

Currently adding that one header would add:

Pods/J2ObjC
Pods/J2ObjC/java
Pods/J2ObjC/java/util

which can have bad side effects... say if you have a file named the same as
a system include file (j2ObjC has several of these... time.h is a bad
offender).  This means that any other library that includes <time.h> will
get the j2ObjC one instead of the system time.h that they wanted.  The
header search paths had been polluted.