### PR TITLE
add CoreData .datamodeld into source files of pod target, so that we may simply add data model as source file

### DIFF
--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -187,7 +187,7 @@ module Pod
           end
         end
       end
-  
+
       def add_datamodels_to_pods_group
         file_accessors.each do |file_accessor|
           file_accessor.path_list.datamodels.each do |model|

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -57,6 +57,7 @@ module Pod
       def refresh_file_accessors
         file_accessors.each do |fa|
           fa.path_list.read_file_system
+          fa.path_list.wrap_xcdatamodeld_as_file
         end
       end
 
@@ -70,6 +71,7 @@ module Pod
       def add_source_files_references
         UI.message '- Adding source files to Pods project' do
           add_file_accessors_paths_to_pods_group(:source_files, nil, true)
+          add_datamodels_to_pods_group
         end
       end
 
@@ -182,6 +184,16 @@ module Pod
           paths.each do |path|
             group = pods_project.group_for_spec(file_accessor.spec.name, group_key)
             pods_project.add_file_reference(path, group, local && reflect_file_system_structure_for_development)
+          end
+        end
+      end
+      
+      def add_datamodels_to_pods_group
+        file_accessors.each do |file_accessor|
+          file_accessor.path_list.datamodels.each do |model|
+            group = pods_project.group_for_spec(file_accessor.spec.name, nil)
+            UI.message "- Adding data model #{model}"
+            pods_project.add_file_reference(model, group, false)
           end
         end
       end

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -187,7 +187,7 @@ module Pod
           end
         end
       end
-      
+  
       def add_datamodels_to_pods_group
         file_accessors.each do |file_accessor|
           file_accessor.path_list.datamodels.each do |model|

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -57,12 +57,12 @@ module Pod
         @datamodels.map do |bundle_dir|
           left_files = left_files.reject { |sub_file| sub_file.include?(bundle_dir) }
           left_dirs = left_dirs.reject { |sub_dir| sub_dir.include?(bundle_dir) && sub_dir.length > bundle_dir.length }
-          end
-          @files = left_files
-          @dirs = left_dirs
-
-          @datamodels = @datamodels.map { |d| "#{root}/" + d }
         end
+        @files = left_files
+        @dirs = left_dirs
+
+        @datamodels = @datamodels.map { |d| "#{root}/" + d }
+      end
 
       # @return [void] Reads the file system and populates the files and paths
       #         lists.

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -40,6 +40,32 @@ module Pod
         @dirs
       end
 
+      def datamodels
+          @datamodels
+        end
+        
+        # @return [void] the .xcdatamodeld internals are already exposed by Dir.glob,
+        # it should be take as a file so that it can be added to project as a source file.
+        #
+        def wrap_xcdatamodeld_as_file
+          @datamodels = @dirs.select { |d| (d =~ /\.xcdatamodeld$/) != nil }
+          return unless @datamodels.count > 0
+  
+          #files/dirs under that dir had been globbed, remove them
+          left_files = @files
+          left_dirs = @dirs
+          @datamodels.map do |bundle_dir|
+            left_files = left_files.reject { |sub_file| sub_file.include?(bundle_dir) }
+            left_dirs = left_dirs.reject { |sub_dir| 
+              sub_dir.include?(bundle_dir) && sub_dir.length > bundle_dir.length
+            }
+          end
+          @files = left_files
+          @dirs = left_dirs
+          
+          @datamodels = @datamodels.map { |d| "#{root}/"+d }
+        end
+
       # @return [void] Reads the file system and populates the files and paths
       #         lists.
       #

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -13,7 +13,10 @@ module Pod
       # @return [Pathname] The root of the list whose files and directories
       #         are used to perform the matching operations.
       #
-      attr_accessor :root, :datamodel
+      attr_accessor :root
+
+      # @return [Absolutepathname] The list of .xcdatamodeld bundles in source files
+      attr_accessor :datamodels
 
       # Initialize a new instance
       #
@@ -22,6 +25,7 @@ module Pod
       def initialize(root)
         @root = root
         @glob_cache = {}
+        @datamodels = []
       end
 
       # @return [Array<String>] The list of absolute the path of all the files

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -13,7 +13,7 @@ module Pod
       # @return [Pathname] The root of the list whose files and directories
       #         are used to perform the matching operations.
       #
-      attr_accessor :root
+      attr_accessor :root, :datamodel
 
       # Initialize a new instance
       #
@@ -40,30 +40,24 @@ module Pod
         @dirs
       end
 
-      def datamodels
-          @datamodels
-        end
-        
-        # @return [void] the .xcdatamodeld internals are already exposed by Dir.glob,
-        # it should be take as a file so that it can be added to project as a source file.
-        #
-        def wrap_xcdatamodeld_as_file
-          @datamodels = @dirs.select { |d| (d =~ /\.xcdatamodeld$/) != nil }
-          return unless @datamodels.count > 0
-  
-          #files/dirs under that dir had been globbed, remove them
-          left_files = @files
-          left_dirs = @dirs
-          @datamodels.map do |bundle_dir|
-            left_files = left_files.reject { |sub_file| sub_file.include?(bundle_dir) }
-            left_dirs = left_dirs.reject { |sub_dir| 
-              sub_dir.include?(bundle_dir) && sub_dir.length > bundle_dir.length
-            }
+      # @return [void] the .xcdatamodeld internals are already exposed by Dir.glob,
+      # it should be take as a file so that it can be added to project as a source file.
+      #
+      def wrap_xcdatamodeld_as_file
+        @datamodels = @dirs.select { |d| !(d =~ /\.xcdatamodeld$/).nil? }
+        return unless @datamodels.count > 0
+
+        # files/dirs under that dir had been globbed, remove them
+        left_files = @files
+        left_dirs = @dirs
+        @datamodels.map do |bundle_dir|
+          left_files = left_files.reject { |sub_file| sub_file.include?(bundle_dir) }
+          left_dirs = left_dirs.reject { |sub_dir| sub_dir.include?(bundle_dir) && sub_dir.length > bundle_dir.length }
           end
           @files = left_files
           @dirs = left_dirs
-          
-          @datamodels = @datamodels.map { |d| "#{root}/"+d }
+
+          @datamodels = @datamodels.map { |d| "#{root}/" + d }
         end
 
       # @return [void] Reads the file system and populates the files and paths


### PR DESCRIPTION
Currently, we may add .datamodeld as source file, it will be downloaded during pod installation. But it will not be added to Pod's compiling list. This simple change just add it back.

BTW, I feel there may be a better way to integrate the logic, I just spend about one half day to learn ruby, read the source code and test the patch, far away from understanding file_accessor totally. Let me know if the feeling is right.