### PR TITLE
Create Info.plist files for resource bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix compiling of asset catalog files inside resource bundles.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#4501](https://github.com/CocoaPods/CocoaPods/issues/4501)
+
 * Prevent installer to be run from inside sandbox directory.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: f7d31a59aa080c24fd50cbb66b50ee30ddf52a50
+  revision: ad8f6b78e424c274b63ff42ff6ad72840cb307a6
   branch: master
   specs:
     xcodeproj (0.28.2)

--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -137,8 +137,17 @@ module Pod
               end
             end
 
+            # Create Info.plist file for bundle
+            path = target.info_plist_path
+            info_plist_path = path.dirname + "ResourceBundle-#{bundle_name}-#{path.basename}"
+            generator = Generator::InfoPlistFile.new(target)
+            generator.save_as(info_plist_path)
+            add_file_to_support_group(info_plist_path)
+
             bundle_target.build_configurations.each do |c|
               c.build_settings['PRODUCT_NAME'] = bundle_name
+              relative_info_plist_path = info_plist_path.relative_path_from(sandbox.root)
+              c.build_settings['INFOPLIST_FILE'] = relative_info_plist_path.to_s
               if target.requires_frameworks? && target.scoped?
                 c.build_settings['CONFIGURATION_BUILD_DIR'] = target.configuration_build_dir
               end

--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -139,6 +139,7 @@ module Pod
 
             # Create Info.plist file for bundle
             path = target.info_plist_path
+            path.dirname.mkdir unless path.dirname.exist?
             info_plist_path = path.dirname + "ResourceBundle-#{bundle_name}-#{path.basename}"
             generator = Generator::InfoPlistFile.new(target)
             generator.save_as(info_plist_path)


### PR DESCRIPTION
Closes #4501.

Resource bundles generated by CocoaPods were not having Info.plist files, which was weirdly causing asset catalogs not to be compiled.

Adding Info.plist solves compiling issues for asset catalog files inside resource bundles.

Thanks to @samdmarshall for insight!