### PR TITLE
[Validator] Validate that apps can import the Pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3428](https://github.com/CocoaPods/CocoaPods/issues/3428)
 
+* The validator will now attempt to build an app that imports the pod.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#2095](https://github.com/CocoaPods/CocoaPods/issues/2095)
+  [#2134](https://github.com/CocoaPods/CocoaPods/issues/2134)
+
 ##### Bug Fixes
 
 * Improve repo lint error message when no repo found with given name.  

--- a/lib/cocoapods/command/lib.rb
+++ b/lib/cocoapods/command/lib.rb
@@ -164,7 +164,7 @@ module Pod
             validator.validate
 
             unless @clean
-              UI.puts "Pods project available at `#{validator.validation_dir}/Pods/Pods.xcodeproj` for inspection."
+              UI.puts "Pods workspace available at `#{validator.validation_dir}/App.xcworkspace` for inspection."
               UI.puts
             end
             if validator.validated?

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -61,7 +61,7 @@ module Pod
             failure_reasons << validator.failure_reason
 
             unless @clean
-              UI.puts "Pods project available at `#{validator.validation_dir}/Pods/Pods.xcodeproj` for inspection."
+              UI.puts "Pods workspace available at `#{validator.validation_dir}/App.xcworkspace` for inspection."
               UI.puts
             end
           end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -247,12 +247,12 @@ module Pod
         if config.integrate_targets?
           target_inspection = result.target_inspections[target_definition]
           target.user_project = target_inspection.project
-          target.client_root = target.user_project_path.dirname
+          target.client_root = target.user_project_path.dirname.realpath
           target.user_target_uuids = target_inspection.project_target_uuids
           target.user_build_configurations = target_inspection.build_configurations
           target.archs = target_inspection.archs
         else
-          target.client_root = config.installation_root
+          target.client_root = config.installation_root.realpath
           target.user_target_uuids = []
           target.user_build_configurations = target_definition.build_configurations || { 'Release' => :release, 'Debug' => :debug }
           if target_definition.platform && target_definition.platform.name == :osx

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -275,7 +275,7 @@ module Pod
     rescue => e
       message = e.to_s
       message << "\n" << e.backtrace.join("\n") << "\n" if config.verbose?
-      error('unknown', "Encountered an unknown error (#{e}) during validation.")
+      error('unknown', "Encountered an unknown error (#{message}) during validation.")
       false
     end
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -390,7 +390,16 @@ module Pod
       else
         source_file = validation_dir.+('App/main.m')
         source_file.parent.mkpath
-        import_statement = use_frameworks ? "@import #{pod_target.product_module_name};\n" : ''
+        import_statement = if use_frameworks
+          "@import #{pod_target.product_module_name};\n"
+        else
+          header_name = "#{pod_target.product_module_name}/#{pod_target.product_module_name}.h"
+          if pod_target.sandbox.public_headers.root.+(header_name).file?
+            "#import <#{header_name}>\n"
+          else
+            ''
+          end
+        end
         source_file.open('w') { |f| f << "@import Foundation;\n#{import_statement}int main() {}\n" }
       end
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -391,14 +391,14 @@ module Pod
         source_file = validation_dir.+('App/main.m')
         source_file.parent.mkpath
         import_statement = if use_frameworks
-          "@import #{pod_target.product_module_name};\n"
-        else
-          header_name = "#{pod_target.product_module_name}/#{pod_target.product_module_name}.h"
-          if pod_target.sandbox.public_headers.root.+(header_name).file?
-            "#import <#{header_name}>\n"
-          else
-            ''
-          end
+                             "@import #{pod_target.product_module_name};\n"
+                           else
+                             header_name = "#{pod_target.product_module_name}/#{pod_target.product_module_name}.h"
+                             if pod_target.sandbox.public_headers.root.+(header_name).file?
+                               "#import <#{header_name}>\n"
+                             else
+                               ''
+                             end
         end
         source_file.open('w') { |f| f << "@import Foundation;\n#{import_statement}int main() {}\n" }
       end
@@ -678,7 +678,7 @@ module Pod
     #         returns its output (both STDOUT and STDERR).
     #
     def xcodebuild
-      command = %W(clean build -workspace App.xcworkspace -scheme App)
+      command = %w(clean build -workspace App.xcworkspace -scheme App)
       case consumer.platform_name
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)
@@ -706,7 +706,7 @@ module Pod
     #
     def _xcodebuild(command)
       UI.puts 'xcodebuild ' << command.join(' ') if config.verbose
-      Executable.capture_command('xcodebuild', command, capture: :merge)
+      Executable.capture_command('xcodebuild', command, :capture => :merge)
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -380,6 +380,14 @@ module Pod
     def add_app_project_import
       app_project = Xcodeproj::Project.open(validation_dir + 'App.xcodeproj')
       pod_target = @installer.pod_targets.find { |pt| pt.pod_name == spec.root.name }
+
+      source_file = write_app_import_source_file(pod_target)
+      source_file_ref = app_project.new_group('App', 'App').new_file(source_file)
+      app_project.targets.first.add_file_references([source_file_ref])
+      app_project.save
+    end
+
+    def write_app_import_source_file(pod_target)
       language = pod_target.uses_swift? ? :swift : :objc
 
       if language == :swift
@@ -402,10 +410,7 @@ module Pod
         end
         source_file.open('w') { |f| f << "@import Foundation;\n#{import_statement}int main() {}\n" }
       end
-
-      source_file_ref = app_project.new_group('App', 'App').new_file(source_file)
-      app_project.targets.first.add_file_references([source_file_ref])
-      app_project.save
+      source_file
     end
 
     # It creates a podfile in memory and builds a library containing the pod

--- a/spec/functional/command/lib_spec.rb
+++ b/spec/functional/command/lib_spec.rb
@@ -104,7 +104,7 @@ module Pod
           run_command('lib', 'lint', 'Broken.podspec', '--no-clean')
         end
         UI.output.should.include 'Missing required attribute'
-        UI.output.should.include 'Pods project available at'
+        UI.output.should.include 'Pods workspace available at'
       end
     end
 

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -130,6 +130,7 @@ module Pod
       Installer.any_instance.stubs(:aggregate_targets).returns([])
       Installer.any_instance.stubs(:pod_targets).returns([])
       Validator.any_instance.stubs(:install_pod)
+      Validator.any_instance.stubs(:add_app_project_import)
       Validator.any_instance.stubs(:check_file_patterns)
       Validator.any_instance.stubs(:validated?).returns(true)
       Validator.any_instance.stubs(:validate_url)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -404,11 +404,11 @@ module Pod
         git = Executable.which(:git)
         Executable.stubs(:which).with('git').returns(git)
         Executable.expects(:which).with('xcodebuild').times(4).returns('/usr/bin/xcodebuild')
-        command = 'xcodebuild clean build -target Pods'
-        validator.expects(:`).with("#{command} 2>&1").once.returns('')
-        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk appletvsimulator 2>&1").once.returns('')
-        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk iphonesimulator 2>&1").once.returns('')
-        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk watchsimulator 2>&1").once.returns('')
+        command = %w(clean build -workspace App.xcworkspace -scheme App)
+        Executable.expects(:capture_command).with('xcodebuild', command, capture: :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator), capture: :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator), capture: :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator), capture: :merge).once.returns(['', stub(:success? => true)])
         validator.validate
       end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -102,6 +102,7 @@ module Pod
           @validator.stubs(:download_pod)
           @validator.stubs(:check_file_patterns)
           @validator.stubs(:install_pod)
+          @validator.stubs(:add_app_project_import)
           @validator.stubs(:build_pod)
           @validator.stubs(:tear_down_validation_environment)
           WebMock::API.stub_request(:head, /not-found/).to_return(:status => 404)
@@ -128,7 +129,7 @@ module Pod
             WebMock::API.stub_request(:head, /found/).to_return(:status => 200)
             Specification.any_instance.stubs(:homepage).returns('http://banana-corp.local/redirect/')
             @validator.validate
-            @validator.results.length.should.equal 0
+            @validator.results.should.be.empty
           end
 
           it 'does not fail if the homepage does not support HEAD' do
@@ -136,7 +137,7 @@ module Pod
             WebMock::API.stub_request(:get, /page/).to_return(:status => 200)
             Specification.any_instance.stubs(:homepage).returns('http://banana-corp.local/page/')
             @validator.validate
-            @validator.results.length.should.equal 0
+            @validator.results.should.be.empty
           end
 
           it 'does not fail if the homepage errors on HEAD' do
@@ -144,7 +145,7 @@ module Pod
             WebMock::API.stub_request(:get, /page/).to_return(:status => 200)
             Specification.any_instance.stubs(:homepage).returns('http://banana-corp.local/page/')
             @validator.validate
-            @validator.results.length.should.equal 0
+            @validator.results.should.be.empty
           end
 
           it 'does not follow redirects infinitely' do
@@ -166,7 +167,7 @@ module Pod
             Specification.any_instance.stubs(:homepage).returns(
               'http://banana-corp.local/redirect')
             @validator.validate
-            @validator.results.length.should.equal 0
+            @validator.results.should.be.empty
           end
         end
 
@@ -300,8 +301,8 @@ module Pod
         validator.stubs(:validate_url)
         validator.stubs(:validate_screenshots)
         validator.stubs(:check_file_patterns)
-        validator.stubs(:check_file_patterns)
         validator.stubs(:install_pod)
+        validator.stubs(:add_app_project_import)
         %i(prepare resolve_dependencies download_dependencies).each do |m|
           Installer.any_instance.stubs(m)
         end
@@ -538,6 +539,7 @@ module Pod
         @validator.stubs(:validate_screenshots)
         @validator.stubs(:check_file_patterns)
         @validator.stubs(:install_pod)
+        @validator.stubs(:add_app_project_import)
         %i(prepare resolve_dependencies download_dependencies).each do |m|
           Installer.any_instance.stubs(m)
         end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -445,6 +445,113 @@ module Pod
         validator.results.count.should == 0
       end
 
+      describe 'import validation' do
+        before do
+          @validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+          @validator.stubs(:validate_url)
+          @consumer = Specification.from_file(podspec_path).consumer(:ios)
+          @validator.instance_variable_set(:@consumer, @consumer)
+          @validator.send(:setup_validation_environment)
+        end
+
+        after do
+          @validator.send(:tear_down_validation_environment)
+        end
+
+        it 'creates an empty app project & target to integrate into' do
+          @validator.send(:create_app_project)
+          project = Xcodeproj::Project.open(@validator.validation_dir + 'App.xcodeproj')
+
+          target = project.native_targets.find { |t| t.name == 'App' }
+          target.should.not.be.nil
+          target.symbol_type.should == :application
+          target.deployment_target.should.be.nil
+          target.platform_name.should == :ios
+
+          Xcodeproj::Project.schemes(project.path).should == %w(App)
+        end
+
+        describe 'creating the importing file' do
+          describe 'when linting as a framework' do
+            before do
+              @validator.stubs(:use_frameworks).returns(true)
+            end
+
+            it 'creates a swift import' do
+              pod_target = stub(:uses_swift? => true, :product_module_name => 'ModuleName')
+
+              file = @validator.send(:write_app_import_source_file, pod_target)
+              file.basename.to_s.should == 'main.swift'
+              file.read.should == <<-SWIFT.strip_heredoc
+                import ModuleName
+              SWIFT
+            end
+
+            it 'creates an objective-c import' do
+              pod_target = stub(:uses_swift? => false, :product_module_name => 'ModuleName')
+
+              file = @validator.send(:write_app_import_source_file, pod_target)
+              file.basename.to_s.should == 'main.m'
+              file.read.should == <<-OBJC.strip_heredoc
+                @import Foundation;
+                @import ModuleName;
+                int main() {}
+              OBJC
+            end
+          end
+
+          describe 'when linting as a static lib' do
+            before do
+              @validator.stubs(:use_frameworks).returns(false)
+              @sandbox = config.sandbox
+            end
+
+            it 'creates an objective-c import when a plausible umbrella header is found' do
+              pod_target = stub(:uses_swift? => false, :product_module_name => 'ModuleName', :sandbox => @sandbox)
+              header_name = "#{pod_target.product_module_name}/#{pod_target.product_module_name}.h"
+              umbrella = pod_target.sandbox.public_headers.root.+(header_name)
+              umbrella.dirname.mkpath
+              umbrella.open('w') {}
+
+              file = @validator.send(:write_app_import_source_file, pod_target)
+              file.basename.to_s.should == 'main.m'
+              file.read.should == <<-OBJC.strip_heredoc
+                @import Foundation;
+                #import <ModuleName/ModuleName.h>
+                int main() {}
+              OBJC
+            end
+
+            it 'does not create an objective-c import when no umbrella header is found' do
+              pod_target = stub(:uses_swift? => false, :product_module_name => 'ModuleName', :sandbox => @sandbox)
+
+              file = @validator.send(:write_app_import_source_file, pod_target)
+              file.basename.to_s.should == 'main.m'
+              file.read.should == <<-OBJC.strip_heredoc
+                @import Foundation;
+                int main() {}
+              OBJC
+            end
+          end
+        end
+
+        it 'adds the importing file to the app target' do
+          @validator.stubs(:use_frameworks).returns(true)
+          @validator.send(:create_app_project)
+          pod_target = stub(:uses_swift? => true, :pod_name => 'JSONKit', :product_module_name => 'ModuleName')
+          installer = stub(:pod_targets => [pod_target])
+          @validator.instance_variable_set(:@installer, installer)
+          @validator.send(:add_app_project_import)
+
+          project = Xcodeproj::Project.open(@validator.validation_dir + 'App.xcodeproj')
+          group = project['App']
+          file = group.find_file_by_path('main.swift')
+          file.should.not.be.nil
+          target = project.native_targets.find { |t| t.name == 'App' }
+          target.source_build_phase.files_references.should.include(file)
+        end
+      end
+
       describe 'file pattern validation' do
         it 'checks for file patterns' do
           file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "wrong_paht.*",'))

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -406,10 +406,10 @@ module Pod
         Executable.stubs(:which).with('git').returns(git)
         Executable.expects(:which).with('xcodebuild').times(4).returns('/usr/bin/xcodebuild')
         command = %w(clean build -workspace App.xcworkspace -scheme App)
-        Executable.expects(:capture_command).with('xcodebuild', command, capture: :merge).once.returns(['', stub(:success? => true)])
-        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator), capture: :merge).once.returns(['', stub(:success? => true)])
-        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator), capture: :merge).once.returns(['', stub(:success? => true)])
-        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator), capture: :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator), :capture => :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator), :capture => :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator), :capture => :merge).once.returns(['', stub(:success? => true)])
         validator.validate
       end
 


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/2095 in a circuitous manner.
Closes https://github.com/CocoaPods/CocoaPods/issues/2134.

- [x] CHANGELOG
- [x] Tests
  - [x] Project generation
  - [x] Updating existing specs
  - [x] Update integration spec
- [x] Consider importing headers when not validating as a framework?