### PR TITLE
Track .def files as sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add support to track `.def` sources.
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#4490](https://github.com/CocoaPods/CocoaPods/pull/4490)
+
 * `Pod::Installer::PostInstallHooksContext` now offers access to the `sandbox`
   object.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -8,7 +8,7 @@ module Pod
     #
     class FileAccessor
       HEADER_EXTENSIONS = Xcodeproj::Constants::HEADER_FILES_EXTENSIONS
-      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift) + HEADER_EXTENSIONS).uniq.freeze
+      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift .def) + HEADER_EXTENSIONS).uniq.freeze
 
       GLOB_PATTERNS = {
         :readme              => 'readme{*,.*}'.freeze,

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -237,7 +237,7 @@ module Pod
           file_patterns = ['Classes/*.{h,m,d}', 'Vendor', 'framework/Source/*.h']
           options = {
             :exclude_patterns => ['Classes/**/osx/**/*', 'Resources/**/osx/**/*'],
-            :dir_pattern => '*{.m,.mm,.i,.c,.cc,.cxx,.cpp,.c++,.swift,.h,.hh,.hpp,.ipp,.tpp,.hxx}',
+            :dir_pattern => '*{.m,.mm,.i,.c,.cc,.cxx,.cpp,.c++,.swift,.def,.h,.hh,.hpp,.ipp,.tpp,.hxx}',
             :include_dirs => false,
           }
           @spec.exclude_files = options[:exclude_patterns]


### PR DESCRIPTION
We use `.def` files for sources in one of our projects and pods do not pick them up as source files.

`.def` is just a generic extension for files we process using the preprocessor, it’s C/C++ source code.

I know its a bit unique of usage but it seems harmless to track this extension also.