### PR TITLE
The `HEADER_SEARCH_PATHS` will no longer be constructed recursively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Breaking
+
+* The `HEADER_SEARCH_PATHS` will no longer be constructed recursively.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [twoboxen](https://github.com/twoboxen)
+  [#1437](https://github.com/CocoaPods/CocoaPods/issues/1437)
+  [#3760](https://github.com/CocoaPods/CocoaPods/issues/3760)
+
 ##### Bug Fixes
 
 * Build settings specified in `pod_target_xcconfig` of a spec are also for

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -128,17 +128,17 @@ module Pod
               end
 
               header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
-                pod_target.build_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp }, pod_target.platform)
+                pod_target.build_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
               end
 
               unless pod_target.requires_frameworks? && pod_target.should_build?
                 header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
-                  sandbox.public_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp }, pod_target.platform)
+                  sandbox.public_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
                 end
               end
 
               vendored_frameworks_header_mappings(headers_sandbox, file_accessor).each do |namespaced_path, files|
-                sandbox.public_headers.add_files(namespaced_path, files, pod_target.platform)
+                sandbox.public_headers.add_files(namespaced_path, files)
               end
             end
           end

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -66,13 +66,13 @@ module Pod
       #         the path of the header file relative to the Pods project
       #         (`PODS_ROOT` variable of the xcconfigs).
       #
-      # @note   This method adds the files to the search paths.
+      # @note   This method does _not_ add the files to the search paths.
       #
       # @return [Array<Pathname>]
       #
-      def add_files(namespace, relative_header_paths, platform)
+      def add_files(namespace, relative_header_paths)
         relative_header_paths.map do |relative_header_path|
-          add_file(namespace, relative_header_path, relative_header_path.basename, platform)
+          add_file(namespace, relative_header_path, relative_header_path.basename)
         end
       end
 
@@ -90,12 +90,11 @@ module Pod
       #         the name under which the file should be available in the
       #         headers directory.
       #
-      # @note   This method adds the file to the search paths.
+      # @note   This method does _not_ add the file to the search paths.
       #
       # @return [Pathname]
       #
-      def add_file(namespace, relative_header_path, final_name, platform)
-        add_search_path(namespace, platform)
+      def add_file(namespace, relative_header_path, final_name)
         namespaced_path = root + namespace
         namespaced_path.mkpath unless File.exist?(namespaced_path)
 

--- a/spec/unit/sandbox/headers_store_spec.rb
+++ b/spec/unit/sandbox/headers_store_spec.rb
@@ -21,14 +21,14 @@ module Pod
       relative_header_paths.each do |path|
         File.open(@sandbox.root + path, 'w') { |file| file.write('hello') }
       end
-      symlink_paths = @header_dir.add_files(namespace_path, relative_header_paths, :fake_platform)
+      symlink_paths = @header_dir.add_files(namespace_path, relative_header_paths)
       symlink_paths.each do |path|
         path.should.be.symlink
         File.read(path).should == 'hello'
       end
     end
 
-    it 'keeps a list of unique header search paths when headers are added' do
+    it 'does not add recursive search paths' do
       FileUtils.mkdir_p(@sandbox.root + 'ExampleLib/Dir')
       namespace_path = Pathname.new('ExampleLib')
       relative_header_paths = [
@@ -38,8 +38,8 @@ module Pod
       relative_header_paths.each do |path|
         File.open(@sandbox.root + path, 'w') { |file| file.write('hello') }
       end
-      @header_dir.add_files(namespace_path, relative_header_paths, :fake_platform)
-      @header_dir.search_paths(:fake_platform).should.include('${PODS_ROOT}/Headers/Public/ExampleLib')
+      @header_dir.add_files(namespace_path, relative_header_paths)
+      @header_dir.search_paths(:fake_platform).should.not.include('${PODS_ROOT}/Headers/Public/ExampleLib')
     end
 
     it 'always adds the Headers root to the header search paths' do


### PR DESCRIPTION
See https://github.com/CocoaPods/CocoaPods/pull/4042.

Closes #1437. Closes #3760.

\c @neonichu 