### PR TITLE
Fix resource bundle paths for improved deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fixes paths passed for resources bundles in the copy resources script.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#4954](https://github.com/CocoaPods/CocoaPods/pull/4954)
 
 
 ## 1.0.0.beta.4 (2016-02-24)

--- a/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
@@ -107,15 +107,18 @@ module Pod
         library_targets = target.pod_targets.reject do |pod_target|
           pod_target.should_build? && pod_target.requires_frameworks?
         end
-        resources_by_config = {}
-        target.user_build_configurations.keys.each do |config|
-          file_accessors = library_targets.select { |t| t.include_in_build_config?(target_definition, config) }.flat_map(&:file_accessors)
-          resource_paths = file_accessors.flat_map { |accessor| accessor.resources.flat_map { |res| res.relative_path_from(project.path.dirname) } }
-          resource_bundles = file_accessors.flat_map { |accessor| accessor.resource_bundles.keys.map { |name| "${BUILT_PRODUCTS_DIR}/#{name.shellescape}.bundle" } }
-          resources_by_config[config] = (resource_paths + resource_bundles).uniq
-          resources_by_config[config] << bridge_support_file if bridge_support_file
+        target.user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
+          resources_by_config[config] = library_targets.flat_map do |library_target|
+            next [] unless library_target.include_in_build_config?(target_definition, config)
+            resource_paths = library_target.file_accessors.flat_map do |accessor|
+              accessor.resources.flat_map { |res| res.relative_path_from(project.path.dirname) }
+            end
+            resource_bundles = library_target.file_accessors.flat_map do |accessor|
+              accessor.resource_bundles.keys.map { |name| "#{library_target.configuration_build_dir}/#{name.shellescape}.bundle" }
+            end
+            (resource_paths + resource_bundles + [bridge_support_file].compact).uniq
+          end
         end
-        resources_by_config
       end
 
       # Creates a script that copies the resources to the bundle of the client

--- a/spec/unit/installer/target_installer/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/aggregate_target_installer_spec.rb
@@ -150,7 +150,16 @@ module Pod
         script.read.should.not.include?('logo-sidebar.png')
       end
 
-      xit 'adds the resources bundles to the copy resources script' do
+      it 'adds the resources bundles to the copy resources script' do
+        @pod_target.file_accessors.first.stubs(:resource_bundles).returns(
+          'Trees' => [Pathname('palm.jpg')],
+          'Leafs' => [Pathname('leaf.jpg')],
+        )
+        resources_by_config = @installer.send(:resources_by_config)
+        resources_by_config.each_value do |resources|
+          resources.should.include '$CONFIGURATION_BUILD_DIR/BananaLib/Trees.bundle'
+          resources.should.include '$CONFIGURATION_BUILD_DIR/BananaLib/Leafs.bundle'
+        end
       end
 
       it 'adds the bridge support file to the copy resources script, if one was created' do

--- a/spec/unit/installer/target_installer/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/target_installer/aggregate_target_installer_spec.rb
@@ -153,7 +153,12 @@ module Pod
       xit 'adds the resources bundles to the copy resources script' do
       end
 
-      xit 'adds the bridge support file to the copy resources script, if one was created' do
+      it 'adds the bridge support file to the copy resources script, if one was created' do
+        @installer.stubs(:bridge_support_file).returns(@installer.target.bridge_support_path)
+        resources_by_config = @installer.send(:resources_by_config)
+        resources_by_config.each_value do |resources|
+          resources.should.include @installer.target.bridge_support_path
+        end
       end
 
       it 'does add pods to the embed frameworks script' do


### PR DESCRIPTION
While #4146 fixed one problem described in #4872, it brought up another one. The paths in the `CopyResourcesScript` passed to the `install_resource` function for resource bundles are wrong.