### PR TITLE
Audit CLI help for period consistency

### DIFF
--- a/lib/cocoapods/command/init.rb
+++ b/lib/cocoapods/command/init.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/string/strip'
 module Pod
   class Command
     class Init < Command
-      self.summary = 'Generate a Podfile for the current directory.'
+      self.summary = 'Generate a Podfile for the current directory'
       self.description = <<-DESC
         Creates a Podfile for the current directory if none currently exists. If
         an `XCODEPROJ` project file is specified or if there is only a single

--- a/lib/cocoapods/command/inter_process_communication.rb
+++ b/lib/cocoapods/command/inter_process_communication.rb
@@ -11,7 +11,7 @@ module Pod
       #-----------------------------------------------------------------------#
 
       class Spec < IPC
-        self.summary = 'Converts a podspec to JSON.'
+        self.summary = 'Converts a podspec to JSON'
         self.description = 'Converts a podspec to JSON and prints it to STDOUT.'
         self.arguments = [
           CLAide::Argument.new('PATH', true),
@@ -37,7 +37,7 @@ module Pod
       #-----------------------------------------------------------------------#
 
       class Podfile < IPC
-        self.summary = 'Converts a Podfile to YAML.'
+        self.summary = 'Converts a Podfile to YAML'
         self.description = 'Converts a Podfile to YAML and prints it to STDOUT.'
         self.arguments = [
           CLAide::Argument.new('PATH', true),
@@ -63,7 +63,7 @@ module Pod
       #-----------------------------------------------------------------------#
 
       class List < IPC
-        self.summary = 'Lists the specifications known to CocoaPods.'
+        self.summary = 'Lists the specifications known to CocoaPods'
         self.description = <<-DESC
           Prints to STDOUT a YAML dictionary where the keys are the name of the
           specifications and each corresponding value is a dictionary with
@@ -101,7 +101,7 @@ module Pod
       #-----------------------------------------------------------------------#
 
       class UpdateSearchIndex < IPC
-        self.summary = 'Updates the search index.'
+        self.summary = 'Updates the search index'
         self.description = <<-DESC
           Updates the search index and prints its path to standard output.
           The search index is a YAML encoded dictionary where the keys
@@ -125,7 +125,7 @@ module Pod
       class Repl < IPC
         END_OF_OUTPUT_SIGNAL = "\n\r"
 
-        self.summary = 'The repl listens to commands on standard input.'
+        self.summary = 'The repl listens to commands on standard input'
         self.description = <<-DESC
          The repl listens to commands on standard input and prints their
          result to standard output.

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Repo < Command
       class Add < Repo
-        self.summary = 'Add a spec repo.'
+        self.summary = 'Add a spec repo'
 
         self.description = <<-DESC
           Clones `URL` in the local spec-repos directory at `~/.cocoapods/repos/`. The

--- a/lib/cocoapods/command/repo/lint.rb
+++ b/lib/cocoapods/command/repo/lint.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Repo < Command
       class Lint < Repo
-        self.summary = 'Validates all specs in a repo.'
+        self.summary = 'Validates all specs in a repo'
 
         self.description = <<-DESC
           Lints the spec-repo `NAME`. If a directory is provided it is assumed

--- a/lib/cocoapods/command/repo/update.rb
+++ b/lib/cocoapods/command/repo/update.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Repo < Command
       class Update < Repo
-        self.summary = 'Update a spec repo.'
+        self.summary = 'Update a spec repo'
 
         self.description = <<-DESC
           Updates the local clone of the spec-repo `NAME`. If `NAME` is omitted

--- a/lib/cocoapods/command/spec/cat.rb
+++ b/lib/cocoapods/command/spec/cat.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Spec < Command
       class Cat < Spec
-        self.summary = 'Prints a spec file.'
+        self.summary = 'Prints a spec file'
 
         self.description = <<-DESC
           Prints the content of the podspec(s) whose name matches `QUERY` to standard output.

--- a/lib/cocoapods/command/spec/edit.rb
+++ b/lib/cocoapods/command/spec/edit.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Spec < Command
       class Edit < Spec
-        self.summary = 'Edit a spec file.'
+        self.summary = 'Edit a spec file'
 
         self.description = <<-DESC
           Opens the podspec matching `QUERY` to be edited.

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Spec < Command
       class Lint < Spec
-        self.summary = 'Validates a spec file.'
+        self.summary = 'Validates a spec file'
 
         self.description = <<-DESC
           Validates `NAME.podspec`. If a `DIRECTORY` is provided, it validates

--- a/lib/cocoapods/command/spec/which.rb
+++ b/lib/cocoapods/command/spec/which.rb
@@ -2,7 +2,7 @@ module Pod
   class Command
     class Spec < Command
       class Which < Spec
-        self.summary = 'Prints the path of the given spec.'
+        self.summary = 'Prints the path of the given spec'
 
         self.description = <<-DESC
           Prints the path of the .podspec file(s) whose name matches `QUERY`


### PR DESCRIPTION
I noticed inconsistent help messages while using `pod repo --help` so I went through and fixed the summaries in `command`. Short summaries without periods were more prevalent so I adjusted the rest of them.

```sh
» pod repo --help                                                                                                                 
Usage:

    $ pod repo [COMMAND]

      Manage spec-repositories

Commands:

    + add       Add a spec repo.
    + lint      Validates all specs in a repo.
    > list      List repos
    + push      Push new specifications to a spec-repo
    + remove    Remove a spec repo
    + update    Update a spec repo.

Options:

    --silent    Show nothing
    --verbose   Show more debugging information
    --no-ansi   Show output without ANSI codes
    --help      Show help banner of specified command