### PR TITLE
Fixing rake's Inch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,6 +127,8 @@ begin
     # to be run separately.
     #
     task :all => 'fixture_tarballs:unpack' do
+      # Forcing colored to be included on String before Term::ANSIColor, so that Inch will work correctly.
+      require 'colored'
       ENV['GENERATE_COVERAGE'] = 'true'
       puts "\033[0;32mUsing #{`ruby --version`}\033[0m"
 


### PR DESCRIPTION
Hi,

As it stands, the following error is making PRs fail on Travis: https://travis-ci.org/CocoaPods/CocoaPods/jobs/85140003

![screen shot 2015-10-16 at 1 39 13 pm](https://cloud.githubusercontent.com/assets/148319/10552991/7ad8ef5a-740c-11e5-9322-918fe8c7f98c.png)

The TL;DR for the cause is: Rake requires inch (inch-0.5.10/lib/inch/core_ext/string.rb), which requires Term::ANSIColor, and then it requires clintegracon (clintegracon-0.6.1/lib/CLIntegracon/diff.rb:2), which requires Colored. Since Colored is included after, its 'String#color' method, which has arity 1, is called instead of Term::ANSIColor's, which has arity 2. Hence the error.

This PR avoids it because the second`String.send(:include, Colored)` become an empty operation, since it was called at the very beginning of the tests.