### PR TITLE
Fix for resource bundles TARGETED_DEVICE_FAMILY issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix resource bundles only supporting iPhone for target device family
+  [Andy Rifken](https://github.com/arifken)
+
 * Fix compiling of localized resources.
   [Eric Firestone](https://github.com/efirestone)
   [#1653](https://github.com/CocoaPods/CocoaPods/issues/1653)

--- a/lib/cocoapods/installer/target_installer/pod_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/pod_target_installer.rb
@@ -180,6 +180,17 @@ module Pod
               if target.requires_frameworks? && target.scoped?
                 c.build_settings['CONFIGURATION_BUILD_DIR'] = target.configuration_build_dir
               end
+
+              # Set the correct device family for this bundle, based on the platform
+              bundle_device_family_map = {
+                  :ios => '1,2',
+                  :tvos => '3',
+                  :watchos => '1,2' # The device family for watchOS is 4, but Xcode creates watchkit-compatible bundles as 1,2
+              }
+
+              if bundle_device_family_map.keys.include?(target.platform.name)
+                c.build_settings['TARGETED_DEVICE_FAMILY'] = bundle_device_family_map[target.platform.name]
+              end
             end
           end
         end

--- a/spec/unit/installer/target_installer/pod_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/pod_target_installer_spec.rb
@@ -171,6 +171,16 @@ module Pod
             bc.base_configuration_reference.real_path.should == file
           end
         end
+
+        it 'sets the correct targeted device family for the resource bundle targets' do
+          @pod_target.file_accessors.first.stubs(:resource_bundles).returns('banana_bundle' => [])
+          @installer.install!
+          bundle_target = @project.targets.find { |t| t.name == 'Pods-BananaLib-banana_bundle' }
+
+          bundle_target.build_configurations.each do |bc|
+            bc.build_settings['TARGETED_DEVICE_FAMILY'].should == '1,2'
+          end
+        end
       end
 
       #--------------------------------------#


### PR DESCRIPTION
We found that the TARGETED_DEVICE_FAMILY is not set correctly for resource bundles configured in a podspec. The application using the resource bundle from the pod did not compile assets for iPad because this value was defaulted to "1" (iPhone only). Now, it correctly configures the pod resource bundle target to include both iPhone and iPad