### PR TITLE
[Resolver] Give a meaningful message for the case where there is no stable version for a pod, and user do not explicitly specify the required version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Use watchsimulator when validating pods with the watchOS platform.  
 * Give a meaningful message for the case where there is no available stable version for a pod,
   and user do not explicitly specify the required version.
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#4197](https://github.com/CocoaPods/CocoaPods/issues/4197)
 
-* Use watchsimulator when validatng PodSpecs with watchOS compatibility.  
+* Use watchsimulator when validating pods with the watchOS platform.
   [Thomas Kollbach](https://github.com/toto)
   [#4130](https://github.com/CocoaPods/CocoaPods/issues/4130)
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 ##### Bug Fixes
 
 * Use watchsimulator when validating pods with the watchOS platform.  
+* Give a meaningful message for the case where there is no available stable version for a pod,
+  and user do not explicitly specify the required version.
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#4197](https://github.com/CocoaPods/CocoaPods/issues/4197)
+
+* Use watchsimulator when validatng PodSpecs with watchOS compatibility.  
   [Thomas Kollbach](https://github.com/toto)
   [#4130](https://github.com/CocoaPods/CocoaPods/issues/4130)
   

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -383,7 +383,12 @@ module Pod
               'version requirement to your Podfile ' \
               "(e.g. `pod '#{name}', '#{lockfile_reqs.map(&:requirement).join("', '")}'`) " \
               "or revert to a stable version by running `pod update #{name}`."
-          elsif (conflict.possibility && conflict.possibility.version.prerelease?) && (conflict.requirement && !(conflict.requirement.prerelease? || conflict.requirement.external_source || conflict.requirement.head?))
+          elsif (conflict.possibility && conflict.possibility.version.prerelease?) &&
+              (conflict.requirement && !(
+              conflict.requirement.prerelease? ||
+              conflict.requirement.external_source ||
+              conflict.requirement.head?)
+              )
               # Conflict was caused by not specifying an explicit version for the requirement #[name],
               # and there is no available stable version for the requirement.
               message = "There is no corresponding stable version for `#{name}`. " \

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -383,6 +383,11 @@ module Pod
               'version requirement to your Podfile ' \
               "(e.g. `pod '#{name}', '#{lockfile_reqs.map(&:requirement).join("', '")}'`) " \
               "or revert to a stable version by running `pod update #{name}`."
+          elsif (conflict.possibility && conflict.possibility.version.prerelease?) && (conflict.requirement && !(conflict.requirement.prerelease? || conflict.requirement.external_source || conflict.requirement.head?))
+              # Conflict was caused by not specifying an explicit version for the requirement #[name],
+              # and there is no available stable version for the requirement.
+              message = "There is no corresponding stable version for `#{name}`. " \
+              "You should explicitly specify the version in order to install a pre-release version of `#{name}`"
           elsif !conflict.existing
             conflict.requirements.values.flatten.each do |r|
               unless search_for(r).empty?

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -389,10 +389,10 @@ module Pod
               conflict.requirement.external_source ||
               conflict.requirement.head?)
               )
-              # Conflict was caused by not specifying an explicit version for the requirement #[name],
-              # and there is no available stable version for the requirement.
-              message = "There is no corresponding stable version for `#{name}`. " \
-              "You should explicitly specify the version in order to install a pre-release version of `#{name}`"
+            # Conflict was caused by not specifying an explicit version for the requirement #[name],
+            # and there is no available stable version for the requirement.
+            message = "There is no corresponding stable version for `#{name}`. " \
+            "You should explicitly specify the version in order to install a pre-release version of `#{name}`"
           elsif !conflict.existing
             conflict.requirements.values.flatten.each do |r|
               unless search_for(r).empty?

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -390,9 +390,14 @@ module Pod
               conflict.requirement.head?)
               )
             # Conflict was caused by not specifying an explicit version for the requirement #[name],
-            # and there is no available stable version for the requirement.
-            message = "There is no corresponding stable version for `#{name}`. " \
-            "You should explicitly specify the version in order to install a pre-release version of `#{name}`"
+            # and there is no available stable version satisfying constraints for the requirement.
+            message = "There are only pre-release versions available satisfying the following requirements:\n"
+            conflict.requirements.values.flatten.each do |r|
+              unless search_for(r).empty?
+                message << "\n\t'#{name}', '#{r.requirement}'\n"
+              end
+            end
+            message << "\nYou should explicitly specify the version in order to install a pre-release version"
           elsif !conflict.existing
             conflict.requirements.values.flatten.each do |r|
               unless search_for(r).empty?

