### PR TITLE
[xcconfig_helper] Remove the library name's extension when adding it …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#3683](https://github.com/CocoaPods/CocoaPods/issues/3683)
 
+* Remove the library name's extension when adding it in the "linker flags" build setting
+  to support dynamic libraries.
+  [Andrea Cremaschi](https://github.com/andreacremaschi)
+  [#4468][https://github.com/CocoaPods/CocoaPods/issues/4468]
 
 ## 0.39.0 (2015-10-09)
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -153,7 +153,8 @@ module Pod
         #         The path retrieved from Sandbox#root.
         #
         def self.add_library_build_settings(library_path, xcconfig, sandbox_root)
-          name = File.basename(library_path, '.a').sub(/\Alib/, '')
+          extension = File.extname(library_path)
+          name = File.basename(library_path, extension).sub(/\Alib/, '')
           dirname = '${PODS_ROOT}/' + library_path.dirname.relative_path_from(sandbox_root).to_s
           build_settings = {
             'OTHER_LDFLAGS' => "-l#{name}",


### PR DESCRIPTION
…in the "linker flags" build setting to support dynamic libraries.
Fixes https://github.com/CocoaPods/CocoaPods/issues/4468