### PR TITLE
Ask user to run 'pod install' when a resource to copy not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Ask user to run `pod install` when a resource not found during in copy resources script.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+
 * Add support to track `.def` sources.
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#4490](https://github.com/CocoaPods/CocoaPods/pull/4490)

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -114,6 +114,12 @@ realpath() {
 
 install_resource()
 {
+  if [ ! -e "${PODS_ROOT}/$1" ]; then
+    cat << EOM
+error: Resource "${PODS_ROOT}/$1" not found. Run 'pod install' to update the copy resources script.
+EOM
+    exit 1
+  fi
   case $1 in
     *\.storyboard)
       echo "ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$1\\" .storyboard`.storyboardc ${PODS_ROOT}/$1 --sdk ${SDKROOT}"


### PR DESCRIPTION
Shows an error message in Xcode like the following:

```
Resource "RESOURCE_PATH" not found. Run 'pod install' to update the copy resources script.
```
