### PR TITLE
[PodVariantSet] Naive algorithm for #scope_by_specs

### DIFF
--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -90,11 +90,7 @@ module Pod
     #
     def label
       if scoped?
-        if scope_suffix[0] == '.'
-          "#{root_spec.name}#{scope_suffix}"
-        else
-          "#{root_spec.name}-#{scope_suffix}"
-        end
+        "#{root_spec.name}-#{scope_suffix}"
       else
         root_spec.name
       end

--- a/spec/unit/installer/analyzer/pod_variant_set_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_set_spec.rb
@@ -47,75 +47,36 @@ module Pod
           PodVariant.new([@foo_subspec], Platform.ios),
           PodVariant.new([@bar_subspec], Platform.ios),
         ])
-        variants.scope_suffixes.values.should == %w(Foo Bar)
-      end
-
-      it 'returns scopes by subspec names if they qualify and handle partial root spec presence well' do
-        variants = PodVariantSet.new([
-          PodVariant.new([@foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @bar_subspec], Platform.ios),
-        ])
-        variants.scope_suffixes.values.should == %w(Foo .root-Bar)
-      end
-
-      it 'allows to differentiate between an exclusive variant with a specific subspec and ' \
-        'an inclusive variant with the default subspecs plus a non-default subspec' do
-        variants = PodVariantSet.new([
-          PodVariant.new([@foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
-        ])
-        variants.scope_suffixes.values.should == %w(Foo .default-Foo)
-      end
-
-      it 'omits default specs' do
-        variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.ios),
-        ])
-        variants.scope_suffixes.values.should == [nil, '.default-Foo', '.default-Bar']
-      end
-
-      it 'omits common specs' do
-        variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec, @inner_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @inner_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @inner_subspec, @bar_subspec], Platform.ios),
-        ])
-        variants.scope_suffixes.values.should == %w(.common .common-Foo .common-Bar)
+        variants.scope_suffixes.values.should == %w(1 2)
       end
 
       it 'returns scopes by platform names and subspec names if they qualify' do
         variants = PodVariantSet.new([
           PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
           PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
           PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.osx),
         ])
         variants.scope_suffixes.values.should == %w(
-          iOS
-          OSX
-          .default-Foo
-          .default-Bar
+          iOS-1
+          iOS-2
+          OSX-1
+          OSX-2
         )
       end
 
       it 'returns scopes by versioned platform names and subspec names if they qualify' do
         variants = PodVariantSet.new([
           PodVariant.new([@root_spec, @default_subspec], Platform.new(:ios, '7.0')),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.new(:ios, '7.0')),
           PodVariant.new([@root_spec, @default_subspec], Platform.ios),
           PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.osx),
-          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.osx),
         ])
         variants.scope_suffixes.values.should == %w(
-          iOS7.0
-          iOS
-          OSX
-          .default-Foo-iOS
-          .default-Foo-OSX
-          .default-Bar
+          iOS7.0-1
+          iOS7.0-2
+          iOS-1
+          iOS-2
         )
       end
 
@@ -123,14 +84,16 @@ module Pod
         variants = PodVariantSet.new([
           PodVariant.new([@root_spec, @default_subspec], Platform.new(:ios, '7.0')),
           PodVariant.new([@root_spec, @default_subspec], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
           PodVariant.new([@root_spec, @default_subspec], Platform.osx, true),
           PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.osx, true),
         ])
         variants.scope_suffixes.values.should == %w(
           library-iOS7.0
-          library-iOS
-          framework
-          .default-Foo
+          library-iOS-1
+          library-iOS-2
+          framework-1
+          framework-2
         )
       end
     end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -140,13 +140,13 @@ module Pod
         target, test_target = result.targets
 
         test_target.pod_targets.map(&:name).sort.should == %w(
-          libextobjc-EXTKeyPathCoding-EXTSynthesize
+          libextobjc-2
         ).sort
 
         target.pod_targets.map(&:name).sort.should == %w(
           JSONKit
           AFNetworking
-          libextobjc-EXTKeyPathCoding
+          libextobjc-1
           SVPullToRefresh
         ).sort
         target.support_files_dir.should == config.sandbox.target_support_files_dir('Pods-SampleProject')

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -41,8 +41,6 @@ module Pod
       it 'returns its label' do
         @pod_target.label.should == 'BananaLib'
         @pod_target.scoped.first.label.should == 'BananaLib-Pods'
-        spec_scoped_pod_target = @pod_target.scoped.first.tap { |t| t.stubs(:scope_suffix).returns('.default-GreenBanana') }
-        spec_scoped_pod_target.label.should == 'BananaLib.default-GreenBanana'
       end
 
       it 'returns the name of its product' do


### PR DESCRIPTION
The scope suffix name algorithm implemented by #4146 works, but brings up some lengthy suffixes when a pod is used in different subspec variant, e.g. in a case like AFNetworking, where the subspecs define internal dependencies. So depending on just a single subspec of AFNetworking might bring up some more, which might be virtual default subspecs, because they keep popping up everywhere as dependencies. It would be possible to recognize that and leave them out of the name. But as the dependencies can be itself platform-dependent that would open another can of worms.
So instead of that the pod targets could be just enumerated. That has a better performance obviously, but it is then not so easy to grasp anymore what's going on. That makes debugging and supporting harder. Only by taking a look into each aggregate targets' dependencies within Xcode, it's possible to see, which pod target belongs to which target in the user project.