### PR TITLE
Use correct path for import in umbrella header when preserving header_mappings_dir

### DIFF
--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -26,7 +26,13 @@ module Pod
               generator.private_headers += target.file_accessors.flat_map(&:private_headers).map(&:basename)
             end
             create_umbrella_header do |generator|
-              generator.imports += target.file_accessors.flat_map(&:public_headers).map(&:basename)
+              if header_mappings_dir
+                generator.imports += target.file_accessors.flat_map(&:public_headers).map do |pathname|
+                  pathname.relative_path_from(header_mappings_dir)
+                end
+              else
+                generator.imports += target.file_accessors.flat_map(&:public_headers).map(&:basename)
+              end
             end
           end
           create_prefix_header


### PR DESCRIPTION
#4267 preserves the directory structure inside the Pod's header_mappings_dir, if one is specified in the podspec.

This led to problems with the pod target's umbrella header, since the (now nested) path of the included header files needs to be taken into account when generating the import statements.

I would classify this rather as a bugfix than an enhancement. Should I create a Changelog entry for this, even though the Bug has not been released yet?