### PR TITLE
[SourcesManager] Fix wrong sudo recommendation 🌈

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides
 
 To install release candidates run `[sudo] gem install cocoapods --pre`
 
+## Master
+
+##### Enhancements
+
+##### Bug Fixes
+
+* Fix suggestion of sudo when it actually isn't needed
+  [Marcel Jackwerth](https://github.com/sirlantis)
+
 ## 1.0.0.beta.2 (2016-01-05)
 
 ##### Enhancements

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -366,12 +366,10 @@ module Pod
             'Update CocoaPods, or checkout the appropriate tag in the repo.'
         end
 
-        needs_sudo = path_writable?(__FILE__)
-
         if config.new_version_message? && cocoapods_update?(versions)
           last = versions['last']
           rc = Gem::Version.new(last).prerelease?
-          install_message = needs_sudo ? 'sudo ' : ''
+          install_message = needs_sudo? ? 'sudo ' : ''
           install_message << 'gem install cocoapods'
           install_message << ' --pre' if rc
           message = [
@@ -485,6 +483,12 @@ module Pod
       #
       def path_writable?(path)
         Pathname(path).dirname.writable?
+      end
+
+      # @return [Bool] Whether `gem install` probably needs `sudo` to succeed.
+      #
+      def needs_sudo?
+        !path_writable?(__FILE__)
       end
 
       # @return [Source] The git source with the given name. If no git source

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -390,6 +390,16 @@ module Pod
         SourcesManager.send(:path_writable?, path).should.be.true
       end
 
+      it 'knows when sudo is needed' do
+        SourcesManager.stubs(:path_writable?).returns(false)
+        SourcesManager.send(:needs_sudo?).should.be.true
+      end
+
+      it 'knows when sudo is not needed' do
+        SourcesManager.stubs(:path_writable?).returns(true)
+        SourcesManager.send(:needs_sudo?).should.be.false
+      end
+
       it 'returns whether a repository is compatible' do
         SourcesManager.stubs(:version_information).returns('min' => '0.0.1')
         SourcesManager.repo_compatible?('stub').should.be.true


### PR DESCRIPTION
**Issue**
`pod` suggested to prefix `gem install` with `sudo` even though I'm using user-local `rbenv`.
`sudo` shouldn't be suggested if not needed to avoid `chown` pain later.

**Solution**
Extracted `needs_sudo` into own method `needs_sudo?`
Wrote a test for each outcome of `needs_sudo?`

P.S. Would be nice if you could add an empty Master section in CHANGELOG after releases to not make contributors guess what to do here without causing conflicts.