### PR TITLE
[Sandbox::FileAccessor] Add C++ Sources (.i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Thomas Kollbach](https://github.com/toto)
   [#4130](https://github.com/CocoaPods/CocoaPods/issues/4130)
   
+* C or C++ preprocessor output files with `.i` extension now have their compiler 
+  flags set correctly.  
+  [Andrea Aresu](https://github.com/aaresu/)
 
 ## 0.39.0.beta.4 (2015-09-02)
 

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -8,7 +8,7 @@ module Pod
     #
     class FileAccessor
       HEADER_EXTENSIONS = Xcodeproj::Constants::HEADER_FILES_EXTENSIONS
-      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .c .cc .cxx .cpp .c++ .swift) + HEADER_EXTENSIONS).uniq.freeze
+      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift) + HEADER_EXTENSIONS).uniq.freeze
 
       GLOB_PATTERNS = {
         :readme              => 'readme{*,.*}'.freeze,

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -237,7 +237,7 @@ module Pod
           file_patterns = ['Classes/*.{h,m,d}', 'Vendor', 'framework/Source/*.h']
           options = {
             :exclude_patterns => ['Classes/**/osx/**/*', 'Resources/**/osx/**/*'],
-            :dir_pattern => '*{.m,.mm,.c,.cc,.cxx,.cpp,.c++,.swift,.h,.hh,.hpp,.ipp,.tpp}',
+            :dir_pattern => '*{.m,.mm,.i,.c,.cc,.cxx,.cpp,.c++,.swift,.h,.hh,.hpp,.ipp,.tpp}',
             :include_dirs => false,
           }
           @spec.exclude_files = options[:exclude_patterns]


### PR DESCRIPTION
Added file extension '.i' (output of the C or C++ preprocessor) to the list of source file extensions.
It's necessary to set custom compiler flags for these files.

Example of pod that contains these files and sets custom compiler flags: https://github.com/CocoaPods/Specs/blob/master/Specs/glues/1.5/glues.podspec.json