### PR TITLE
improving the performance of Pod::Installer::Analyzer#generate_pod_targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#4374](https://github.com/CocoaPods/CocoaPods/issues/4374)
 
+* Improving the performance of Pod::Installer::Analyzer#generate_pod_targets
+  [Daniel Ribeiro](https://github.com/danielribeiro)
+  [#4399](https://github.com/CocoaPods/CocoaPods/pull/4399)
+
 ##### Bug Fixes
 
 * Fix a crash in dependency resolution when running Ruby 2.3.  

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -57,13 +57,15 @@ module Pod
       @dependent_targets = []
     end
 
+    # @param [Hash{Array => PodTarget}] cache
+    #        the cached PodTarget for a previously scoped (specs, target_definition)
     # @return [Array<PodTarget>] a scoped copy for each target definition.
     #
     def scoped(cache = {})
       target_definitions.map do |target_definition|
-        cash_key = [specs, target_definition]
-        if cache[cash_key]
-          cache[cash_key]
+        cache_key = [specs, target_definition]
+        if cache[cache_key]
+          cache[cache_key]
         else
           target = PodTarget.new(specs, [target_definition], sandbox, true)
           target.file_accessors = file_accessors
@@ -71,7 +73,7 @@ module Pod
           target.native_target = native_target
           target.archs = archs
           target.dependent_targets = dependent_targets.flat_map { |pt| pt.scoped(cache) }.select { |pt| pt.target_definitions == [target_definition] }
-          cache[cash_key] = target
+          cache[cache_key] = target
         end
       end
     end

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -59,14 +59,19 @@ module Pod
 
     # @return [Array<PodTarget>] a scoped copy for each target definition.
     #
-    def scoped
+    def scoped(cache = {})
       target_definitions.map do |target_definition|
-        PodTarget.new(specs, [target_definition], sandbox, true).tap do |target|
+        cash_key = [specs, target_definition]
+        if cache[cash_key]
+          cache[cash_key]
+        else
+          target = PodTarget.new(specs, [target_definition], sandbox, true)
           target.file_accessors = file_accessors
           target.user_build_configurations = user_build_configurations
           target.native_target = native_target
           target.archs = archs
-          target.dependent_targets = dependent_targets.flat_map(&:scoped).select { |pt| pt.target_definitions == [target_definition] }
+          target.dependent_targets = dependent_targets.flat_map { |pt| pt.scoped(cache)}.select { |pt| pt.target_definitions == [target_definition] }
+          cache[cash_key] = target
         end
       end
     end

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -70,7 +70,7 @@ module Pod
           target.user_build_configurations = user_build_configurations
           target.native_target = native_target
           target.archs = archs
-          target.dependent_targets = dependent_targets.flat_map { |pt| pt.scoped(cache)}.select { |pt| pt.target_definitions == [target_definition] }
+          target.dependent_targets = dependent_targets.flat_map { |pt| pt.scoped(cache) }.select { |pt| pt.target_definitions == [target_definition] }
           cache[cash_key] = target
         end
       end


### PR DESCRIPTION
…, by avoiding computing previously computed dependency trees.

On our cases, this makes what would be a 20min+ `pod install`, back into a 2min (measured with the performance gains described on the https://github.com/CocoaPods/CocoaPods/issues/4374 issue).

This gain is huge for projects with a lot of targets (20+) and pods (100+), when the de-duplication process happens.