### PR TITLE
Don't warn about setting base config when existing is identical to new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 To install release candidates run `[sudo] gem install cocoapods --pre`
 
+## Master
+
+##### Enhancement
+
+* Don't warn about setting base config when identical to current config.
+  [Jed Lewison](https://github.com/jedlewison)
+  [#4722](https://github.com/CocoaPods/CocoaPods/issues/4722)
+
 ## 1.0.0.beta.1 (2015-12-30)
 
 ##### Breaking

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator/xcconfig_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator/xcconfig_integrator.rb
@@ -88,12 +88,14 @@ module Pod
               if existing.real_path.to_path.start_with?(pod_bundle.sandbox.root.to_path << '/')
                 set_base_configuration_reference.call
               elsif !xcconfig_includes_target_xcconfig?(config.base_configuration_reference, path)
-                UI.warn 'CocoaPods did not set the base configuration of your ' \
-                'project because your project already has a custom ' \
-                'config set. In order for CocoaPods integration to work at ' \
-                'all, please either set the base configurations of the target ' \
-                "`#{target.name}` to `#{path}` or include the `#{path}` in your " \
-                "build configuration (#{UI.path(existing.real_path)})."
+                unless existing_config_is_identical_to_pod_config?(existing.real_path, pod_bundle.xcconfig_path(config.name))
+                  UI.warn 'CocoaPods did not set the base configuration of your ' \
+                  'project because your project already has a custom ' \
+                  'config set. In order for CocoaPods integration to work at ' \
+                  'all, please either set the base configurations of the target ' \
+                  "`#{target.name}` to `#{path}` or include the `#{path}` in your " \
+                  "build configuration (#{UI.path(existing.real_path)})."
+                end
               end
             elsif config.base_configuration_reference.nil? || file_ref.nil?
               set_base_configuration_reference.call
@@ -158,6 +160,16 @@ module Pod
               )
             /x
             base_config_ref.real_path.readlines.find { |line| line =~ regex }
+          end
+
+          # Checks to see if the config files at two paths exist and are identical
+          #
+          # @param  The existing config path
+          #
+          # @param  The pod config path
+          #
+          def self.existing_config_is_identical_to_pod_config?(existing_config_path, pod_config_path)
+            existing_config_path.file? && (!pod_config_path.file? || FileUtils.compare_file(existing_config_path, pod_config_path))
           end
         end
       end

--- a/spec/unit/installer/user_project_integrator/target_integrator/xcconfig_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator/xcconfig_integrator_spec.rb
@@ -88,6 +88,20 @@ module Pod
       UI.warnings.should.not.match /not set.*base configuration/
     end
 
+    it 'does not log a warning if the existing xcconfig is identical to the Pods config' do
+      sample_config = @project.new_file('SampleConfig.xcconfig')
+      File.write(sample_config.real_path, 'sample config content.')
+      @target.build_configurations.each do |config|
+        config.base_configuration_reference = sample_config
+      end
+      XCConfigIntegrator.integrate(@pod_bundle, [@target])
+      @target.build_configurations.each do |config|
+        config.base_configuration_reference.should == sample_config
+      end
+
+      UI.warnings.should.not.match /not set.*base configuration/
+    end
+
     it 'does not log a warning if the user has set a xcconfig of their own that includes the silence warnings string' do
       SILENCE_TOKEN = '// @COCOAPODS_SILENCE_WARNINGS@ //'
       sample_config = @project.new_file('SampleConfig.xcconfig')


### PR DESCRIPTION
Issue here is the scenario where a project gets added to a new workspace temporarily and has its pods built in a new directory. In that case, the location of the newly generated config file may differ from the existing one, but the config is actually identical. So when the config files are the same, it seems reasonable to silence the ominous "CocoaPods may not work at all" message since it definitely works.

If there's a different or better way to handle this edge case, that'd be great too — I'm not experienced with Ruby so I easily could have missed something else.