--- a/spec/fixtures/spec-repos/test_repo/PrereleaseMonkey/1.0-alpha1/PrereleaseMonkey.podspec
+++ b/spec/fixtures/spec-repos/test_repo/PrereleaseMonkey/1.0-alpha1/PrereleaseMonkey.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name             = "PrereleaseMonkey"
+  s.version          = "1.0-alpha1"
+  s.author           = { "Funky Monkey" => "funky@monkey.local" }
+  s.summary          = "🙈🙉🙊"
+  s.description      = "See no evil! Hear no evil! Speak no evil!"
+  s.homepage         = "http://httpbin.org/html"
+  s.source           = { :git => "http://monkey.local/monkey.git", :tag => s.version.to_s }
+  s.license          = 'MIT'
+  s.vendored_library = 'monkey.a'
+end

--- a/spec/fixtures/spec-repos/test_repo/PrereleaseMonkey/1.0-beta1/PrereleaseMonkey.podspec
+++ b/spec/fixtures/spec-repos/test_repo/PrereleaseMonkey/1.0-beta1/PrereleaseMonkey.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name             = "PrereleaseMonkey"
+  s.version          = "1.0-beta1"
+  s.author           = { "Funky Monkey" => "funky@monkey.local" }
+  s.summary          = "🙈🙉🙊"
+  s.description      = "See no evil! Hear no evil! Speak no evil!"
+  s.homepage         = "http://httpbin.org/html"
+  s.source           = { :git => "http://monkey.local/monkey.git", :tag => s.version.to_s }
+  s.license          = 'MIT'
+  s.vendored_library = 'monkey.a'
+end

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -642,15 +642,28 @@ module Pod
         specs.should == ['AFNetworking (1.2.1)']
       end
 
-      it 'raises when there is no explicit version specified and there are only pre-release versions' do
+      it 'raises when no constraints are specified and only pre-release versions are available' do
         podfile = Podfile.new do
           platform :ios
           pod 'PrereleaseMonkey'
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
         e = lambda { resolver.resolve }.should.raise Informative
-        e.message.should.match(/There is no corresponding stable version for `PrereleaseMonkey`/)
-        e.message.should.match(/You should explicitly specify the version in order to install a pre-release version of `PrereleaseMonkey`/)
+        e.message.should.match(/There are only pre-release versions available satisfying the following requirements/)
+        e.message.should.match(/PrereleaseMonkey.*>= 0/)
+        e.message.should.match(/You should explicitly specify the version in order to install a pre-release version/)
+      end
+
+      it 'raises when no explicit version is specified and only pre-release versions satisfy constraints' do
+        podfile = Podfile.new do
+          platform :ios
+          pod 'AFNetworking', '< 1.0', '> 0.10.1'
+        end
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        e = lambda { resolver.resolve }.should.raise Informative
+        e.message.should.match(/There are only pre-release versions available satisfying the following requirements/)
+        e.message.should.match(/AFNetworking.*< 1\.0, > 0\.10\.1/)
+        e.message.should.match(/You should explicitly specify the version in order to install a pre-release version/)
       end
 
       it 'resolves when there is explicit pre-release version specified and there are only pre-release versions' do

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -641,6 +641,27 @@ module Pod
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.2.1)']
       end
+
+      it 'raises when there is no explicit version specified and there are only pre-release versions' do
+        podfile = Podfile.new do
+          platform :ios
+          pod 'PrereleaseMonkey'
+        end
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        e = lambda { resolver.resolve }.should.raise Informative
+        e.message.should.match(/There is no corresponding stable version for `PrereleaseMonkey`/)
+        e.message.should.match(/You should explicitly specify the version in order to install a pre-release version of `PrereleaseMonkey`/)
+      end
+
+      it 'resolves when there is explicit pre-release version specified and there are only pre-release versions' do
+        podfile = Podfile.new do
+          platform :ios
+          pod 'PrereleaseMonkey', '1.0-beta1'
+        end
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        specs = resolver.resolve.values.flatten.map(&:to_s).sort
+        specs.should == ['PrereleaseMonkey (1.0-beta1)']
+      end
     end
   end
 end


### PR DESCRIPTION
As stated in #4197, `pod install` and `pod update` commands print wrong error information for the following case:

- There are only pre-release versions available for a pod specified in the Podfile (no stable versions).
- User does not explicitly set a version for the pod. She just uses `pod 'PodName'`

This PR fixes the case by  providing a meaningful error message for the occurring dependency conflict. 

While handling resolver error in `handle_resolver_error` method of `resolver.rb` file, the code will check if the specification that is not satisfying given requirement was a pre-release version, and if the requirement was including any explicit version or source. If spec is a pre-release version, and there is no explicit version or source for the requirement, the code will print a message directing the user to specify pre-release version explicitly like this:

```
[!] There is no corresponding stable version for `PodName`. 
You should explicitly specify the version in order to install a pre-release version of `PodName`
```

However, I'm not fully sure that the proposed check handles all scenarios. A double check from anyone would be appreciated.

Thanks!