### PR TITLE
[Generator] Fix missing `$(inherited)` in xcconfig build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Embed frameworks into app and watch extensions.  
   [Boris Bügling](https://github.com/neonichu)
   [#4004](https://github.com/CocoaPods/CocoaPods/pull/4004)
+  
+* Fix missing `$(inherited)` for generated xcconfig `LIBRARY_SEARCH_PATHS` and `HEADER_SEARCH_PATHS` build settings.  
+  [Tyler Fox](https://github.com/smileyborg)
+  [#3908](https://github.com/CocoaPods/CocoaPods/issues/3908)
 
 ##### Enhancements
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -106,9 +106,9 @@ module Pod
               'OTHER_CFLAGS' => '$(inherited) ' + XCConfigHelper.quote(framework_header_search_paths, '-iquote'),
             }
             if pod_targets.any? { |t| !t.should_build? }
-              # Make library headers discoverale by `#import "…"`
+              # Make library headers discoverable by `#import "…"`
               library_header_search_paths = target.sandbox.public_headers.search_paths(target.platform)
-              build_settings['HEADER_SEARCH_PATHS'] = XCConfigHelper.quote(library_header_search_paths)
+              build_settings['HEADER_SEARCH_PATHS'] = '$(inherited) ' + XCConfigHelper.quote(library_header_search_paths)
               build_settings['OTHER_CFLAGS'] += ' ' + XCConfigHelper.quote(library_header_search_paths, '-isystem')
             end
             if pod_targets.any? { |t| t.should_build? && t.scoped? }

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -116,7 +116,7 @@ module Pod
           dirname = '$(PODS_ROOT)/' + library_path.dirname.relative_path_from(sandbox_root).to_s
           build_settings = {
             'OTHER_LDFLAGS' => "-l#{name}",
-            'LIBRARY_SEARCH_PATHS' => quote([dirname]),
+            'LIBRARY_SEARCH_PATHS' => '$(inherited) ' + quote([dirname]),
           }
           xcconfig.merge!(build_settings)
         end

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -181,6 +181,11 @@ module Pod
               expected = '${PODS_ROOT}/Headers/Public'
               @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include expected
             end
+
+            it 'includes $(inherited) in the header search paths' do
+              expected = '$(inherited)'
+              @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include expected
+            end
           end
 
           it 'sets the PODS_FRAMEWORK_BUILD_PATH build variable' do

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -156,7 +156,7 @@ module Pod
             @sut.add_library_build_settings(path, xcconfig, config.sandbox.root)
             hash_config = xcconfig.to_hash
             hash_config['OTHER_LDFLAGS'].should == '-l"Proj4"'
-            hash_config['LIBRARY_SEARCH_PATHS'].should == '"$(PODS_ROOT)/MapBox/Proj4"'
+            hash_config['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "$(PODS_ROOT)/MapBox/Proj4"'
           end
         end
 


### PR DESCRIPTION
- Add missing `$(inherited)` values for the build settings `LIBRARY_SEARCH_PATHS` and `HEADER_SEARCH_PATHS` in generated xcconfig files.
- Update tests to explicitly check for these `$(inherited)` values.

Fixes #3908

This is my first PR to CocoaPods, so hopefully I did things correctly :) Also, I'm pretty sure that I was able to find and fix the two places where $(inherited) was missing. But I would greatly appreciate someone else's eyes on this, as this my first time looking at and touching this code.