### PR TITLE
[Installer] Always Link the AggregateTarget as static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## 0.39.0.beta.4 (2015-09-02)
 
+##### Enhancements
+
+* Always link the aggregate target as static to the user project.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#4137](https://github.com/CocoaPods/CocoaPods/pull/4137)
+
 ##### Bug Fixes
 
 * Using vendored frameworks without a `Headers` directory will no longer cause a

--- a/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
@@ -47,6 +47,7 @@ module Pod
           'OTHER_LIBTOOLFLAGS' => '',
           'PODS_ROOT'          => '$(SRCROOT)',
           'SKIP_INSTALL'       => 'YES',
+          'MACH_O_TYPE'        => 'staticlib',
         }
         super.merge(settings)
       end

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -137,6 +137,30 @@ module Pod
           end
         end
 
+        # Reset the linking of the product reference to strong.
+        #
+        # @return [Bool] whether any changes to the project were made.
+        #
+        # @todo   This can be removed for CocoaPods 1.0
+        #
+        def update_to_cocoapods_0_40
+          frameworks = user_project.frameworks_group
+          native_targets_to_embed_in.any? do |native_target|
+            build_phase = native_target.frameworks_build_phase
+
+            product_ref = frameworks.files.find { |f| f.path == target.product_name }
+            if product_ref
+              build_file = build_phase.build_file(product_ref)
+              if build_file \
+                && build_file.settings.is_a?(Hash) \
+                && build_file.settings['ATTRIBUTES'].is_a?(Array) \
+                && build_file.settings['ATTRIBUTES'].include?('Weak')
+                build_file.settings = nil
+              end
+            end
+          end
+        end
+
         # Adds spec product reference to the frameworks build phase of the
         # {TargetDefinition} integration libraries. Adds a file reference to
         # the frameworks group of the project and adds it to the frameworks

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -44,6 +44,7 @@ module Pod
               update_to_cocoapods_0_34,
               update_to_cocoapods_0_37_1,
               update_to_cocoapods_0_39,
+              update_to_cocoapods_0_40,
               unless native_targets_to_integrate.empty?
                 add_pods_library
                 add_embed_frameworks_script_phase
@@ -161,15 +162,8 @@ module Pod
             target_basename = target.product_basename
             new_product_ref = frameworks.files.find { |f| f.path == target.product_name } ||
               frameworks.new_product_ref_for_target(target_basename, target.product_type)
-            build_file = build_phase.build_file(new_product_ref) ||
+            build_phase.build_file(new_product_ref) ||
               build_phase.add_file_reference(new_product_ref, true)
-            if target.requires_frameworks?
-              # Weak link the aggregate target's product, because as it contains
-              # no symbols, it isn't copied into the app bundle. dyld will so
-              # never try to find the missing executable at runtime.
-              build_file.settings ||= {}
-              build_file.settings['ATTRIBUTES'] = ['Weak']
-            end
           end
         end
 

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -44,7 +44,6 @@ module Pod
               update_to_cocoapods_0_34,
               update_to_cocoapods_0_37_1,
               update_to_cocoapods_0_39,
-              update_to_cocoapods_0_40,
               unless native_targets_to_integrate.empty?
                 add_pods_library
                 add_embed_frameworks_script_phase
@@ -133,19 +132,10 @@ module Pod
           end
           if requires_update
             add_embed_frameworks_script_phase
-            true
           end
-        end
 
-        # Reset the linking of the product reference to strong.
-        #
-        # @return [Bool] whether any changes to the project were made.
-        #
-        # @todo   This can be removed for CocoaPods 1.0
-        #
-        def update_to_cocoapods_0_40
           frameworks = user_project.frameworks_group
-          native_targets_to_embed_in.any? do |native_target|
+          native_targets_to_embed_in.each do |native_target|
             build_phase = native_target.frameworks_build_phase
 
             product_ref = frameworks.files.find { |f| f.path == target.product_name }
@@ -156,9 +146,12 @@ module Pod
                 && build_file.settings['ATTRIBUTES'].is_a?(Array) \
                 && build_file.settings['ATTRIBUTES'].include?('Weak')
                 build_file.settings = nil
+                requires_update = true
               end
             end
           end
+
+          requires_update
         end
 
         # Adds spec product reference to the frameworks build phase of the

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -142,9 +142,9 @@ module Pod
             if product_ref
               build_file = build_phase.build_file(product_ref)
               if build_file &&
-                build_file.settings.is_a?(Hash) &&
-                build_file.settings['ATTRIBUTES'].is_a?(Array) &&
-                build_file.settings['ATTRIBUTES'].include?('Weak')
+                  build_file.settings.is_a?(Hash) &&
+                  build_file.settings['ATTRIBUTES'].is_a?(Array) &&
+                  build_file.settings['ATTRIBUTES'].include?('Weak')
                 build_file.settings = nil
                 requires_update = true
               end

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -135,16 +135,16 @@ module Pod
           end
 
           frameworks = user_project.frameworks_group
