### PR TITLE
Unique the list of vendored frameworks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   being unable to set the base configuration XCConfig.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Ensure that linking multiple times against the same framework does not trigger
+  the duplicate module name check for frameworks.  
+  [Boris Bügling](https://github.com/neonichu)
+  [Samuel Giddins](https://github.com/segiddins)
+  [#4550](https://github.com/CocoaPods/CocoaPods/issues/4550)
+
 
 ## 0.39.0 (2015-10-09)
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -390,7 +390,7 @@ module Pod
       aggregate_targets.each do |aggregate_target|
         aggregate_target.user_build_configurations.keys.each do |config|
           pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
-          vendored_frameworks = pod_targets.flat_map(&:file_accessors).flat_map(&:vendored_frameworks)
+          vendored_frameworks = pod_targets.flat_map(&:file_accessors).flat_map(&:vendored_frameworks).uniq
           frameworks = vendored_frameworks.map { |fw| fw.basename('.framework') }
           frameworks += pod_targets.select { |pt| pt.should_build? && pt.requires_frameworks? }.map(&:product_module_name)
 


### PR DESCRIPTION
Since those are full paths, uniquing the list ensures we only consider each framework once for the check, no matter if it is linked against multiple targets.

Fixes #4550

- [x] Changelog
- [x] Specs