### PR TITLE
Changes search index format to fasten `pod search --full` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Improve `pod search` performance while using _`--full`_ flag  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [cocoapods-search#8](https://github.com/CocoaPods/cocoapods-search/issues/8)
+  
 * Improve message when there is no spec in repos for dependency set in Podfile.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#4430](https://github.com/CocoaPods/CocoaPods/issues/4430)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 8dcb8cbb3694102b1b391d4c0dd483339f9e5064
+  revision: d66fcb7160f060198c3808eb2ff3f51edf212687
   branch: master
   specs:
     cocoapods-core (0.39.0)
@@ -49,7 +49,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-search.git
-  revision: b85d8a86a08b9d30cd6d4b2c156bae5215f74c12
+  revision: 4e7de92e477f47918d869a7c4819251633efca0d
   branch: master
   specs:
     cocoapods-search (0.1.0)

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -274,7 +274,7 @@ module Pod
     # @return [Pathname] The file to use to cache the search data.
     #
     def search_index_file
-      cache_root + 'search_index.yaml'
+      cache_root + 'search_index.json'
     end
 
     private

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -114,7 +114,7 @@ module Pod
       #
       def search_by_name(query, full_text_search = false)
         if full_text_search
-          query_word_regexps = query.split.map{ |word| /#{word}/i }
+          query_word_regexps = query.split.map { |word| /#{word}/i }
           query_word_results_hash = {}
           updated_search_index.each_value do |word_spec_hash|
             word_spec_hash.each_pair do |word, spec_symbols|
@@ -161,7 +161,7 @@ module Pod
           unless index[source_name]
             UI.print "Creating search index for spec repo '#{source_name}'.."
             index[source_name] = aggregate.generate_search_index_for_source(source)
-            UI.puts " Done!"
+            UI.puts ' Done!'
           end
         end
         save_search_index(index)
@@ -216,6 +216,7 @@ module Pod
       # Update is performed incrementally. Only the changed pods' search data is re-generated and updated.
       # @param  [Hash{Source => Array<String>}] changed_spec_paths
       #                  A hash containing changed specification paths for each source.
+      #
       def update_search_index_if_needed(changed_spec_paths)
         search_index = stored_search_index
         return unless search_index
@@ -242,6 +243,9 @@ module Pod
       end
 
       # Updates search index for changed pods in background
+      # @param  [Hash{Source => Array<String>}] changed_spec_paths
+      #                  A hash containing changed specification paths for each source.
+      #
       def update_search_index_if_needed_in_background(changed_spec_paths)
         Process.fork do
           Process.daemon
@@ -540,15 +544,13 @@ module Pod
     executable :git
 
     def update_git_repo(show_output = false)
-      begin
-        output = git! %w(pull --ff-only)
-        UI.puts output if show_output
-      rescue
-        UI.warn 'CocoaPods was not able to update the ' \
-                  "`#{name}` repo. If this is an unexpected issue " \
-                  'and persists you can inspect it running ' \
-                  '`pod repo update --verbose`'
-      end
+      output = git! %w(pull --ff-only)
+      UI.puts output if show_output
+    rescue
+      UI.warn 'CocoaPods was not able to update the ' \
+                "`#{name}` repo. If this is an unexpected issue " \
+                'and persists you can inspect it running ' \
+                '`pod repo update --verbose`'
     end
   end
 end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -531,4 +531,21 @@ module Pod
       end
     end
   end
+
+  class Source
+    extend Executable
+    executable :git
+
+    def update_git_repo(show_output = false)
+      begin
+        output = git! %w(pull --ff-only)
+        UI.puts output if show_output
+      rescue
+        UI.warn 'CocoaPods was not able to update the ' \
+                  "`#{name}` repo. If this is an unexpected issue " \
+                  'and persists you can inspect it running ' \
+                  '`pod repo update --verbose`'
+      end
+    end
+  end
 end

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -19,6 +19,7 @@ module Pod
         `git fetch -q`
         `git branch --set-upstream-to=origin/master master`
       end
+      SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
       lambda { command('repo', 'update').run }.should.not.raise
     end
 
@@ -27,6 +28,12 @@ module Pod
       repo2 = repo_clone('repo1', 'repo2')
       repo_make_readme_change(repo1, 'Updated')
       Dir.chdir(repo1) { `git commit -a -m "Update"` }
+      SourcesManager.expects(:update_search_index_if_needed_in_background).with() { |value|
+        value.each_pair { |source, paths|
+          source.name.should == 'repo2'
+          paths.should == ['README']
+        }
+      }
       run_command('repo', 'update', 'repo2')
       (repo2 + 'README').read.should.include 'Updated'
     end

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -28,12 +28,12 @@ module Pod
       repo2 = repo_clone('repo1', 'repo2')
       repo_make_readme_change(repo1, 'Updated')
       Dir.chdir(repo1) { `git commit -a -m "Update"` }
-      SourcesManager.expects(:update_search_index_if_needed_in_background).with() { |value|
-        value.each_pair { |source, paths|
+      SourcesManager.expects(:update_search_index_if_needed_in_background).with do |value|
+        value.each_pair do |source, paths|
           source.name.should == 'repo2'
           paths.should == ['README']
-        }
-      }
+        end
+      end
       run_command('repo', 'update', 'repo2')
       (repo2 + 'README').read.should.include 'Updated'
     end

--- a/spec/spec_helper/pre_flight.rb
+++ b/spec/spec_helper/pre_flight.rb
@@ -28,7 +28,7 @@ module Bacon
       SpecHelper.temporary_directory.mkpath
 
       # TODO
-      ::Pod::SourcesManager.stubs(:search_index_path).returns(temporary_directory + 'search_index.yaml')
+      ::Pod::SourcesManager.stubs(:search_index_path).returns(temporary_directory + 'search_index.json')
 
       old_run_requirement.bind(self).call(description, spec)
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -161,7 +161,7 @@ module Pod
       end
 
       it 'returns the search index file' do
-        @config.search_index_file.to_s.should.end_with?('search_index.yaml')
+        @config.search_index_file.to_s.should.end_with?('search_index.json')
       end
     end
 

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -244,14 +244,14 @@ module Pod
       end
 
       it 'updates search index for changed paths if source is updated' do
-        prev_index = {@test_source.name => {}}
+        prev_index = { @test_source.name => {} }
         SourcesManager.expects(:stored_search_index).returns(prev_index)
 
-        SourcesManager.expects(:save_search_index).with() { |value|
+        SourcesManager.expects(:save_search_index).with do |value|
           value[@test_source.name]['BananaLib'].should.include(:BananaLib)
           value[@test_source.name]['JSONKit'].should.include(:JSONKit)
-        }
-        changed_paths = {@test_source => %w(BananaLib/1.0/BananaLib.podspec JSONKit/1.4/JSONKit.podspec)}
+        end
+        changed_paths = { @test_source => %w(BananaLib/1.0/BananaLib.podspec JSONKit/1.4/JSONKit.podspec) }
         SourcesManager.update_search_index_if_needed(changed_paths)
       end
 
@@ -259,10 +259,10 @@ module Pod
         prev_index = {}
         SourcesManager.expects(:stored_search_index).returns(prev_index)
 
-        SourcesManager.expects(:save_search_index).with() { |value|
+        SourcesManager.expects(:save_search_index).with do |value|
           value[@test_source.name].should.be.nil
-        }
-        changed_paths = {@test_source => %w(BananaLib/1.0/BananaLib.podspec JSONKit/1.4/JSONKit.podspec)}
+        end
+        changed_paths = { @test_source => %w(BananaLib/1.0/BananaLib.podspec JSONKit/1.4/JSONKit.podspec) }
         SourcesManager.update_search_index_if_needed(changed_paths)
       end
 

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -232,6 +232,13 @@ module Pod
         UI.output.should.match /is up to date/
       end
 
+      it 'uses the only fast forward git option' do
+        set_up_test_repo_for_update
+        Source.any_instance.expects(:git!).with { |options| options.should.include? '--ff-only' }
+        SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+        SourcesManager.update(test_repo_path.basename.to_s, true)
+      end
+
       it 'prints a warning if the update failed' do
         UI.warnings = ''
         set_up_test_repo_for_update


### PR DESCRIPTION
Detailed discussion can be found here: CocoaPods/cocoapods-search#8 
- Previous implementation was having the drawback of traversing and performing `gsub` on all index strings for each pod specification.
- New implementation stores words as keys and list of pods containing corresponding word inside their specification as the values for corresponding hash keys. Therefore, while searching for a query, we only need to check if query is matched with any key in index hash, if so, we will add corresponding list of spec names to a Set object. Resulted Set object gives us the search result. Using this policy, sources manager can perform a faster search operation.