### PR TITLE
[FileAccessor] Access root-only values from the spec consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Handle when `$PATH` isn't set.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Module maps that are set per-platform will be installed for the correct
+  platform.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#4968](https://github.com/CocoaPods/CocoaPods/issues/4968)
+
 
 ## 1.0.0.beta.4 (2016-02-24)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: cc77e5194b892786a698f67f272f13cefeca5f17
+  revision: 014afb20ee157ea25c53f55c7d50a9e3c6591766
   branch: master
   specs:
     cocoapods-core (1.0.0.beta.4)
@@ -115,7 +115,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5.1)
+    activesupport (4.2.5.2)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -259,8 +259,8 @@ module Pod
       # @return [Pathname] The of the prefix header file of the specification.
       #
       def prefix_header
-        if spec_consumer.prefix_header_file
-          path_list.root + spec_consumer.prefix_header_file
+        if file = spec_consumer.prefix_header_file
+          path_list.root + file
         end
       end
 
@@ -274,8 +274,8 @@ module Pod
       #         specification or auto-detected.
       #
       def license
-        if spec_consumer.spec.root.license[:file]
-          path_list.root + spec_consumer.spec.root.license[:file]
+        if file = spec_consumer.license[:file]
+          path_list.root + file
         else
           path_list.glob([GLOB_PATTERNS[:license]]).first
         end
@@ -284,7 +284,7 @@ module Pod
       # @return [Pathname, Nil] The path of the custom module map file of the
       #         specification, if specified.
       def module_map
-        if module_map = spec_consumer.spec.root.module_map
+        if module_map = spec_consumer.module_map
           path_list.root + module_map
         end
       end


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/CocoaPods/issues/4968.
Relies on https://github.com/CocoaPods/Core/compare/seg-allow-inheriting-root-only?expand=1

- [x] Tests
- [x] CHANGELOG
