### PR TITLE
[Command::Project] No repo update by default on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ## Master
 
+##### Breaking
+
+* Running `pod install` doesn't imply an automatic spec repo update.  
+  The old behavior can be achieved by passing in the option `--repo-update`
+  or running `pod repo update`.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#5004](https://github.com/CocoaPods/CocoaPods/issues/5004)
+
+* Remove the configuration variable `skip_repo_update` as the default behavior
+  varies now between `pod install` and `pod (update|outdated)`.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#5017](https://github.com/CocoaPods/CocoaPods/issues/5017)
+
 ##### Enhancements
 
 * The master specs repo will no longer perform 'no-op' git fetches. This should

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -33,7 +33,6 @@ module Pod
     self.plugin_prefixes = %w(claide cocoapods)
 
     [Install, Update, Outdated, IPC::Podfile, IPC::Repl].each { |c| c.send(:include, ProjectDirectory) }
-    [Outdated].each { |c| c.send(:include, Project) }
 
     def self.options
       [
@@ -101,6 +100,14 @@ module Pod
     include Config::Mixin
 
     private
+
+    # Returns a new {Installer} parametrized from the {Config}.
+    #
+    # @return [Installer]
+    #
+    def installer_for_config
+      Installer.new(config.sandbox, config.podfile, config.lockfile)
+    end
 
     # Checks that the podfile exists.
     #

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -14,6 +14,9 @@ module Pod
   end
 
   class Command < CLAide::Command
+    require 'cocoapods/command/options/project_directory'
+    include Options
+
     require 'cocoapods/command/inter_process_communication'
     require 'cocoapods/command/lib'
     require 'cocoapods/command/list'
@@ -31,8 +34,6 @@ module Pod
     self.version = VERSION
     self.description = 'CocoaPods, the Cocoa library package manager.'
     self.plugin_prefixes = %w(claide cocoapods)
-
-    [Install, Update, Outdated, IPC::Podfile, IPC::Repl].each { |c| c.send(:include, ProjectDirectory) }
 
     def self.options
       [

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -17,14 +17,15 @@ module Pod
     require 'cocoapods/command/options/project_directory'
     include Options
 
+    require 'cocoapods/command/install'
     require 'cocoapods/command/inter_process_communication'
     require 'cocoapods/command/lib'
     require 'cocoapods/command/list'
     require 'cocoapods/command/outdated'
-    require 'cocoapods/command/project'
     require 'cocoapods/command/repo'
     require 'cocoapods/command/setup'
     require 'cocoapods/command/spec'
+    require 'cocoapods/command/update'
     require 'cocoapods/command/init'
     require 'cocoapods/command/cache'
     require 'cocoapods/command/env'

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -17,6 +17,9 @@ module Pod
     require 'cocoapods/command/options/project_directory'
     include Options
 
+    require 'cocoapods/command/cache'
+    require 'cocoapods/command/env'
+    require 'cocoapods/command/init'
     require 'cocoapods/command/install'
     require 'cocoapods/command/inter_process_communication'
     require 'cocoapods/command/lib'
@@ -26,9 +29,6 @@ module Pod
     require 'cocoapods/command/setup'
     require 'cocoapods/command/spec'
     require 'cocoapods/command/update'
-    require 'cocoapods/command/init'
-    require 'cocoapods/command/cache'
-    require 'cocoapods/command/env'
 
     self.abstract_command = true
     self.command = 'pod'

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -14,6 +14,7 @@ module Pod
   end
 
   class Command < CLAide::Command
+    require 'cocoapods/command/options/repo_update'
     require 'cocoapods/command/options/project_directory'
     include Options
 

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -12,7 +12,7 @@ module Pod
 
         The Xcode project file should be specified in your `Podfile` like this:
 
-            project 'path/to/XcodeProject'
+            project 'path/to/XcodeProject.xcodeproj'
 
         If no project is specified, then a search for an Xcode project will
         be made. If more than one Xcode project is found, the command will

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -30,10 +30,9 @@ module Pod
       end
 
       def run
-        config.skip_repo_update = !repo_update?(:default => false)
-
         verify_podfile_exists!
         installer = installer_for_config
+        installer.repo_update = repo_update?(:default => false)
         installer.update = false
         installer.install!
       end

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -1,6 +1,7 @@
 module Pod
   class Command
     class Install < Command
+      include RepoUpdate
       include ProjectDirectory
 
       self.summary = 'Install project dependencies to Podfile.lock versions'
@@ -25,15 +26,12 @@ module Pod
       def self.options
         [
           ['--repo-update', 'Force running `pod repo update` before install'],
-        ].concat(super)
-      end
-
-      def initialize(argv)
-        config.skip_repo_update = !argv.flag?('repo-update', false)
-        super
+        ].concat(super).reject { |(name, _)| name == '--no-repo-update' }
       end
 
       def run
+        config.skip_repo_update = !repo_update?(:default => false)
+
         verify_podfile_exists!
         installer = installer_for_config
         installer.update = false

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -1,0 +1,44 @@
+module Pod
+  class Command
+    class Install < Command
+      include ProjectDirectory
+
+      self.summary = 'Install project dependencies to Podfile.lock versions'
+
+      self.description = <<-DESC
+        Downloads all dependencies defined in `Podfile` and creates an Xcode
+        Pods library project in `./Pods`.
+
+        The Xcode project file should be specified in your `Podfile` like this:
+
+            project 'path/to/XcodeProject'
+
+        If no project is specified, then a search for an Xcode project will
+        be made. If more than one Xcode project is found, the command will
+        raise an error.
+
+        This will configure the project to reference the Pods static library,
+        add a build configuration file, and add a post build script to copy
+        Pod resources.
+      DESC
+
+      def self.options
+        [
+          ['--repo-update', 'Force running `pod repo update` before install'],
+        ].concat(super)
+      end
+
+      def initialize(argv)
+        config.skip_repo_update = !argv.flag?('repo-update', false)
+        super
+      end
+
+      def run
+        verify_podfile_exists!
+        installer = installer_for_config
+        installer.update = false
+        installer.install!
+      end
+    end
+  end
+end

--- a/lib/cocoapods/command/inter_process_communication.rb
+++ b/lib/cocoapods/command/inter_process_communication.rb
@@ -37,6 +37,8 @@ module Pod
       #-----------------------------------------------------------------------#
 
       class Podfile < IPC
+        include ProjectDirectory
+
         self.summary = 'Converts a Podfile to YAML'
         self.description = 'Converts a Podfile to YAML and prints it to STDOUT.'
         self.arguments = [
@@ -123,6 +125,8 @@ module Pod
       #-----------------------------------------------------------------------#
 
       class Repl < IPC
+        include ProjectDirectory
+
         END_OF_OUTPUT_SIGNAL = "\n\r"
 
         self.summary = 'The repl listens to commands on standard input'

--- a/lib/cocoapods/command/options/project_directory.rb
+++ b/lib/cocoapods/command/options/project_directory.rb
@@ -1,0 +1,36 @@
+module Pod
+  class Command
+    module Options
+      # Provides support for commands to take a user-specified `project directory`
+      #
+      module ProjectDirectory
+        module Options
+          def options
+            [
+              ['--project-directory=/project/dir/', 'The path to the root of the project directory'],
+            ].concat(super)
+          end
+        end
+
+        def self.included(base)
+          base.extend(Options)
+        end
+
+        def initialize(argv)
+          if project_directory = argv.option('project-directory')
+            @project_directory = Pathname.new(project_directory).expand_path
+          end
+          config.installation_root = @project_directory
+          super
+        end
+
+        def validate!
+          super
+          if @project_directory && !@project_directory.directory?
+            raise Informative, "`#{@project_directory}` is not a valid directory."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods/command/options/repo_update.rb
+++ b/lib/cocoapods/command/options/repo_update.rb
@@ -1,0 +1,34 @@
+module Pod
+  class Command
+    module Options
+      # Provides support for commands to skip updating the spec repositories.
+      #
+      module RepoUpdate
+        module Options
+          def options
+            [
+              ['--no-repo-update', 'Skip running `pod repo update` before install'],
+            ].concat(super)
+          end
+        end
+
+        def self.included(base)
+          base.extend(Options)
+        end
+
+        def repo_update?(default: false)
+          if @repo_update.nil?
+            default
+          else
+            @repo_update
+          end
+        end
+
+        def initialize(argv)
+          @repo_update = argv.flag?('repo-update')
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -8,6 +8,17 @@ module Pod
         spec repos, not those from local/external sources or `:head` versions.
       DESC
 
+      def self.options
+        [
+          ['--no-repo-update', 'Skip running `pod repo update` before install'],
+        ].concat(super)
+      end
+
+      def initialize(argv)
+        config.skip_repo_update = !argv.flag?('repo-update', !config.skip_repo_update)
+        super
+      end
+
       # Run the command
       #
       # @todo the command report new dependencies added to the Podfile as

--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -1,6 +1,8 @@
 module Pod
   class Command
     class Outdated < Command
+      include ProjectDirectory
+
       self.summary = 'Show outdated project dependencies'
 
       self.description = <<-DESC

--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -1,6 +1,7 @@
 module Pod
   class Command
     class Outdated < Command
+      include RepoUpdate
       include ProjectDirectory
 
       self.summary = 'Show outdated project dependencies'
@@ -9,17 +10,6 @@ module Pod
         Shows the outdated pods in the current Podfile.lock, but only those from
         spec repos, not those from local/external sources or `:head` versions.
       DESC
-
-      def self.options
-        [
-          ['--no-repo-update', 'Skip running `pod repo update` before install'],
-        ].concat(super)
-      end
-
-      def initialize(argv)
-        config.skip_repo_update = !argv.flag?('repo-update', !config.skip_repo_update)
-        super
-      end
 
       # Run the command
       #
@@ -103,7 +93,7 @@ module Pod
 
       def spec_sets
         @spec_sets ||= begin
-          analyzer.send(:update_repositories) unless config.skip_repo_update?
+          analyzer.send(:update_repositories) if repo_update?(:default => true)
           aggregate = Source::Aggregate.new(analyzer.sources)
           installed_pods.map do |pod_name|
             aggregate.search(Dependency.new(pod_name))

--- a/lib/cocoapods/command/project.rb
+++ b/lib/cocoapods/command/project.rb
@@ -1,40 +1,8 @@
 module Pod
   class Command
-    # Provides support for commands to take a user-specified `project directory`
-    #
-    module ProjectDirectory
-      module Options
-        def options
-          [
-            ['--project-directory=/project/dir/', 'The path to the root of the project directory'],
-          ].concat(super)
-        end
-      end
-
-      def self.included(base)
-        base.extend(Options)
-      end
-
-      def initialize(argv)
-        if project_directory = argv.option('project-directory')
-          @project_directory = Pathname.new(project_directory).expand_path
-        end
-        config.installation_root = @project_directory
-        super
-      end
-
-      def validate!
-        super
-        if @project_directory && !@project_directory.directory?
-          raise Informative,
-                "`#{@project_directory}` is not a valid directory."
-        end
-      end
-    end
-
-    #-------------------------------------------------------------------------#
-
     class Install < Command
+      include ProjectDirectory
+
       self.summary = 'Install project dependencies to Podfile.lock versions'
 
       self.description = <<-DESC
@@ -76,6 +44,8 @@ module Pod
     #-------------------------------------------------------------------------#
 
     class Update < Command
+      include ProjectDirectory
+
       self.summary = 'Update outdated project dependencies and create new ' \
         'Podfile.lock'
 

--- a/lib/cocoapods/command/project.rb
+++ b/lib/cocoapods/command/project.rb
@@ -102,7 +102,7 @@ module Pod
           verify_pods_are_installed!
           installer.update = { :pods => @pods }
         else
-          UI.puts 'Update all pods'.yellow unless @pods
+          UI.puts 'Update all pods'.yellow
           installer.update = true
         end
         installer.install!

--- a/lib/cocoapods/command/project.rb
+++ b/lib/cocoapods/command/project.rb
@@ -36,23 +36,6 @@ module Pod
     # commands.
     #
     module Project
-      module Options
-        def options
-          [
-            ['--no-repo-update', 'Skip running `pod repo update` before install'],
-          ].concat(super)
-        end
-      end
-
-      def self.included(base)
-        base.extend Options
-      end
-
-      def initialize(argv)
-        config.skip_repo_update = !argv.flag?('repo-update', !config.skip_repo_update)
-        super
-      end
-
       # Runs the installer.
       #
       # @param  [Hash, Boolean, nil] update
@@ -92,6 +75,17 @@ module Pod
         Pod resources.
       DESC
 
+      def self.options
+        [
+          ['--repo-update', 'Force running `pod repo update` before install'],
+        ].concat(super)
+      end
+
+      def initialize(argv)
+        config.skip_repo_update = !argv.flag?('repo-update', false)
+        super
+      end
+
       def run
         verify_podfile_exists!
         run_install_with_update(false)
@@ -118,7 +112,14 @@ module Pod
         CLAide::Argument.new('POD_NAMES', false, true),
       ]
 
+      def self.options
+        [
+          ['--no-repo-update', 'Skip running `pod repo update` before install'],
+        ].concat(super)
+      end
+
       def initialize(argv)
+        config.skip_repo_update = !argv.flag?('repo-update', !config.skip_repo_update)
         @pods = argv.arguments! unless argv.arguments.empty?
         super
       end

--- a/lib/cocoapods/command/update.rb
+++ b/lib/cocoapods/command/update.rb
@@ -1,6 +1,7 @@
 module Pod
   class Command
     class Update < Command
+      include RepoUpdate
       include ProjectDirectory
 
       self.summary = 'Update outdated project dependencies and create new ' \
@@ -18,14 +19,7 @@ module Pod
         CLAide::Argument.new('POD_NAMES', false, true),
       ]
 
