### PR TITLE
Undo tracking of .def files as sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
 
 * Add support to track `.def` sources.
+* Add support to track `.def` files as headers.
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
-  [#4490](https://github.com/CocoaPods/CocoaPods/pull/4490)
+  [#338](https://github.com/CocoaPods/Xcodeproj/pull/338)
 
 * `Pod::Installer::PostInstallHooksContext` now offers access to the `sandbox`
   object.  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: 7a3d0c6520d995353b7ec09c4585aebf43e6c613
+  revision: f7d31a59aa080c24fd50cbb66b50ee30ddf52a50
   branch: master
   specs:
     xcodeproj (0.28.2)
@@ -99,7 +99,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.4)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -8,7 +8,7 @@ module Pod
     #
     class FileAccessor
       HEADER_EXTENSIONS = Xcodeproj::Constants::HEADER_FILES_EXTENSIONS
-      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift .def) + HEADER_EXTENSIONS).uniq.freeze
+      SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift) + HEADER_EXTENSIONS).uniq.freeze
 
       GLOB_PATTERNS = {
         :readme              => 'readme{*,.*}'.freeze,

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -237,7 +237,7 @@ module Pod
           file_patterns = ['Classes/*.{h,m,d}', 'Vendor', 'framework/Source/*.h']
           options = {
             :exclude_patterns => ['Classes/**/osx/**/*', 'Resources/**/osx/**/*'],
-            :dir_pattern => '*{.m,.mm,.i,.c,.cc,.cxx,.cpp,.c++,.swift,.def,.h,.hh,.hpp,.ipp,.tpp,.hxx}',
+            :dir_pattern => '*{.m,.mm,.i,.c,.cc,.cxx,.cpp,.c++,.swift,.h,.hh,.hpp,.ipp,.tpp,.hxx,.def}',
             :include_dirs => false,
           }
           @spec.exclude_files = options[:exclude_patterns]


### PR DESCRIPTION
My initial pull request was wrong at https://github.com/CocoaPods/CocoaPods/pull/4490 and they are meant to be treated as header files instead of source files.

Correct xcodeproj PR https://github.com/CocoaPods/Xcodeproj/pull/338

Apologies for this.