### PR TITLE
[Project] Remove automatic preprocessor macro named after configuration

### DIFF
--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -230,38 +230,6 @@ module Pod
       podfile_ref
     end
 
-    # Adds a new build configuration to the project and populates it with
-    # default settings according to the provided type.
-    #
-    # @note   This method extends the original Xcodeproj implementation to
-    #         include a preprocessor definition named after the build
-    #         setting. This is done to support the TargetEnvironmentHeader
-    #         specification of Pods available only on certain build
-    #         configurations.
-    #
-    # @param  [String] name
-    #         The name of the build configuration.
-    #
-    # @param  [Symbol] type
-    #         The type of the build configuration used to populate the build
-    #         settings, must be :debug or :release.
-    #
-    # @return [XCBuildConfiguration] The new build configuration.
-    #
-    def add_build_configuration(name, type)
-      build_configuration = super
-      values = ["#{name.gsub(/[^a-zA-Z0-9_]/, '_').sub(/(^[0-9])/, '_\1').upcase}=1"]
-      settings = build_configuration.build_settings
-      definitions = Array(settings['GCC_PREPROCESSOR_DEFINITIONS'])
-      values.each do |value|
-        unless definitions.include?(value)
-          definitions << value
-        end
-      end
-      settings['GCC_PREPROCESSOR_DEFINITIONS'] = definitions
-      build_configuration
-    end
-
     private
 
     # @!group Private helpers

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -228,42 +228,6 @@ module Pod
         f.xc_language_specification_identifier.should == 'xcode.lang.ruby'
         f.path.should == '../Podfile'
       end
-
-      #----------------------------------------#
-
-      describe '#add_build_configuration' do
-        it 'adds a preprocessor definition for build configurations' do
-          configuration = @project.add_build_configuration('Release', :release)
-          settings = configuration.build_settings
-          settings['GCC_PREPROCESSOR_DEFINITIONS'].should.include('RELEASE=1')
-        end
-
-        it "doesn't create invalid preprocessor definitions for configurations" do
-          configuration = @project.add_build_configuration('1 Release-Foo.bar', :release)
-          settings = configuration.build_settings
-          settings['GCC_PREPROCESSOR_DEFINITIONS'].should.include('_1_RELEASE_FOO_BAR=1')
-        end
-
-        it "doesn't duplicate values" do
-          original = @project.build_configuration_list['Debug']
-          original_settings = original.build_settings
-          original_settings['GCC_PREPROCESSOR_DEFINITIONS'].should ==
-            ['DEBUG=1', '$(inherited)']
-
-          configuration = @project.add_build_configuration('Debug', :debug)
-          settings = configuration.build_settings
-          settings['GCC_PREPROCESSOR_DEFINITIONS'].should ==
-            ['DEBUG=1', '$(inherited)']
-        end
-
-        it 'normalizes the name of the configuration' do
-          configuration = @project.add_build_configuration(
-            'My Awesome Configuration', :release)
-          settings = configuration.build_settings
-          settings['GCC_PREPROCESSOR_DEFINITIONS'].should ==
-            ['MY_AWESOME_CONFIGURATION=1']
-        end
-      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
This addresses #4143.

CocoaPods extended the original Xcodeproj behavior when adding a new configuration. A preprocessor definition named after the newly created configuration was automatically configured. This was done to support the TargetEnvironmentHeader specification of Pods available only on certain build configurations. The TargetEnvironmentHeader was removed meanwhile, but that was left.

#### Note:

This has potential to break a lot of pods for debugging, especially those which have relied on the `DEBUG=1` definition.

#### Agreement:

`DEBUG=1` should be kept, additionally all other configuration macros should be prefixed by `POD_CONFIGURATION_`