### PR TITLE
Use release configuration with new linter

### DIFF
--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -697,7 +697,7 @@ module Pod
     #         returns its output (both STDOUT and STDERR).
     #
     def xcodebuild
-      command = %w(clean build -workspace App.xcworkspace -scheme App)
+      command = %w(clean build -workspace App.xcworkspace -scheme App -configuration Release)
       case consumer.platform_name
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -435,7 +435,7 @@ module Pod
         git = Executable.which(:git)
         Executable.stubs(:which).with('git').returns(git)
         Executable.expects(:which).with('xcodebuild').times(4).returns('/usr/bin/xcodebuild')
-        command = %w(clean build -workspace App.xcworkspace -scheme App)
+        command = %w(clean build -workspace App.xcworkspace -scheme App -configuration Release)
         Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
         Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator), :capture => :merge).once.returns(['', stub(:success? => true)])
         Executable.expects(:capture_command).with('xcodebuild', command + %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator), :capture => :merge).once.returns(['', stub(:success? => true)])


### PR DESCRIPTION
By using the `-scheme` it defaults to `Debug` versus using the `-target` that the old linter had.

/cc @segiddins 