### PR TITLE
Remove newline causing color problem when printing to a pager

### DIFF
--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -203,7 +203,7 @@ module Pod
           puts_indented "#{set.name} #{set.versions.first.version}"
         else
           pod = Specification::Set::Presenter.new(set)
-          title = "\n-> #{pod.name} (#{pod.version})"
+          title = "-> #{pod.name} (#{pod.version})"
           if pod.spec.deprecated?
             title += " #{pod.deprecation_description}"
             colored_title = title.red


### PR DESCRIPTION
Related to CocoaPods/cocoapods-search#17. Removes newline included while printing pod information in order to make coloring work in a pager.