### PR TITLE
Improve sorting algorithm for `pod search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#4487](https://github.com/CocoaPods/CocoaPods/pull/4487)
 
 * Improve `pod search` performance while using _`--full`_ flag  
+* Improve sorting algorithm for `pod search`.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [cocoapods-search#12](https://github.com/CocoaPods/cocoapods-search/issues/12)
+
+* Improve `pod search` performance while using _`--full`_ flag.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [cocoapods-search#8](https://github.com/CocoaPods/cocoapods-search/issues/8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-search.git
-  revision: 1dd4aba6378678ca45e364e58f96196937fd297b
+  revision: 4281e740769875ba4e48748b73c7ff832a8d336e
   branch: master
   specs:
     cocoapods-search (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: d66fcb7160f060198c3808eb2ff3f51edf212687
+  revision: ce26e1eb797a6ad1f1d94b0304a50c491bc41237
   branch: master
   specs:
     cocoapods-core (0.39.0)
@@ -49,7 +49,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-search.git
-  revision: 4e7de92e477f47918d869a7c4819251633efca0d
+  revision: 1dd4aba6378678ca45e364e58f96196937fd297b
   branch: master
   specs:
     cocoapods-search (0.1.0)

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -125,6 +125,7 @@ module Pod
             end
           end
           found_set_symbols = query_word_results_hash.values.reduce(:&)
+          found_set_symbols ||= []
           sets = found_set_symbols.map do |symbol|
             aggregate.representative_set(symbol.to_s)
           end
@@ -138,15 +139,27 @@ module Pod
           raise Informative, "Unable to find a pod with name#{extra}" \
             "matching `#{query}`"
         end
+        sorted_sets(sets, query_word_regexps)
+      end
 
-        # Sort sets
-        sets.sort_by! { |set|
+      # Returns given set array by sorting it in-place.
+      #
+      # @param  [Array<Set>] sets
+      #         Array of sets to be sorted.
+      #
+      # @param  [Array<Regexp>] query_word_regexps
+      #         Array of regexp objects for user query.
+      #
+      # @return [Array<Set>]  Given sets parameter itself after sorting it in-place.
+      #
+      def sorted_sets(sets, query_word_regexps)
+        sets.sort_by! do |set|
           pre_match_length = nil
           found_query_index = nil
           found_query_count = 0
           query_word_regexps.each_with_index do |q, idx|
             if (m = set.name.match(/#{q}/i))
-              pre_match_length ||=  (m.pre_match.length)
+              pre_match_length ||= (m.pre_match.length)
               found_query_index ||= idx
               found_query_count += 1
             end
@@ -154,7 +167,7 @@ module Pod
           pre_match_length ||= 1000
           found_query_index ||= 1000
           [-found_query_count, pre_match_length, found_query_index, set.name.downcase]
-        }
+        end
         sets
       end
 

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -113,8 +113,8 @@ module Pod
       # @return [Array<Set>]  The sets that contain the search term.
       #
       def search_by_name(query, full_text_search = false)
+        query_word_regexps = query.split.map { |word| /#{word}/i }
         if full_text_search
-          query_word_regexps = query.split.map { |word| /#{word}/i }
           query_word_results_hash = {}
           updated_search_index.each_value do |word_spec_hash|
             word_spec_hash.each_pair do |word, spec_symbols|
@@ -138,6 +138,23 @@ module Pod
           raise Informative, "Unable to find a pod with name#{extra}" \
             "matching `#{query}`"
         end
+
+        # Sort sets
+        sets.sort_by! { |set|
+          pre_match_length = nil
+          found_query_index = nil
+          found_query_count = 0
+          query_word_regexps.each_with_index do |q, idx|
+            if (m = set.name.match(/#{q}/i))
+              pre_match_length ||=  (m.pre_match.length)
+              found_query_index ||= idx
+              found_query_count += 1
+            end
+          end
+          pre_match_length ||= 1000
+          found_query_index ||= 1000
+          [-found_query_count, pre_match_length, found_query_index, set.name.downcase]
+        }
         sets
       end
 

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -84,6 +84,57 @@ module Pod
         sets.any? { |s| s.name == 'BananaLib' }.should.be.true
       end
 
+      describe 'Sorting algorithm' do
+        before do
+          @test_search_results = %w(HockeyKit DLSuit VCLReachability NPReachability AVReachability PYNetwork
+                                    SCNetworkReachability AFNetworking Networking).map do |name|
+            Specification::Set.new(name)
+          end
+        end
+
+        it 'puts pod with exact match at the first index while sorting' do
+          regexps = [/networking/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets[0].name.should == 'Networking'
+        end
+
+        it 'puts pod with less prefix length before pods with more prefix length in search results' do
+          regexps = [/reachability/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'AVReachability' }.should.be < sets.index { |s| s.name == 'VCLReachability' }
+        end
+
+        it 'puts pod with more query word match before pods with less match in multi word query search results' do
+          regexps = [/network/i, /reachability/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'SCNetworkReachability' }.should.be < sets.index { |s| s.name == 'AVReachability' }
+        end
+
+        it 'puts pod matching first query word before pods matching later words in multi word query search results' do
+          regexps = [/network/i, /reachability/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'PYNetwork' }.should.be < sets.index { |s| s.name == 'AVReachability' }
+        end
+
+        it 'puts pod matching first query word before pods matching later words in multi word query search results' do
+          regexps = [/network/i, /reachability/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'PYNetwork' }.should.be < sets.index { |s| s.name == 'AVReachability' }
+        end
+
+        it 'alphabetically sorts pods having exact other conditions' do
+          regexps = [/reachability/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'AVReachability' }.should.be < sets.index { |s| s.name == 'NPReachability' }
+        end
+
+        it 'alphabetically sorts pods whose names does not match query' do
+          regexps = [/reachability/i]
+          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'DLSuit' }.should.be < sets.index { |s| s.name == 'HockeyKit' }
+        end
+      end
+
       it "generates the search index before performing a search if it doesn't exits" do
         SourcesManager.stubs(:all).returns([@test_source])
         Source::Aggregate.any_instance.expects(:generate_search_index_for_source).with(@test_source).returns('BananaLib' => ['BananaLib'])


### PR DESCRIPTION
Closes CocoaPods/cocoapods-search#12.

Calculates ordering score according to following criteria with evaluating in the written order.

- # of found queries in pod name (in cases for multi word queries)
- Pre-match length of the first matched query word.
- Index of of the first matched query word.
- Downcase name of the pod.