### PR TITLE
Improve message when there is no spec in repos for a given dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Improve message when there is no spec in repos for dependency set in Podfile.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#4430](https://github.com/CocoaPods/CocoaPods/issues/4430)
+
 * Reduce the number of times the user's Xcode project is opened, speeding up
   installation.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -400,7 +400,13 @@ module Pod
             message << "\nYou should explicitly specify the version in order to install a pre-release version"
           elsif !conflict.existing
             conflict.requirements.values.flatten.each do |r|
-              unless search_for(r).empty?
+              if search_for(r).empty?
+                # There is no existing specification inside any of the spec repos with given requirements.
+                message << "\n\nNone of the spec sources contain a spec satisfying the `#{r}` dependency." \
+                  "\nYou have either; mistyped the name or version," \
+                  ' not added the source repo that hosts the Podspec to your Podfile,' \
+                  ' or not got the latest versions of your source repos.'
+              else
                 message << "\n\nSpecs satisfying the `#{r}` dependency were found, " \
                   'but they required a higher minimum deployment target.'
               end

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -405,6 +405,10 @@ module Pod
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/Unable to satisfy the following requirements/)
         e.message.should.match(/`AFNetworking \(= 3.0.1\)` required by `Podfile`/)
+        e.message.should.match(/None of the spec sources contain a spec satisfying the `AFNetworking \(= 3.0.1\)` dependency./)
+        e.message.should.match(/You have either; mistyped the name or version,/)
+        e.message.should.match(/ not added the source repo that hosts the Podspec to your Podfile,/)
+        e.message.should.match(/ or not got the latest versions of your source repos./)
       end
 
       it 'takes into account locked dependencies' do


### PR DESCRIPTION
This solves #4430.

Currently, when there is no existing specification inside any of the spec repos with given requirements, user would get the following error:

```
[!] Unable to satisfy the following requirements:
- `Lib (= 4.0.0)` required by `Podfile`
```

Now, user will get sth like this:

```
[!] Unable to find a specification for the following requirement:

	'Lib', '= 4.0.0'
```

I think this is enough for user to understand that their repo either not up-to-date or there is really no such specification with given dependency.

I actually wanted to use `Molinillo::NoSuchDependencyError` rather manually adding another message, but it's message does not contain name of the dependency, just it's version. 

I'm open to better management suggestions.