### PR TITLE
[XCConfig Helper] Add dependency target vendored libs and frameworks to build settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#4124](https://github.com/CocoaPods/CocoaPods/issues/4124)
 
-* Support for adding dependency target vendored libraries and frameworks to build settings.
+* Support for adding dependency target vendored libraries and frameworks to build settings.  
   [Kevin Coleman](https://github.com/kcoleman731)
+  [#4278](https://github.com/CocoaPods/CocoaPods/pull/4278)
   
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#4124](https://github.com/CocoaPods/CocoaPods/issues/4124)
 
+* Support for adding dependency target vendored libraries and frameworks to build settings.
+  [Kevin Coleman](https://github.com/kcoleman731)
+  
 ##### Bug Fixes
 
 * Give a meaningful message for the case where there is no available stable

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -43,7 +43,6 @@ module Pod
           target_search_paths = target.build_headers.search_paths(target.platform)
           sandbox_search_paths = target.sandbox.public_headers.search_paths(target.platform)
           search_paths = target_search_paths.concat(sandbox_search_paths).uniq
-          framework_search_paths = target.dependent_targets.flat_map(&:file_accessors).flat_map(&:vendored_frameworks).map { |fw| '${PODS_ROOT}/' << fw.dirname.relative_path_from(target.sandbox.root).to_s }
 
           config = {
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),
@@ -51,7 +50,7 @@ module Pod
             'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(search_paths),
             'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1',
             'SKIP_INSTALL' => 'YES',
-            'FRAMEWORK_SEARCH_PATHS' => '$(inherited) ' << XCConfigHelper.quote(framework_search_paths)
+            'FRAMEWORK_SEARCH_PATHS' => '$(inherited) '
             # 'USE_HEADERMAP' => 'NO'
           }
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -65,7 +65,7 @@ module Pod
         #        The xcconfig to edit.
         #
         def self.add_vendored_dependency_build_settings(target, xcconfig)
-          if target.host_requires_frameworks?
+          if target.requires_frameworks?
             target.dependent_targets.each do |dependent_target|
               XCConfigHelper.add_vendored_dependency_build_settings(dependent_target, xcconfig)
             end

--- a/spec/fixtures/monkey/monkey.podspec
+++ b/spec/fixtures/monkey/monkey.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "http://monkey.local/monkey.git", :tag => s.version.to_s }
   s.license          = 'MIT'
   s.vendored_library = 'monkey.a'
+  #s.ios.vendored_framework = "monkey.framework"
   s.public_header_files = 'monkey.h'
 end

--- a/spec/fixtures/monkey/monkey.podspec
+++ b/spec/fixtures/monkey/monkey.podspec
@@ -8,6 +8,5 @@ Pod::Spec.new do |s|
   s.source           = { :git => "http://monkey.local/monkey.git", :tag => s.version.to_s }
   s.license          = 'MIT'
   s.vendored_library = 'monkey.a'
-  #s.ios.vendored_framework = "monkey.framework"
   s.public_header_files = 'monkey.h'
 end

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -127,7 +127,7 @@ module Pod
             @sut.add_framework_build_settings(framework_path, xcconfig, config.sandbox.root)
             hash_config = xcconfig.to_hash
             hash_config['OTHER_LDFLAGS'].should == '-framework "Parse"'
-            hash_config['FRAMEWORK_SEARCH_PATHS'].should == '"$(PODS_ROOT)/Parse"'
+            hash_config['FRAMEWORK_SEARCH_PATHS'].should == '"${PODS_ROOT}/Parse"'
           end
 
           it "doesn't override existing linker flags" do
@@ -143,7 +143,7 @@ module Pod
             xcconfig = Xcodeproj::Config.new('FRAMEWORK_SEARCH_PATHS' => '"path/to/frameworks"')
             @sut.add_framework_build_settings(framework_path, xcconfig, config.sandbox.root)
             hash_config = xcconfig.to_hash
-            hash_config['FRAMEWORK_SEARCH_PATHS'].should == '"path/to/frameworks" "$(PODS_ROOT)/Parse"'
+            hash_config['FRAMEWORK_SEARCH_PATHS'].should == '"path/to/frameworks" "${PODS_ROOT}/Parse"'
           end
         end
 
@@ -156,7 +156,7 @@ module Pod
             @sut.add_library_build_settings(path, xcconfig, config.sandbox.root)
             hash_config = xcconfig.to_hash
             hash_config['OTHER_LDFLAGS'].should == '-l"Proj4"'
-            hash_config['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "$(PODS_ROOT)/MapBox/Proj4"'
+            hash_config['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/MapBox/Proj4"'
           end
         end
 


### PR DESCRIPTION
🌈 :thumbsup: 

This pull requests adds support for recursively processing `dependent_targets` to ensure that all `vendored_frameworks` and `vendored_libraries` are included in the target's build settings. This is only done if `use_frameworks` is specified.  
