### PR TITLE
Remove copying of Swift runtime libraries

### DIFF
--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -78,15 +78,6 @@ module Pod
 
             # Resign the code if required by the build settings to avoid unstable apps
             code_sign_if_enabled "${destination}/$(basename "$1")"
-
-            # Embed linked Swift runtime libraries
-            local swift_runtime_libs
-            swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\\\/\\(.+dylib\\).*/\\\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
-            for lib in $swift_runtime_libs; do
-              echo "rsync -auv \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
-              rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
-              code_sign_if_enabled "${destination}/${lib}"
-            done
           }
 
           # Signs a framework with the provided identity


### PR DESCRIPTION
Fixes `Invalid Swift Support` error when uploading to iTunes Connect with Xcode 7. See #4188.

I'm not sure if this breaks non-Xcode 7 builds.  Someone should definitely test this more.  This fix is working great for me, but I'm not sure if it's the appropriate solution for all projects.  (Will some projects be missing the necessary Swift runtime libraries?  Why does this work?  Does Xcode 7 handle copying the Swift runtime libraries now?)