### PR TITLE
Add ability to specify source with each dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add support for specifying :source with a pod dependency.  
+  [Eric Firestone](https://github.com/efirestone)
+  [#4486](https://github.com/CocoaPods/CocoaPods/pull/4486)
+
 * Ask user to run `pod install` when a resource not found during in copy resources script.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: ce26e1eb797a6ad1f1d94b0304a50c491bc41237
+  revision: 6c2544496ed201104e712dd95793ec7bc6a171e8
   branch: master
   specs:
     cocoapods-core (0.39.0)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -614,13 +614,21 @@ module Pod
       def sources
         @sources ||= begin
           sources = podfile.sources
-          if sources.empty?
-            url = 'https://github.com/CocoaPods/Specs.git'
-            [SourcesManager.find_or_create_source_with_url(url)]
+
+          # Add any sources specified using the :source flag on individual dependencies.
+          dependency_sources = podfile.dependencies.map(&:podspec_repo).compact
+
+          all_dependencies_have_sources = dependency_sources.count == podfile.dependencies.count
+          if all_dependencies_have_sources
+            sources = dependency_sources
+          elsif sources.empty?
+            sources = ['https://github.com/CocoaPods/Specs.git']
           else
-            sources.map do |source_url|
-              SourcesManager.find_or_create_source_with_url(source_url)
-            end
+            sources += dependency_sources
+          end
+
+          sources.uniq.map do |source_url|
+            SourcesManager.find_or_create_source_with_url(source_url)
           end
         end
       end

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -335,13 +335,17 @@ module Pod
     #         The dependency for which the set is needed.
     #
     def create_set_from_sources(dependency)
-      aggregate.search(dependency)
+      aggregate_for_dependency(dependency).search(dependency)
     end
 
     # @return [Source::Aggregate] The aggregate of the {#sources}.
     #
-    def aggregate
-      @aggregate ||= Source::Aggregate.new(sources.map(&:repo))
+    def aggregate_for_dependency(dependency)
+      if dependency && dependency.podspec_repo
+        return SourcesManager.aggregate_for_dependency(dependency)
+      else
+        @aggregate ||= Source::Aggregate.new(sources.map(&:repo))
+      end
     end
 
     # Ensures that a specification is compatible with the platform of a target.

--- a/spec/fixtures/spec-repos/test_repo/CrossRepoDependent/1.0/CrossRepoDependent.podspec
+++ b/spec/fixtures/spec-repos/test_repo/CrossRepoDependent/1.0/CrossRepoDependent.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = 'CrossRepoDependent'
+  s.version      = '1.0'
+  s.authors      = 'Ned Needy', { 'Mr. Needy' => 'needy@example.local' }
+  s.homepage     = 'http://example.local/cross-repo-dependent.html'
+  s.summary      = 'I\'m dependent upon another spec repo to resolve my dependencies.'
+  s.description  = 'I\'m dependent upon another spec repo to resolve my dependencies.'
+  s.platform     = :ios
+
+  s.source       = { :git => 'http://example.local/cross-repo-dependent.git', :tag => 'v1.0' }
+  s.source_files = 'Classes/*.{h,m}', 'Vendor'
+  s.dependency   'AFNetworking', '2.4.0'
+  s.license      = {
+    :type => 'MIT',
+    :file => 'LICENSE',
+    :text => 'Permission is hereby granted ...'
+  }
+end

--- a/spec/functional/command/outdated_spec.rb
+++ b/spec/functional/command/outdated_spec.rb
@@ -50,10 +50,11 @@ module Pod
     end
 
     it "updates the Podfile's sources by default" do
-      config.stubs(:podfile).returns Podfile.new do
+      podfile = Podfile.new do
         source 'https://github.com/CocoaPods/Specs.git'
         pod 'AFNetworking'
       end
+      config.stubs(:podfile).returns(podfile)
       config.stubs(:skip_repo_update?).returns(false)
       lockfile = mock
       lockfile.stubs(:version).returns(Version.new('1.0'))


### PR DESCRIPTION
This adds the ability to add a `:source` flag to pod dependencies in a Podfile. This behavior mirrors in [Gemfiles](http://bundler.io/gemfile.html), allowing a dependency to be specified as such:

`pod 'JSONKit', '1.4', :source => 'http://github.com/MyOrg/Specs.git'`

Depends on https://github.com/CocoaPods/Core/pull/278