### PR TITLE
Fix validator message

### DIFF
--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -139,8 +139,8 @@ module Pod
         reasons << reason
       end
       if results.all?(&:public_only)
-        reasons << 'All results apply only to public specs, but you can use ' \
-                   '`--private` to ignore them if linting the specification for a private pod.'
+        reasons << 'all results apply only to public specs, but you can use ' \
+                   '`--private` to ignore them if linting the specification for a private pod'
       end
       reasons.to_sentence
     end


### PR DESCRIPTION
Before:

```[!] Contentful did not pass validation, due to 1 warning (but you can use `--allow-warnings` to ignore it) and All results apply only to public specs, but you can use `--private` to ignore them if linting the specification for a private pod..```

After:

```[!] Contentful did not pass validation, due to 1 warning (but you can use `--allow-warnings` to ignore it) and all results apply only to public specs, but you can use `--private` to ignore them if linting the specification for a private pod.```