### PR TITLE
[Repo Command] Add Ability to Add Custom Commit Message When Pushing Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add the ability to add a custom commit message when pushing a spec.
+  [Bart Jacobs](https://github.com/bartjacobs)
+  [#4583](https://github.com/CocoaPods/CocoaPods/issues/4583)
+
 * Added support for `pod env` to print the pod environment without having to crash.  
   [Hemal Shah](https://github.com/hemal)
   [#3660](https://github.com/CocoaPods/CocoaPods/issues/3660)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -29,7 +29,7 @@ module Pod
              'Multiple sources must be comma-delimited.'],
             ['--local-only', 'Does not perform the step of pushing REPO to its remote'],
             ['--no-private', 'Lint includes checks that apply only to public repos'],
-            ['--message', 'Add custom commit message']
+            ['--message', 'Add custom commit message'],
           ].concat(super)
         end
 
@@ -76,11 +76,11 @@ module Pod
           File.chmod(0777, file.path)
           file.close
 
-          unless ENV['EDITOR'].nil?
+          if !ENV['EDITOR'].nil?
+            @message = nil
+          else
             system("#{ENV['EDITOR']} #{file.path}")
             @message = File.read file.path
-          else
-            @message = nil
           end
         end
 


### PR DESCRIPTION
When pushing a spec to the specs repo, the commit message cannot be customized. It would be useful to add the ability to add a custom commit message.

If the user adds the `--message` flag, the default editor is opened, allowing the user to enter a custom commit message that is used when the spec is pushed to the specs repository.