-          native_targets_to_embed_in.each do |native_target|
+          native_targets.each do |native_target|
             build_phase = native_target.frameworks_build_phase
 
             product_ref = frameworks.files.find { |f| f.path == target.product_name }
             if product_ref
               build_file = build_phase.build_file(product_ref)
-              if build_file \
-                && build_file.settings.is_a?(Hash) \
-                && build_file.settings['ATTRIBUTES'].is_a?(Array) \
-                && build_file.settings['ATTRIBUTES'].include?('Weak')
+              if build_file &&
+                build_file.settings.is_a?(Hash) &&
+                build_file.settings['ATTRIBUTES'].is_a?(Array) &&
+                build_file.settings['ATTRIBUTES'].include?('Weak')
                 build_file.settings = nil
                 requires_update = true
               end

--- a/spec/unit/installer/target_installer/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/aggregate_target_installer_spec.rb
@@ -101,6 +101,13 @@ module Pod
         end
       end
 
+      it 'will be built as static library' do
+        @installer.install!
+        @installer.target.native_target.build_configurations.each do |config|
+          config.build_settings['MACH_O_TYPE'].should == 'staticlib'
+        end
+      end
+
       it 'will be skipped when installing' do
         @installer.install!
         @installer.target.native_target.build_configurations.each do |config|

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -73,7 +73,6 @@ module Pod
           phase = target.frameworks_build_phase
           build_file = phase.files.find { |f| f.file_ref.path == 'Pods.framework' }
           build_file.should.not.be.nil
-          build_file.settings['ATTRIBUTES'].should == %w(Weak)
         end
 
         it 'adds a Copy Pods Resources build phase to each target' do

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -47,6 +47,17 @@ module Pod
           phase.shell_script.strip.should == "\"${SRCROOT}/../Pods/Target Support Files/Pods/Pods-resources.sh\""
         end
 
+        it 'fixes the "Link binary with libraries" build phase of legacy installations' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          @target_integrator.integrate!
+          target = @target_integrator.send(:native_targets).first
+          phase = target.frameworks_build_phase
+          build_file = phase.files.find { |f| f.file_ref.path == 'Pods.framework' }
+          build_file.settings = { 'ATTRIBUTES' => %w(Weak) }
+          @target_integrator.integrate!
+          build_file.settings.should.be.nil
+        end
+
         it 'adds references to the Pods static libraries to the Frameworks group' do
           @target_integrator.integrate!
           @target_integrator.send(:user_project)['Frameworks/libPods.a'].should.not.be.nil

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -49,7 +49,7 @@ module Pod
 
         it 'adds references to the Pods static libraries to the Frameworks group' do
           @target_integrator.integrate!
-          @target_integrator.send(:user_project)['Frameworks/libPods.a'].should.not.nil?
+          @target_integrator.send(:user_project)['Frameworks/libPods.a'].should.not.be.nil
         end
 
         it 'adds the libPods static library to the "Link binary with libraries" build phase of each target' do

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -60,6 +60,22 @@ module Pod
           build_file.should.not.be.nil
         end
 
+        it 'adds references to the Pods static framework to the Frameworks group' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          @target_integrator.integrate!
+          @target_integrator.send(:user_project)['Frameworks/Pods.framework'].should.not.be.nil
+        end
+
+        it 'adds the Pods static framework to the "Link binary with libraries" build phase of each target' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          @target_integrator.integrate!
+          target = @target_integrator.send(:native_targets).first
+          phase = target.frameworks_build_phase
+          build_file = phase.files.find { |f| f.file_ref.path == 'Pods.framework' }
+          build_file.should.not.be.nil
+          build_file.settings['ATTRIBUTES'].should == %w(Weak)
+        end
+
         it 'adds a Copy Pods Resources build phase to each target' do
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -56,8 +56,8 @@ module Pod
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.frameworks_build_phase
-          ref = phase.files.find { |f| f.file_ref.path == 'libPods.a' }
-          ref.should.not.be.nil
+          build_file = phase.files.find { |f| f.file_ref.path == 'libPods.a' }
+          build_file.should.not.be.nil
         end
 
         it 'adds a Copy Pods Resources build phase to each target' do


### PR DESCRIPTION
The AggregateTarget is linked to the user target, so that Xcode can find implicit dependencies. As it contains no symbols a user target can reference to, it was safe to weak link it only and not copy it in the app bundle as it would never loaded. By static linking it instead, we can achieve the same and after link-time there will be no trace left. By avoiding weak linking the aggregate target, we can fix some issues with bitcode and AppStore deployment validation, but that needs larger testing and validation with real-world projects.

### Note

There could be one alternative way to fix that all together and make explicit target dependencies happen: when the Pods.xcodeproj and the aggregate targets are generated, the existing UUID of the prior project need to be picked up or they need to be generated deterministicly, so they remain the same.