### PR TITLE
[Command Project] xcodeproj was renamed to project

### DIFF
--- a/lib/cocoapods/command/project.rb
+++ b/lib/cocoapods/command/project.rb
@@ -81,9 +81,9 @@ module Pod
 
         The Xcode project file should be specified in your `Podfile` like this:
 
-            xcodeproj 'path/to/XcodeProject'
+            project 'path/to/XcodeProject'
 
-        If no xcodeproj is specified, then a search for an Xcode project will
+        If no project is specified, then a search for an Xcode project will
         be made. If more than one Xcode project is found, the command will
         raise an error.
 


### PR DESCRIPTION
I skipped references to `xcodeproj` in strings, so I missed these occurrences. I double checked all remaining occurrences and it seems like these were the only ones which had to be changed.