### PR TITLE
Prevent installer to be run from inside sandbox directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#4487](https://github.com/CocoaPods/CocoaPods/pull/4487)
 
-* Improve `pod search` performance while using _`--full`_ flag  
 * Improve sorting algorithm for `pod search`.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [cocoapods-search#12](https://github.com/CocoaPods/cocoapods-search/issues/12)
@@ -76,6 +75,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Prevent installer to be run from inside sandbox directory.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  
 * Improve repo lint error message when no repo found with given name.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#4142](https://github.com/CocoaPods/CocoaPods/issues/4142)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -115,9 +115,9 @@ module Pod
 
     def prepare
       # Raise if pwd is inside Pods
-      if (Pathname.pwd <=> sandbox.root) >= 0
+      if Dir.pwd.start_with?(sandbox.root.to_path)
         message = 'Command should be run from a directory outside Pods directory.'
-        message << "\n\n\tCurrent directory is '#{Pathname.pwd}'\n"
+        message << "\n\n\tCurrent directory is #{UI.path(Pathname.pwd)}\n"
         raise Informative, message
       end
       UI.message 'Preparing' do

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -114,6 +114,12 @@ module Pod
     end
 
     def prepare
+      # Raise if pwd is inside Pods
+      if (Pathname.pwd <=> sandbox.root) >= 0
+        message = 'Command should be run from a directory outside Pods directory.'
+        message << "\n\n\tCurrent directory is '#{Pathname.pwd}'\n"
+        raise Informative, message
+      end
       UI.message 'Preparing' do
         sandbox.prepare
         ensure_plugins_are_installed!

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -166,11 +166,17 @@ module Pod
         UI.warnings.should.include 'BlocksKit has been deprecated'
       end
 
-      it 'raises if command is run inside sandbox directory' do
+      it 'does not raise if command is run outside sandbox directory' do
+        Dir.chdir(@installer.sandbox.root.parent) do
+          should.not.raise(Informative) { @installer.install! }
+        end
+      end
+
+      it 'raises if command is run in sandbox directory' do
         Dir.chdir(@installer.sandbox.root) do
           should.raise Informative do
             @installer.install!
-          end.message.should.match %r{should.*run.*outside.*Pods directory.*Current directory.*/Pods}m
+          end.message.should.match %r{should.*run.*outside.*Pods directory.*Current directory.*\.}m
         end
       end
     end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -165,6 +165,14 @@ module Pod
         UI.warnings.should.include 'deprecated in favor of AFNetworking'
         UI.warnings.should.include 'BlocksKit has been deprecated'
       end
+
+      it 'raises if command is run inside sandbox directory' do
+        Dir.chdir(@installer.sandbox.root) do
+          should.raise Informative do
+            @installer.install!
+          end.message.should.match %r{should.*run.*outside.*Pods directory.*Current directory.*/Pods}m
+        end
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -176,7 +176,7 @@ module Pod
         Dir.chdir(@installer.sandbox.root) do
           should.raise Informative do
             @installer.install!
-          end.message.should.match %r{should.*run.*outside.*Pods directory.*Current directory.*\.}m
+          end.message.should.match /should.*run.*outside.*Pods directory.*Current directory.*\./m
         end
       end
     end


### PR DESCRIPTION
This prevents crashes which can happen when `pod install` command is run from inside subdirectories of Pods directory.