### PR TITLE
Add emoji in CocoaPods Build Phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add :package: emoji in front of CocoaPods Script Build Phases
+  to quickly and visually differentiate them from other phases.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#4985](https://github.com/CocoaPods/CocoaPods/issues/4985)
+
 * Enable syntax highlighting on the Podfile in the generated
   `Pods.xcodeproj`.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -9,6 +9,14 @@ module Pod
       class TargetIntegrator
         autoload :XCConfigIntegrator, 'cocoapods/installer/user_project_integrator/target_integrator/xcconfig_integrator'
 
+        # @return [String] the PACKAGE emoji to use as prefix for every build phase aded to the user project
+        #
+        BUILD_PHASE_PREFIX = "\u{1F4E6} ".freeze
+
+        # @return [String] the name of the check manifest phase
+        #
+        CHECK_MANIFEST_PHASE_NAME = 'Check Pods Manifest.lock'.freeze
+
         # @return [Array<Symbol>] the symbol types, which require that the pod
         # frameworks are embedded in the output directory / product bundle.
         #
@@ -18,9 +26,9 @@ module Pod
         #
         EMBED_FRAMEWORK_PHASE_NAME = 'Embed Pods Frameworks'.freeze
 
-        # @return [String] the PACKAGE emoji to use as prefix for every build phase aded to the user project
+        # @return [String] the name of the copy resources phase
         #
-        BUILD_PHASE_PREFIX = "\u{1F4E6} ".freeze
+        COPY_PODS_RESOURCES_PHASE_NAME = 'Copy Pods Resources'.freeze
 
         # @return [AggregateTarget] the target that should be integrated.
         #
@@ -125,7 +133,7 @@ module Pod
         # @return [void]
         #
         def add_copy_resources_script_phase
-          phase_name = 'Copy Pods Resources'
+          phase_name = COPY_PODS_RESOURCES_PHASE_NAME
           native_targets.each do |native_target|
             phase = create_or_update_build_phase(native_target, phase_name)
             script_path = target.copy_resources_script_relative_path
@@ -143,7 +151,7 @@ module Pod
         # @return [void]
         #
         def add_check_manifest_lock_script_phase
-          phase_name = 'Check Pods Manifest.lock'
+          phase_name = CHECK_MANIFEST_PHASE_NAME
           native_targets.each do |native_target|
             phase = create_or_update_build_phase(native_target, phase_name)
             native_target.build_phases.unshift(phase).uniq! unless native_target.build_phases.first == phase

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -1,6 +1,13 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
 
 module Pod
+  CHECK_MANIFEST_PHASE_NAME = Installer::UserProjectIntegrator::TargetIntegrator::BUILD_PHASE_PREFIX +
+    Installer::UserProjectIntegrator::TargetIntegrator::CHECK_MANIFEST_PHASE_NAME
+  EMBED_FRAMEWORK_PHASE_NAME = Installer::UserProjectIntegrator::TargetIntegrator::BUILD_PHASE_PREFIX +
+    Installer::UserProjectIntegrator::TargetIntegrator::EMBED_FRAMEWORK_PHASE_NAME
+  COPY_PODS_RESOURCES_PHASE_NAME = Installer::UserProjectIntegrator::TargetIntegrator::BUILD_PHASE_PREFIX +
+    Installer::UserProjectIntegrator::TargetIntegrator::COPY_PODS_RESOURCES_PHASE_NAME
+
   describe TargetIntegrator = Installer::UserProjectIntegrator::TargetIntegrator do
     describe 'In general' do
       # The project contains a `PBXReferenceProxy` in the build files of the
@@ -42,7 +49,7 @@ module Pod
         it 'fixes the copy resource scripts of legacy installations' do
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Copy Pods Resources' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == COPY_PODS_RESOURCES_PHASE_NAME }
           phase.shell_script = %("${SRCROOT}/../Pods/Pods-resources.sh"\n)
           @target_integrator.integrate!
           phase.shell_script.strip.should == "\"${SRCROOT}/../Pods/Target Support Files/Pods/Pods-resources.sh\""
@@ -79,14 +86,14 @@ module Pod
         it 'adds a Copy Pods Resources build phase to each target' do
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Copy Pods Resources' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == COPY_PODS_RESOURCES_PHASE_NAME }
           phase.shell_script.strip.should == "\"${SRCROOT}/../Pods/Target Support Files/Pods/Pods-resources.sh\""
         end
 
         it 'adds a Check Manifest.lock build phase to each target' do
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Check Pods Manifest.lock' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == CHECK_MANIFEST_PHASE_NAME }
           phase.shell_script.should == <<-EOS.strip_heredoc
           diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
           if [[ $? != 0 ]] ; then
@@ -102,7 +109,7 @@ module Pod
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           target.build_phases.first
-          phase = target.build_phases.find { |bp| bp.name == 'Check Pods Manifest.lock' }
+          phase = target.build_phases.find { |bp| bp.name == CHECK_MANIFEST_PHASE_NAME }
           target.build_phases.first.should.equal? phase
         end
 
@@ -119,14 +126,14 @@ module Pod
           @pod_bundle.stubs(:requires_frameworks? => true)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == false
         end
 
         it 'adds an embed frameworks build phase by default' do
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == false
         end
 
@@ -135,7 +142,7 @@ module Pod
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:framework)
           @target_integrator.integrate!
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == true
         end
 
@@ -144,7 +151,7 @@ module Pod
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:app_extension)
           @target_integrator.integrate!
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == false
         end
 
@@ -153,7 +160,7 @@ module Pod
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:watch_extension)
           @target_integrator.integrate!
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == false
         end
 
@@ -162,7 +169,7 @@ module Pod
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:watch2_extension)
           @target_integrator.integrate!
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == false
         end
 
@@ -172,7 +179,7 @@ module Pod
           @pod_bundle.stubs(:requires_frameworks? => false)
           target = @target_integrator.send(:native_targets).first
           @target_integrator.integrate!
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.should.not.be.nil
         end
 
@@ -182,7 +189,7 @@ module Pod
           @pod_bundle.stubs(:requires_frameworks? => false)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
-          phase = target.shell_script_build_phases.find { |bp| bp.name == 'Embed Pods Frameworks' }
+          phase = target.shell_script_build_phases.find { |bp| bp.name == EMBED_FRAMEWORK_PHASE_NAME }
           phase.nil?.should == false
         end
       end


### PR DESCRIPTION
This adds an emoji in front of every Script Build Phase added by CocoaPods to the user project.

Aside the fact that emojis are awesome and should be everywhere, this also has the practical application of quickly & visually identify which phases are CP and which are from Xcode (or others).

<img width="268" alt="emojis" src="https://cloud.githubusercontent.com/assets/216089/13551428/a5fc11b6-e339-11e5-858b-b0eb624005df.png">
---

~~This PR is still WIP as the integration specs should be rebuild with the new phase names before merging.~~

However, I wanted to open it early so that we can **discuss a very serious matter: which standard Unicode emoji best describe CocoaPods-related stuff?** (is :package: a good fit or should we use another one?)

---

* [x] Prefix build phase names with an emoji
* [x] Recognize both emoji-prefixed and non-prefixed phase names in existing integrations
* [x] Update phase name for old non-prefixed integrations
* [x] Fix `Pod::Installer::UserProjectIntegrator::TargetIntegrator` specs with new name
* [x] Update integration specs
* [x] CHANGELOG