### PR TITLE
[EmbedFrameworksScript] Only manually copy swift runtime libs in Xcode 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   appropriate.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* The embed frameworks script will no longer manually copy over the Swift
+  runtime libraries on Xcode 7 and later.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [earltedly](https://github.com/segiddins)
+  [DJ Tarazona](https://github.com/djtarazona)
+  [#4188](https://github.com/CocoaPods/CocoaPods/issues/4188)
+
 ##### Bug Fixes
 
 * Give a meaningful message for the case where there is no available stable version for a pod,

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -79,14 +79,16 @@ module Pod
             # Resign the code if required by the build settings to avoid unstable apps
             code_sign_if_enabled "${destination}/$(basename "$1")"
 
-            # Embed linked Swift runtime libraries
-            local swift_runtime_libs
-            swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\\\/\\(.+dylib\\).*/\\\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
-            for lib in $swift_runtime_libs; do
-              echo "rsync -auv \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
-              rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
-              code_sign_if_enabled "${destination}/${lib}"
-            done
+            # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
+            if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then
+              local swift_runtime_libs
+              swift_runtime_libs=$(xcrun otool -LX "$binary" | grep --color=never @rpath/libswift | sed -E s/@rpath\\\\/\\(.+dylib\\).*/\\\\1/g | uniq -u  && exit ${PIPESTATUS[0]})
+              for lib in $swift_runtime_libs; do
+                echo "rsync -auv \\"${SWIFT_STDLIB_PATH}/${lib}\\" \\"${destination}\\""
+                rsync -auv "${SWIFT_STDLIB_PATH}/${lib}" "${destination}"
+                code_sign_if_enabled "${destination}/${lib}"
+              done
+            fi
           }
 
           # Signs a framework with the provided identity


### PR DESCRIPTION
Successor to https://github.com/CocoaPods/CocoaPods/pull/4221.

Closes https://github.com/CocoaPods/CocoaPods/issues/4188.

\c @neonichu @orta @samdmarshall 