### PR TITLE
[FileReferencesInstaller] Add build headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Link build and private headers in the target support files but not in the
+  sandbox when integrating with frameworks.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#4848](https://github.com/CocoaPods/CocoaPods/issues/4848)
+
 * Don't try to embed project headers into frameworks.
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#4819](https://github.com/CocoaPods/CocoaPods/issues/4819)

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -118,18 +118,17 @@ module Pod
               framework_exp = /\.framework\//
               headers_sandbox = Pathname.new(file_accessor.spec.root.name)
 
+              pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform)
+              header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
+                pod_target.build_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
+              end
+
               # When integrating Pod as frameworks, built Pods are built into
               # frameworks, whose headers are included inside the built
               # framework. Those headers do not need to be linked from the
               # sandbox.
               unless pod_target.requires_frameworks? && pod_target.should_build?
-                pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform)
                 sandbox.public_headers.add_search_path(headers_sandbox, pod_target.platform)
-
-                header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
-                  pod_target.build_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
-                end
-
                 header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
                   sandbox.public_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
                 end

--- a/spec/unit/installer/file_references_installer_spec.rb
+++ b/spec/unit/installer/file_references_installer_spec.rb
@@ -78,6 +78,23 @@ module Pod
         framework_header.should.not.exist
       end
 
+      it 'links the headers required for building the pod target with frameworks and header_mapping_dir' do
+        @pod_target = fixture_pod_target('snake/snake.podspec')
+        @pod_target.host_requires_frameworks = true
+        @project = Project.new(config.sandbox.project_path)
+        @project.add_pod_group('snake', fixture('snake'))
+        @installer = Installer::FileReferencesInstaller.new(config.sandbox, [@pod_target], @project)
+        @installer.install!
+        headers_root = @pod_target.build_headers.root
+        private_headers = [
+          headers_root + 'snake/A/Boa.h',
+          headers_root + 'snake/B/Boa.h',
+          headers_root + 'snake/C/Boa.h',
+          headers_root + 'snake/snake.h',
+        ]
+        private_headers.each { |private_header| private_header.should.exist }
+      end
+
       it 'links the public headers meant for the user' do
         @installer.install!
         headers_root = config.sandbox.public_headers.root


### PR DESCRIPTION
Built frameworks require still private and build headers to be linked in the pod target support files' header directory.

- [ ] Verify doesn't regress #4476