### PR TITLE
[TargetInstaller] Ensure installed targets still have unique paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Boris Bügling](https://github.com/neonichu)
   [#3777](https://github.com/CocoaPods/CocoaPods/issues/3777)
 
+* Avoid the duplicate UUID warning when a Pod is installed for multiple
+  platforms.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#4521](https://github.com/CocoaPods/CocoaPods/issues/4521)
+
 
 ## 0.39.0 (2015-10-09)
 

--- a/lib/cocoapods/installer/target_installer.rb
+++ b/lib/cocoapods/installer/target_installer.rb
@@ -45,7 +45,6 @@ module Pod
         product_name = target.product_name
         product = @native_target.product_reference
         product.name = product_name
-        product.path = product_name
 
         target.user_build_configurations.each do |bc_name, type|
           @native_target.add_build_configuration(bc_name, type)


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/4521.

The aforementioned issue was due to the fact that the products group file references didn't have unique paths / names, and therefore the deterministic UUID generator was unable to distinguish them. This PR fixes that by ensuring that the PBXFileReference keeps its normal path.

- [x] CHANGELOG

\c @mrackwitz 