### PR TITLE
Propagate the CocoaPods version to the prepare_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#4146](https://github.com/CocoaPods/CocoaPods/pull/4146)
 
+* Pass `COCOAPODS_VERSION` as environment variable to the `prepare_command`.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#4933](https://github.com/CocoaPods/CocoaPods/pull/4933)
+
 ##### Bug Fixes
 
 * Pods are built by default in another scoping level of the build products

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -30,7 +30,7 @@ module Pod
 
     # Executes the given command displaying it if in verbose mode.
     #
-    # @param  [String] bin
+    # @param  [String] executable
     #         The binary to use.
     #
     # @param  [Array<#to_s>] command

--- a/lib/cocoapods/installer/pod_source_preparer.rb
+++ b/lib/cocoapods/installer/pod_source_preparer.rb
@@ -59,9 +59,11 @@ module Pod
         UI.section(' > Running prepare command', '', 1) do
           Dir.chdir(path) do
             ENV.delete('CDPATH')
+            ENV['COCOAPODS_VERSION'] = Pod::VERSION
             prepare_command = spec.prepare_command.strip_heredoc.chomp
             full_command = "\nset -e\n" + prepare_command
             bash!('-c', full_command)
+            ENV.delete('COCOAPODS_VERSION')
           end
         end
       end

--- a/lib/cocoapods/installer/pod_source_preparer.rb
+++ b/lib/cocoapods/installer/pod_source_preparer.rb
@@ -58,12 +58,15 @@ module Pod
         return unless spec.prepare_command
         UI.section(' > Running prepare command', '', 1) do
           Dir.chdir(path) do
-            ENV.delete('CDPATH')
-            ENV['COCOAPODS_VERSION'] = Pod::VERSION
-            prepare_command = spec.prepare_command.strip_heredoc.chomp
-            full_command = "\nset -e\n" + prepare_command
-            bash!('-c', full_command)
-            ENV.delete('COCOAPODS_VERSION')
+            begin
+              ENV.delete('CDPATH')
+              ENV['COCOAPODS_VERSION'] = Pod::VERSION
+              prepare_command = spec.prepare_command.strip_heredoc.chomp
+              full_command = "\nset -e\n" + prepare_command
+              bash!('-c', full_command)
+            ensure
+              ENV.delete('COCOAPODS_VERSION')
+            end
           end
         end
       end

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -63,6 +63,13 @@ module Pod
           @spec.prepare_command = "[ \"$COCOAPODS_VERSION\" == \"#{Pod::VERSION}\" ] || exit 1"
           lambda { @installer.install! }.should.not.raise
         end
+
+        it 'doesn\'t leak the $COCOAPODS_VERSION environment variable' do
+          ENV['COCOAPODS_VERSION'] = nil
+          @spec.prepare_command = 'exit 1'
+          lambda { @installer.install! }.should.raise(Pod::Informative)
+          ENV['COCOAPODS_VERSION'].should.be.nil
+        end
       end
 
       #--------------------------------------#

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -58,6 +58,11 @@ module Pod
           @spec.prepare_command = 'cd Classes;ls Banana.h'
           lambda { @installer.install! }.should.not.raise
         end
+
+        it 'sets the $COCOAPODS_VERSION environment variable' do
+          @spec.prepare_command = "[ \"$COCOAPODS_VERSION\" == \"#{Pod::VERSION}\" ] || exit 1"
+          lambda { @installer.install! }.should.not.raise
+        end
       end
 
       #--------------------------------------#


### PR DESCRIPTION
This gives non-trivial podspecs one way to adopt the breaking changes of 1.0 while staying backwards-compatibility with 0.39. This isn't suitable when two versions of CocoaPods are used alongside as the `prepare_command` is run once on the cached sources. We could mitigate this by making the cache version-specific.