### PR TITLE
Integrate Code of Covenant 1.2.0 changes

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 We expect everyone to follow these rules anywhere in the CocoaPods project’s codebases, issue trackers, IRC channel, group chat, and mailing lists.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+This code of conduct applies both within project spaces and in public spaces when an individual is actively representing the project or its community. Due to their strong association with the project, core contributors are always seen as actively representing it.
 
 Finally, don't forget that it is human to make mistakes! We all do. Let’s work together to help each other, resolve issues, and learn from the mistakes that we will all inevitably make from time to time.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,11 +20,13 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 We expect everyone to follow these rules anywhere in the CocoaPods project’s codebases, issue trackers, IRC channel, group chat, and mailing lists.
 
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
 Finally, don't forget that it is human to make mistakes! We all do. Let’s work together to help each other, resolve issues, and learn from the mistakes that we will all inevitably make from time to time.
 
 ### Thanks
 
-Thanks to the [Bundler Code of Conduct](https://github.com/bundler/bundler/blob/e3ce14f5ecd9b729338435c8689553ef209d83aa/CODE_OF_CONDUCT.md), [JSConf Code of Conduct](http://jsconf.com/codeofconduct.html) and [Fedora Code of Conduct](http://fedoraproject.org/code-of-conduct) for inspiration and ideas.
+Thanks to the [Bundler Code of Conduct](https://github.com/bundler/bundler/blob/e3ce14f5ecd9b729338435c8689553ef209d83aa/CODE_OF_CONDUCT.md), [JSConf Code of Conduct](http://jsconf.com/codeofconduct.html), [Fedora Code of Conduct](http://fedoraproject.org/code-of-conduct), and [Contributor Covenant](http:contributor-covenant.org), version 1.1.0 for inspiration and ideas.
 
 ### License
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ Harassment in code and discussion or violation of physical boundaries is complet
 
 ### In detail
 
-Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images, deliberate intimidation, stalking, sustained disruption, and unwelcome sexual attention.
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, sexual images, deliberate intimidation, stalking, sustained disruption, and unwelcome sexual attention.
 
 Individuals asked to stop any harassing behavior are expected to comply immediately.
 
@@ -26,7 +26,7 @@ Finally, don't forget that it is human to make mistakes! We all do. Let’s work
 
 ### Thanks
 
-Thanks to the [Bundler Code of Conduct](https://github.com/bundler/bundler/blob/e3ce14f5ecd9b729338435c8689553ef209d83aa/CODE_OF_CONDUCT.md), [JSConf Code of Conduct](http://jsconf.com/codeofconduct.html), [Fedora Code of Conduct](http://fedoraproject.org/code-of-conduct), and [Contributor Covenant](http:contributor-covenant.org), version 1.1.0 for inspiration and ideas.
+Thanks to the [Bundler Code of Conduct](https://github.com/bundler/bundler/blob/e3ce14f5ecd9b729338435c8689553ef209d83aa/CODE_OF_CONDUCT.md), [JSConf Code of Conduct](http://jsconf.com/codeofconduct.html), [Fedora Code of Conduct](http://fedoraproject.org/code-of-conduct), and [Contributor Covenant](http://contributor-covenant.org), version 1.2.0 for inspiration and ideas.
 
 ### License
 


### PR DESCRIPTION
Supersedes #3705

I have fixed the broken URL and incorporated 1.2.0 changes.

We still have to agree on a wording for when contributors are actively representing the project — I didn't really feel we reached a conclusion in the earlier discussion.

cc @alloy @samdmarshall 