### PR TITLE
[Validator] build watchOS pods against watchossimulator for validation 🌈

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 To install release candidates run `[sudo] gem install cocoapods --pre`
 
+## Master
+
 ##### Bug Fixes
 
 * Use watchsimulator when validatng PodSpecs with watchOS compatibility.  
   [Thomas Kollbach](https://github.com/toto)
   [#4130](https://github.com/CocoaPods/CocoaPods/issues/4130)
+  
 
 ## 0.39.0.beta.4 (2015-09-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 To install release candidates run `[sudo] gem install cocoapods --pre`
 
+##### Bug Fixes
+
+* Use watchsimulator when validatng PodSpecs with watchOS compatibility.  
+  [Thomas Kollbach](https://github.com/toto)
+  [#4130](https://github.com/CocoaPods/CocoaPods/issues/4130)
+
 ## 0.39.0.beta.4 (2015-09-02)
 
 ##### Bug Fixes

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -608,8 +608,15 @@ module Pod
     #         returns its output (both STDOUT and STDERR).
     #
     def xcodebuild
-      command = 'xcodebuild clean build -target Pods'
-      command << ' CODE_SIGN_IDENTITY=- -sdk iphonesimulator' if consumer.platform_name == :ios
+      command = 'xcodebuild clean build -target Pods
+'
+      case consumer.platform_name
+      when :ios
+        command << ' CODE_SIGN_IDENTITY=- -sdk iphonesimulator'
+      when :watchos
+        command << ' CODE_SIGN_IDENTITY=- -sdk watchsimulator'
+      end
+
       output, status = _xcodebuild "#{command} 2>&1"
 
       unless status.success?

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -608,8 +608,8 @@ module Pod
     #         returns its output (both STDOUT and STDERR).
     #
     def xcodebuild
-      command = 'xcodebuild clean build -target Pods
-'
+      command = 'xcodebuild clean build -target Pods'
+
       case consumer.platform_name
       when :ios
         command << ' CODE_SIGN_IDENTITY=- -sdk iphonesimulator'

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -404,8 +404,9 @@ module Pod
         Executable.stubs(:which).with('git').returns(git)
         Executable.expects(:which).with('xcodebuild').times(3).returns('/usr/bin/xcodebuild')
         command = 'xcodebuild clean build -target Pods'
-        validator.expects(:`).with("#{command} 2>&1").twice.returns('')
+        validator.expects(:`).with("#{command} 2>&1").once.returns('')
         validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk iphonesimulator 2>&1").once.returns('')
+        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk watchsimulator 2>&1").once.returns('')        
         validator.validate
       end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -406,7 +406,7 @@ module Pod
         command = 'xcodebuild clean build -target Pods'
         validator.expects(:`).with("#{command} 2>&1").once.returns('')
         validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk iphonesimulator 2>&1").once.returns('')
-        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk watchsimulator 2>&1").once.returns('')
+        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk watchsimulator 2>&1").once.returns('')        
         validator.validate
       end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -406,7 +406,7 @@ module Pod
         command = 'xcodebuild clean build -target Pods'
         validator.expects(:`).with("#{command} 2>&1").once.returns('')
         validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk iphonesimulator 2>&1").once.returns('')
-        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk watchsimulator 2>&1").once.returns('')        
+        validator.expects(:`).with("#{command} CODE_SIGN_IDENTITY=- -sdk watchsimulator 2>&1").once.returns('')
         validator.validate
       end
 


### PR DESCRIPTION
This fixes watchOS pods not being built using the `-sdk watchsimulator` SDK. 

Not doing this makes validation fail in bad ways. E.g. if you rely on preprocessor macros such as `TARGET_OS_IOS` vs. `TARGET_OS_WATCH` (not to be confused with `TARGET_OS_IPHONE` wich is true for watchOS and iOS).