-      def self.options
-        [
-          ['--no-repo-update', 'Skip running `pod repo update` before install'],
-        ].concat(super)
-      end
-
       def initialize(argv)
-        config.skip_repo_update = !argv.flag?('repo-update', !config.skip_repo_update)
         @pods = argv.arguments! unless argv.arguments.empty?
         super
       end
@@ -51,6 +45,8 @@ module Pod
       end
 
       def run
+        config.skip_repo_update = !repo_update?(:default => true)
+
         verify_podfile_exists!
 
         installer = installer_for_config

--- a/lib/cocoapods/command/update.rb
+++ b/lib/cocoapods/command/update.rb
@@ -45,11 +45,10 @@ module Pod
       end
 
       def run
-        config.skip_repo_update = !repo_update?(:default => true)
-
         verify_podfile_exists!
 
         installer = installer_for_config
+        installer.repo_update = repo_update?(:default => true)
         if @pods
           verify_lockfile_exists!
           verify_pods_are_installed!

--- a/lib/cocoapods/command/update.rb
+++ b/lib/cocoapods/command/update.rb
@@ -1,48 +1,5 @@
 module Pod
   class Command
-    class Install < Command
-      include ProjectDirectory
-
-      self.summary = 'Install project dependencies to Podfile.lock versions'
-
-      self.description = <<-DESC
-        Downloads all dependencies defined in `Podfile` and creates an Xcode
-        Pods library project in `./Pods`.
-
-        The Xcode project file should be specified in your `Podfile` like this:
-
-            project 'path/to/XcodeProject'
-
-        If no project is specified, then a search for an Xcode project will
-        be made. If more than one Xcode project is found, the command will
-        raise an error.
-
-        This will configure the project to reference the Pods static library,
-        add a build configuration file, and add a post build script to copy
-        Pod resources.
-      DESC
-
-      def self.options
-        [
-          ['--repo-update', 'Force running `pod repo update` before install'],
-        ].concat(super)
-      end
-
-      def initialize(argv)
-        config.skip_repo_update = !argv.flag?('repo-update', false)
-        super
-      end
-
-      def run
-        verify_podfile_exists!
-        installer = installer_for_config
-        installer.update = false
-        installer.install!
-      end
-    end
-
-    #-------------------------------------------------------------------------#
-
     class Update < Command
       include ProjectDirectory
 

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -14,7 +14,6 @@ module Pod
     DEFAULTS = {
       :verbose             => false,
       :silent              => false,
-      :skip_repo_update    => false,
       :skip_download_cache => !ENV['COCOAPODS_SKIP_CACHE'].nil?,
 
       :new_version_message => ENV['COCOAPODS_SKIP_UPDATE_MESSAGE'].nil?,
@@ -68,11 +67,6 @@ module Pod
     #-------------------------------------------------------------------------#
 
     # @!group Installation
-
-    # @return [Bool] Whether the installer should skip the repos update.
-    #
-    attr_accessor :skip_repo_update
-    alias_method :skip_repo_update?, :skip_repo_update
 
     # @return [Bool] Whether the installer should skip the download cache.
     #

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -84,6 +84,11 @@ module Pod
     #
     attr_accessor :update
 
+    # @return [Bool] Whether the spec repos should be updated.
+    #
+    attr_accessor :repo_update
+    alias_method :repo_update?, :repo_update
+
     # @return [Boolean] Whether default plugins should be used during
     #                   installation. Defaults to true.
     #
@@ -140,7 +145,7 @@ module Pod
 
       UI.section 'Updating local specs repositories' do
         analyzer.update_repositories
-      end unless config.skip_repo_update?
+      end if repo_update?
 
       UI.section 'Analyzing dependencies' do
         analyze(analyzer)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -212,7 +212,7 @@ module Pod
 
       public
 
-      # Updates the git source repositories unless the config indicates to skip it.
+      # Updates the git source repositories.
       #
       def update_repositories
         sources.each do |source|

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -349,7 +349,6 @@ module Pod
       @original_config = Config.instance.clone
       config.installation_root   = validation_dir
       config.silent              = !config.verbose
-      config.skip_repo_update    = true
     end
 
     def tear_down_validation_environment

--- a/spec/functional/command/install_spec.rb
+++ b/spec/functional/command/install_spec.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  describe Command::Install do
+    it 'tells the user that no Podfile or podspec was found in the project dir' do
+      exception = lambda { run_command('install', '--no-repo-update') }.should.raise Informative
+      exception.message.should.include "No `Podfile' found in the project directory."
+    end
+
+    it "doesn't update the spec repos by default" do
+      config.with_changes(:skip_repo_update => nil) do
+        Pod::Command.parse(['install'])
+        config.skip_repo_update.should.be.true
+      end
+    end
+
+    it 'updates the spec repos if that option was given' do
+      config.with_changes(:skip_repo_update => nil) do
+        Pod::Command.parse(['install', '--repo-update'])
+        config.skip_repo_update.should.be.false
+      end
+    end
+  end
+end

--- a/spec/functional/command/install_spec.rb
+++ b/spec/functional/command/install_spec.rb
@@ -7,17 +7,24 @@ module Pod
       exception.message.should.include "No `Podfile' found in the project directory."
     end
 
-    it "doesn't update the spec repos by default" do
-      config.with_changes(:skip_repo_update => nil) do
-        Pod::Command.parse(['install'])
-        config.skip_repo_update.should.be.true
+    describe 'updates of the spec repos' do
+      before do
+        file = temporary_directory + 'Podfile'
+        File.open(file, 'w') do |f|
+          f.puts('platform :ios')
+          f.puts('pod "Reachability"')
+        end
+        Installer.any_instance.expects(:install!)
       end
-    end
 
-    it 'updates the spec repos if that option was given' do
-      config.with_changes(:skip_repo_update => nil) do
-        Pod::Command.parse(['install', '--repo-update'])
-        config.skip_repo_update.should.be.false
+      it "doesn't update the spec repos by default" do
+        Installer.any_instance.expects(:repo_update=).with(false)
+        run_command('install')
+      end
+
+      it 'updates the spec repos if that option was given' do
+        Installer.any_instance.expects(:repo_update=).with(true)
+        run_command('install', '--repo-update')
       end
     end
   end

--- a/spec/functional/command/outdated_spec.rb
+++ b/spec/functional/command/outdated_spec.rb
@@ -6,7 +6,6 @@ module Pod
 
     before do
       Command::Outdated.any_instance.stubs(:unlocked_pods).returns([])
-      config.stubs(:skip_repo_update?).returns(true)
     end
 
     it 'tells the user that no Podfile was found in the project dir' do
@@ -55,7 +54,6 @@ module Pod
         pod 'AFNetworking'
       end
       config.stubs(:podfile).returns(podfile)
-      config.stubs(:skip_repo_update?).returns(false)
       lockfile = mock
       lockfile.stubs(:version).returns(Version.new('1.0'))
       lockfile.stubs(:pod_names).returns(%w(AFNetworking))
@@ -69,8 +67,6 @@ module Pod
         source 'https://github.com/CocoaPods/Specs.git'
         pod 'AFNetworking'
       end
-      config.unstub(:skip_repo_update?)
-      config.skip_repo_update = false
       lockfile = mock
       lockfile.stubs(:version).returns(Version.new('1.0'))
       lockfile.stubs(:pod_names).returns(%w(AFNetworking))

--- a/spec/functional/command/project_spec.rb
+++ b/spec/functional/command/project_spec.rb
@@ -1,19 +1,24 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 module Pod
-  describe Command::Project do
-    it 'tells the user that no Podfile or podspec was found in the current working dir' do
-      Command::Install.new(CLAide::ARGV.new(['--no-repo-update']))
-      config.skip_repo_update.should.be.true
-    end
-  end
-
-  #---------------------------------------------------------------------------#
-
   describe Command::Install do
     it 'tells the user that no Podfile or podspec was found in the project dir' do
       exception = lambda { run_command('install', '--no-repo-update') }.should.raise Informative
       exception.message.should.include "No `Podfile' found in the project directory."
+    end
+
+    it "doesn't update the spec repos by default" do
+      config.with_changes(:skip_repo_update => nil) do
+        Pod::Command.parse(['install'])
+        config.skip_repo_update.should.be.true
+      end
+    end
+
+    it 'updates the spec repos if that option was given' do
+      config.with_changes(:skip_repo_update => nil) do
+        Pod::Command.parse(['install', '--repo-update'])
+        config.skip_repo_update.should.be.false
+      end
     end
   end
 
@@ -25,6 +30,20 @@ module Pod
     it 'tells the user that no Podfile was found in the project dir' do
       exception = lambda { run_command('update', '--no-repo-update') }.should.raise Informative
       exception.message.should.include "No `Podfile' found in the project directory."
+    end
+
+    it 'updates the spec repos by default' do
+      config.with_changes(:skip_repo_update => nil) do
+        Pod::Command.parse(['update'])
+        config.skip_repo_update.should.be.false
+      end
+    end
+
+    it "doesn't update the spec repos if that option was given" do
+      config.with_changes(:skip_repo_update => nil) do
+        Pod::Command.parse(['update', '--no-repo-update'])
+        config.skip_repo_update.should.be.true
+      end
     end
 
     it 'tells the user that no Lockfile was found in the project dir' do

--- a/spec/functional/command/repo/list_spec.rb
+++ b/spec/functional/command/repo/list_spec.rb
@@ -44,8 +44,6 @@ module Pod
     end
 
     describe 'with a git based spec repository with a remote' do
-      extend SpecHelper::TemporaryRepos
-
       before do
         config.repos_dir = tmp_repos_path
 

--- a/spec/functional/command/spec_spec.rb
+++ b/spec/functional/command/spec_spec.rb
@@ -194,8 +194,6 @@ module Pod
     #-------------------------------------------------------------------------#
 
     describe 'lint subcommand' do
-      extend SpecHelper::TemporaryRepos
-
       it "complains if it can't find any spec to lint" do
         Dir.chdir(temporary_directory) do
           lambda { command('spec', 'lint').run }.should.raise Informative

--- a/spec/functional/command/update_spec.rb
+++ b/spec/functional/command/update_spec.rb
@@ -38,8 +38,6 @@ module Pod
       end
 
       describe 'tells the user that the Pods cannot be updated unless they are installed' do
-        extend SpecHelper::TemporaryRepos
-
         before do
           podfile = Podfile.new do
             platform :ios

--- a/spec/functional/command/update_spec.rb
+++ b/spec/functional/command/update_spec.rb
@@ -1,29 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 module Pod
-  describe Command::Install do
-    it 'tells the user that no Podfile or podspec was found in the project dir' do
-      exception = lambda { run_command('install', '--no-repo-update') }.should.raise Informative
-      exception.message.should.include "No `Podfile' found in the project directory."
-    end
-
-    it "doesn't update the spec repos by default" do
-      config.with_changes(:skip_repo_update => nil) do
-        Pod::Command.parse(['install'])
-        config.skip_repo_update.should.be.true
-      end
-    end
-
-    it 'updates the spec repos if that option was given' do
-      config.with_changes(:skip_repo_update => nil) do
-        Pod::Command.parse(['install', '--repo-update'])
-        config.skip_repo_update.should.be.false
-      end
-    end
-  end
-
-  #---------------------------------------------------------------------------#
-
   describe Command::Update do
     extend SpecHelper::TemporaryRepos
 
@@ -99,6 +76,4 @@ module Pod
       end
     end
   end
-
-  #---------------------------------------------------------------------------#
 end

--- a/spec/functional/command/update_spec.rb
+++ b/spec/functional/command/update_spec.rb
@@ -7,20 +7,6 @@ module Pod
       exception.message.should.include "No `Podfile' found in the project directory."
     end
 
-    it 'updates the spec repos by default' do
-      config.with_changes(:skip_repo_update => nil) do
-        Pod::Command.parse(['update'])
-        config.skip_repo_update.should.be.false
-      end
-    end
-
-    it "doesn't update the spec repos if that option was given" do
-      config.with_changes(:skip_repo_update => nil) do
-        Pod::Command.parse(['update', '--no-repo-update'])
-        config.skip_repo_update.should.be.true
-      end
-    end
-
     describe 'with Podfile' do
       extend SpecHelper::TemporaryRepos
 
@@ -29,6 +15,22 @@ module Pod
         File.open(file, 'w') do |f|
           f.puts('platform :ios')
           f.puts('pod "BananaLib", "1.0"')
+        end
+      end
+
+      describe 'updates of the spec repos' do
+        before do
+          Installer.any_instance.expects(:install!)
+        end
+
+        it 'updates the spec repos by default' do
+          Installer.any_instance.expects(:repo_update=).with(true)
+          run_command('update')
+        end
+
+        it "doesn't update the spec repos if that option was given" do
+          Installer.any_instance.expects(:repo_update=).with(false)
+          run_command('update', '--no-repo-update')
         end
       end
 

--- a/spec/spec_helper/pre_flight.rb
+++ b/spec/spec_helper/pre_flight.rb
@@ -11,7 +11,6 @@ module Bacon
         c.silent            =  true
         c.repos_dir         =  fixture('spec-repos')
         c.installation_root =  SpecHelper.temporary_directory
-        c.skip_repo_update  =  true
         c.cache_root        =  SpecHelper.temporary_directory + 'Cache'
       end
 

--- a/spec/spec_helper/temporary_repos.rb
+++ b/spec/spec_helper/temporary_repos.rb
@@ -76,12 +76,26 @@ module SpecHelper
     #--------------------------------------#
 
     def tmp_repos_path
+      TemporaryRepos.tmp_repos_path
+    end
+
+    def self.tmp_repos_path
       SpecHelper.temporary_directory + 'cocoapods/repos'
     end
 
-    module_function :tmp_repos_path
-
     def self.extended(base)
+      # Make Context methods available
+      # WORKAROUND: Bacon auto-inherits singleton methods to child contexts
+      # by using the runtime and won't include methods in modules included
+      # by the parent context. We have to ensure that the methods will be
+      # accessible by the child contexts by defining them as singleton methods.
+      TemporaryRepos.instance_methods.each do |method|
+        unbound_method = base.method(method).unbind
+        base.define_singleton_method method do |*args, &b|
+          unbound_method.bind(self).call(*args, &b)
+        end
+      end
+
       base.before do
         tmp_repos_path.mkpath
       end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -66,7 +66,6 @@ module Pod
       #--------------------------------------#
 
       it 'does not update unused sources' do
-        config.skip_repo_update = false
         @analyzer.stubs(:sources).returns(SourcesManager.master)
         SourcesManager.expects(:update).once.with('master')
         @analyzer.update_repositories
@@ -77,7 +76,6 @@ module Pod
           source 'https://github.com/CocoaPods/Specs.git'
           # No dependencies specified
         end
-        config.skip_repo_update = false
         config.verbose = true
 
         SourcesManager.expects(:update).never
@@ -96,7 +94,6 @@ module Pod
           project 'SampleProject/SampleProject'
           pod 'BananaLib', '1.0'
         end
-        config.skip_repo_update = false
         config.verbose = true
 
         source = Source.new(non_git_repo)
@@ -118,7 +115,6 @@ module Pod
           pod 'BananaLib', '1.0', :source => repo_url
           pod 'JSONKit', :source => repo_url
         end
-        config.skip_repo_update = false
         config.verbose = true
 
         # Note that we are explicitly ignoring 'repo_1' since it isn't used.

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -105,7 +105,6 @@ module Pod
       end
 
       it 'runs source provider hooks before analyzing' do
-        config.skip_repo_update = true
         @installer.unstub(:resolve_dependencies)
         @installer.stubs(:validate_build_configurations)
         @installer.stubs(:clean_sandbox)
@@ -136,7 +135,6 @@ module Pod
         @installer.stubs(:clean_sandbox)
         @installer.stubs(:ensure_plugins_are_installed!)
         @installer.stubs(:analyze)
-        config.skip_repo_update = true
 
         analyzer = Installer::Analyzer.new(config.sandbox, @installer.podfile, @installer.lockfile)
         analyzer.stubs(:analyze)
@@ -376,14 +374,13 @@ module Pod
 
     describe 'Dependencies Resolution' do
       describe 'updating spec repos' do
-        it 'does not updates the repositories if config indicates to skip them' do
-          config.skip_repo_update = true
+        it 'does not updates the repositories by default' do
           SourcesManager.expects(:update).never
           @installer.send(:resolve_dependencies)
         end
 
-        it 'updates the repositories by default' do
-          config.skip_repo_update = false
+        it 'updates the repositories if that was requested' do
+          @installer.repo_update = true
           SourcesManager.expects(:update).once
           @installer.send(:resolve_dependencies)
         end


### PR DESCRIPTION
Fixes #5004.

Will requires updates in because of the removal of `Config.skip_repo_update`:
* [x] [cocoapods-search](https://github.com/CocoaPods/cocoapods-search)
* [x] [cocoapods-edit](https://github.com/CocoaPods/cocoapods-edit)
* [x] [cocoapods-packager](https://github.com/CocoaPods/cocoapods-packager)
* [x] [cocoapods-try](https://github.com/CocoaPods/cocoapods-try)