### PR TITLE
[Analyzer] Don't require platform for podless targets when not integrating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#4119](https://github.com/CocoaPods/CocoaPods/issues/4119)
 
+* Don't require the `platform` attribute for targets without any declared pods
+  when running `pod install --no-integrate`.
+  [Sylvain Guillopé](https://github.com/sguillope)
+  [#3151](https://github.com/CocoaPods/CocoaPods/issues/3151)
 
 ## 0.39.0.beta.4 (2015-09-02)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -636,7 +636,7 @@ module Pod
       def verify_platforms_specified!
         unless config.integrate_targets?
           podfile.target_definition_list.each do |target_definition|
-            if target_definition.dependencies.size > 0 && target_definition.platform.nil?
+            if !target_definition.empty? && target_definition.platform.nil?
               raise Informative, 'It is necessary to specify the platform in the Podfile if not integrating.'
             end
           end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -255,7 +255,7 @@ module Pod
           target.client_root = config.installation_root
           target.user_target_uuids = []
           target.user_build_configurations = target_definition.build_configurations || { 'Release' => :release, 'Debug' => :debug }
-          if target_definition.platform.name == :osx
+          if target_definition.platform && target_definition.platform.name == :osx
             target.archs = '$(ARCHS_STANDARD_64_BIT)'
           end
         end
@@ -636,7 +636,7 @@ module Pod
       def verify_platforms_specified!
         unless config.integrate_targets?
           podfile.target_definition_list.each do |target_definition|
-            unless target_definition.platform
+            if target_definition.dependencies.size > 0 && target_definition.platform.nil?
               raise Informative, 'It is necessary to specify the platform in the Podfile if not integrating.'
             end
           end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -221,7 +221,7 @@ module Pod
           config.integrate_targets = false
         end
 
-        it 'does not require a platform for a podless target' do
+        it 'does not require a platform for an empty target' do
           podfile = Pod::Podfile.new do
             source SpecHelper.test_repo_url
             xcodeproj 'SampleProject/SampleProject'
@@ -235,7 +235,21 @@ module Pod
           lambda { analyzer.analyze }.should.not.raise
         end
 
-        it 'raises if a target with pods does not specify a platform' do
+        it 'does not raise if a target with dependencies inherits the platform from its parent' do
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            xcodeproj 'SampleProject/SampleProject'
+            platform :osx
+            target 'TestRunner' do
+              pod 'monkey'
+            end
+          end
+
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          lambda { analyzer.analyze }.should.not.raise
+        end
+
+        it 'raises if a target with dependencies does not have a platform' do
           podfile = Pod::Podfile.new do
             source SpecHelper.test_repo_url
             xcodeproj 'SampleProject/SampleProject'


### PR DESCRIPTION
When running `pod install --no-integrate`, it's not required to validate that the `platform` attribute is specified for targets that don't declare any dependencies.