### PR TITLE
Remove SDKROOT relative search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   flags set correctly.  
   [Andrea Aresu](https://github.com/aaresu/)
 
+* Remove SDKROOT relative search path as it isn't needed anymore since XCTest.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#4219](https://github.com/CocoaPods/CocoaPods/issues/4219)
+
+
 ## 0.39.0.beta.4 (2015-09-02)
 
 ##### Bug Fixes

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -74,7 +74,7 @@ module Pod
           xcconfig.libraries.merge(consumer.libraries)
           xcconfig.frameworks.merge(consumer.frameworks)
           xcconfig.weak_frameworks.merge(consumer.weak_frameworks)
-          add_developers_frameworks_if_needed(xcconfig, consumer.platform_name)
+          add_developers_frameworks_if_needed(xcconfig)
         end
 
         # Configures the given Xcconfig with the build settings for the given
@@ -183,17 +183,12 @@ module Pod
         #
         # @return [void]
         #
-        def self.add_developers_frameworks_if_needed(xcconfig, platform)
+        def self.add_developers_frameworks_if_needed(xcconfig)
           matched_frameworks = xcconfig.frameworks & %w(XCTest SenTestingKit)
           unless matched_frameworks.empty?
             search_paths = xcconfig.attributes['FRAMEWORK_SEARCH_PATHS'] ||= ''
             search_paths_to_add = []
             search_paths_to_add << '$(inherited)'
-            if platform == :ios || platform == :watchos
-              search_paths_to_add << '"$(SDKROOT)/Developer/Library/Frameworks"'
-            else
-              search_paths_to_add << '"$(DEVELOPER_LIBRARY_DIR)/Frameworks"'
-            end
             frameworks_path = '"$(PLATFORM_DIR)/Developer/Library/Frameworks"'
             search_paths_to_add << frameworks_path
             search_paths_to_add.each do |search_path|

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -47,14 +47,6 @@ module Pod
             @xcconfig.to_hash['OTHER_LDFLAGS'].should.include('-weak_framework "iAd"')
           end
 
-          it 'includes the developer frameworks search paths when SenTestingKit is detected' do
-            @spec.xcconfig = { 'OTHER_LDFLAGS' => '-no_compact_unwind' }
-            @spec.frameworks = ['SenTestingKit']
-            xcconfig = @generator.generate
-            framework_search_paths = xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS']
-            framework_search_paths.should.include('$(SDKROOT)/Developer')
-          end
-
           it 'does not configure the project to load all members that implement Objective-c classes or categories from the static library' do
             @xcconfig.to_hash['OTHER_LDFLAGS'].should.not.include '-ObjC'
           end

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -99,7 +99,7 @@ module Pod
               :platform_name => :ios,
             )
             @sut.add_spec_build_settings_to_xcconfig(consumer, xcconfig)
-            xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('SDKROOT')
+            xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('SDKROOT')
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('DEVELOPER_LIBRARY_DIR')
           end
 
@@ -113,7 +113,7 @@ module Pod
               :platform_name => :osx,
             )
             @sut.add_spec_build_settings_to_xcconfig(consumer, xcconfig)
-            xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('DEVELOPER_LIBRARY_DIR')
+            xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('DEVELOPER_LIBRARY_DIR')
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('SDKROOT')
           end
         end
@@ -165,34 +165,22 @@ module Pod
         describe '::add_developers_frameworks_if_needed' do
           it 'adds the developer frameworks search paths to the xcconfig if SenTestingKit has been detected' do
             xcconfig = Xcodeproj::Config.new('OTHER_LDFLAGS' => '-framework SenTestingKit')
-            @sut.add_developers_frameworks_if_needed(xcconfig, :ios)
+            @sut.add_developers_frameworks_if_needed(xcconfig)
             frameworks_search_paths = xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS']
             frameworks_search_paths.should.include?('$(inherited)')
-            frameworks_search_paths.should.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
+            frameworks_search_paths.should.not.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
             frameworks_search_paths.should.not.include?('"$(DEVELOPER_LIBRARY_DIR)/Frameworks"')
           end
 
           it 'adds the developer frameworks search paths to the xcconfig if XCTest has been detected' do
             xcconfig = Xcodeproj::Config.new('OTHER_LDFLAGS' => '-framework XCTest')
-            @sut.add_developers_frameworks_if_needed(xcconfig, :ios)
+            @sut.add_developers_frameworks_if_needed(xcconfig)
             frameworks_search_paths = xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS']
             frameworks_search_paths.should.include?('$(inherited)')
-            frameworks_search_paths.should.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
+            frameworks_search_paths.should.not.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
             frameworks_path = '"$(PLATFORM_DIR)/Developer/Library/Frameworks"'
             frameworks_search_paths.should.include?(frameworks_path)
             frameworks_search_paths.should.not.include?('"$(DEVELOPER_LIBRARY_DIR)/Frameworks"')
-          end
-
-          it "doesn't adds the developer frameworks relative to the SDK for OS X" do
-            xcconfig = Xcodeproj::Config.new('OTHER_LDFLAGS' => '-framework XCTest')
-            @sut.add_developers_frameworks_if_needed(xcconfig, :ios)
-            frameworks_search_paths = xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS']
-            frameworks_search_paths.should.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
-
-            xcconfig = Xcodeproj::Config.new('OTHER_LDFLAGS' => '-framework XCTest')
-            @sut.add_developers_frameworks_if_needed(xcconfig, :osx)
-            frameworks_search_paths = xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS']
-            frameworks_search_paths.should.not.include?('"$(SDKROOT)/Developer/Library/Frameworks"')
           end
         end
 


### PR DESCRIPTION
This was causing warnings with the iOS 9 SDK as this path doesn't even exist anymore and seemingly wasn't needed since XCTest came along.

Fixes #4168