### PR TITLE
Improve repo lint error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#4374](https://github.com/CocoaPods/CocoaPods/issues/4374)
 
-* Improving the performance of Pod::Installer::Analyzer#generate_pod_targets
+* Improving the performance of Pod::Installer::Analyzer#generate_pod_targets  
   [Daniel Ribeiro](https://github.com/danielribeiro)
   [#4399](https://github.com/CocoaPods/CocoaPods/pull/4399)
 
 ##### Bug Fixes
+
+* Improve repo lint error message when no repo found with given name.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#4142](https://github.com/CocoaPods/CocoaPods/issues/4142)
 
 * Fix a crash in dependency resolution when running Ruby 2.3.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/command/repo/lint.rb
+++ b/lib/cocoapods/command/repo/lint.rb
@@ -35,15 +35,16 @@ module Pod
         #
         def run
           if @name
-            dirs = File.exist?(@name) ? [Pathname.new(@name)] : [dir]
+            sources = SourcesManager.sources([@name])
           else
-            dirs = config.repos_dir.children.select(&:directory?)
+            sources = SourcesManager.aggregate.sources
           end
-          dirs.each do |dir|
-            SourcesManager.check_version_information(dir)
-            UI.puts "\nLinting spec repo `#{dir.realpath.basename}`\n".yellow
 
-            validator = Source::HealthReporter.new(dir)
+          sources.each do |source|
+            SourcesManager.check_version_information(source.repo)
+            UI.puts "\nLinting spec repo `#{source.repo.basename}`\n".yellow
+
+            validator = Source::HealthReporter.new(source.repo)
             validator.pre_check do |_name, _version|
               UI.print '.'
             end

--- a/spec/functional/command/repo/lint_spec.rb
+++ b/spec/functional/command/repo/lint_spec.rb
@@ -16,5 +16,12 @@ module Pod
       repo = fixture('spec-repos/test_repo').to_s
       lambda { run_command('repo', 'lint', repo) }.should.not.raise
     end
+
+    it 'raises when there is no repository with given name' do
+      repo = fixture('spec-repos/not_existing_repo').to_s
+      e = lambda { run_command('repo', 'lint', repo) }.should.raise Informative
+      e.message.should.match(/Unable to find a source named/)
+      e.message.should.match(/not_existing_repo/)
+    end
   end
 end


### PR DESCRIPTION
Solves #4142.

When the example command `pod repo lint artsy.podspec` runs, it will print the following message:

```
% poddev repo lint artsy.podspec

Linting spec repo `artsy.podspec`

[!] Unable to find a source named: `artsy.podspec`
```

I did not add another raise check, instead rely on the checks performed in `Source` class. Also used `SourceManager`'s methods to remove duplicate code.