### PR TITLE
Fix bug where lproj directories aren't added to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Properly add resource files to resources build phase.
+  [Eric Firestone](https://github.com/efirestone)
+  [#4762](https://github.com/CocoaPods/CocoaPods/issues/4762)
+
 * Fix suggestion of sudo when it actually isn't needed.  
   [Marcel Jackwerth](https://github.com/sirlantis)
 

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -199,29 +199,29 @@ module Pod
         lproj_paths = Set.new
         lproj_paths_with_files = Set.new
         allowable_paths = paths.select do |path|
-          path_str = path.to_s.downcase
+          path_str = path.to_s
 
           # We add the directory for a Core Data model, but not the items in it.
-          next if path_str =~ /.*\.xcdatamodeld\/.+/
+          next if path_str =~ /.*\.xcdatamodeld\/.+/i
 
           # We add the directory for an asset catalog, but not the items in it.
-          next if path_str =~ /.*\.xcassets\/.+/
+          next if path_str =~ /.*\.xcassets\/.+/i
 
-          if path_str =~ /\.lproj(\/|$)/
+          if path_str =~ /\.lproj(\/|$)/i
             # If the element is an .lproj directory then save it and potentially
             # add it later if we don't find any contained items.
-            if path_str.end_with?('.lproj') && path.directory?
-              lproj_paths << path_str
+            if path_str =~ /\.lproj$/i && path.directory?
+              lproj_paths << path
               next
             end
 
             # Collect the paths for the .lproj directories that contain files.
-            lproj_path = /(^.*\.lproj)\/.*/.match(path_str)[1]
-            lproj_paths_with_files << lproj_path
+            lproj_path = /(^.*\.lproj)\/.*/i.match(path_str)[1]
+            lproj_paths_with_files << Pathname(lproj_path)
 
             # Directories nested within an .lproj directory are added as file
             # system references so their contained items are not added directly.
-            next if path.dirname.dirname.to_s.downcase == lproj_path
+            next if path.dirname.dirname == lproj_path
           end
 
           true

--- a/spec/unit/installer/file_references_installer_spec.rb
+++ b/spec/unit/installer/file_references_installer_spec.rb
@@ -12,7 +12,7 @@ module Pod
 
     #-------------------------------------------------------------------------#
 
-    describe 'Installation' do
+    describe 'Installation With Flat Resources Glob' do
       it 'adds the files references of the source files the Pods project' do
         @file_accessor.path_list.read_file_system
         @file_accessor.path_list.expects(:read_file_system)
@@ -47,20 +47,24 @@ module Pod
         file_ref.path.should == 'Resources/logo-sidebar.png'
       end
 
-      it "add file references for localization directories if glob doesn't include contained files" do
+      it "adds file references for localization directories if glob doesn't include contained files" do
         @installer.install!
         file_ref = @installer.pods_project['Pods/BananaLib/Resources/en.lproj']
         file_ref.should.be.not.nil
+        file_ref.path.should == 'Resources/en.lproj'
       end
 
       it 'adds file references for files within CoreData directories' do
         @installer.install!
         model_ref = @installer.pods_project['Pods/BananaLib/Resources/Sample.xcdatamodeld']
         model_ref.should.be.not.nil
+        model_ref.path.should == 'Resources/Sample.xcdatamodeld'
 
         # Files within the .xcdatamodeld directory are added automatically by adding the .xcdatamodeld directory.
         file_ref = @installer.pods_project['Pods/BananaLib/Resources/Sample.xcdatamodeld/Sample.xcdatamodel']
         file_ref.should.be.not.nil
+        file_ref.path.should == 'Sample.xcdatamodel'
+        file_ref.source_tree.should == '<group>'
       end
 
       it 'links the headers required for building the pod target' do

--- a/spec/unit/installer/target_installer/pod_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/pod_target_installer_spec.rb
@@ -124,6 +124,9 @@ module Pod
         resources.count.should > 0
         resource = resources.find { |res| res.file_ref.path.include?('logo-sidebar.png') }
         resource.should.be.not.nil
+
+        resource = resources.find { |res| res.file_ref.path.include?('en.lproj') }
+        resource.should.be.not.nil
       end
 
       #--------------------------------------#


### PR DESCRIPTION
https://github.com/CocoaPods/CocoaPods/issues/4762

Root of the issue was that the resources were being added to the xcodeproj in all-lowercase, and when the target installer went to look for items using properly-cased paths they didn't match, so it didn't add them to the targets.