### PR TITLE
Disallow shallow clones of specs repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#5005](https://github.com/CocoaPods/CocoaPods/issues/5005)
   [#4989](https://github.com/CocoaPods/CocoaPods/issues/4989)
 
+* The master specs repo will no longer support shallow clones to reduce CPU load
+  on GitHub's servers. Pre-existing shallow clones will automatically be
+  upgraded to deep clones when the repo is updated.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#5016](https://github.com/CocoaPods/CocoaPods/issues/5016)
+
 ##### Bug Fixes
 
 * None.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* The master specs repository can no longer be added via `pod repo add`, but
+  instead must be done via `pod setup`.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 1.0.0.beta.5 (2016-03-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#5005](https://github.com/CocoaPods/CocoaPods/issues/5005)
   [#4989](https://github.com/CocoaPods/CocoaPods/issues/4989)
 
-* The master specs repo will no longer support shallow clones to reduce CPU load
-  on GitHub's servers. Pre-existing shallow clones will automatically be
-  upgraded to deep clones when the repo is updated.  
+* The specs repos will no longer support shallow clones to reduce CPU load
+  on git servers. Pre-existing shallow clones of the `master` repo will
+  automatically be upgraded to deep clones when the repo is updated.  
   [Samuel Giddins](https://github.com/segiddins)
   [#5016](https://github.com/CocoaPods/CocoaPods/issues/5016)
 

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -15,14 +15,7 @@ module Pod
           CLAide::Argument.new('BRANCH', false),
         ]
 
-        def self.options
-          [
-            ['--shallow', 'Create a shallow clone (fast clone, but no push capabilities)'],
-          ].concat(super)
-        end
-
         def initialize(argv)
-          @shallow = argv.flag?('shallow', false)
           @name = argv.shift_argument
           @url = argv.shift_argument
           @branch = argv.shift_argument
@@ -41,8 +34,7 @@ module Pod
         end
 
         def run
-          prefix = @shallow ? 'Creating shallow clone of' : 'Cloning'
-          section = "#{prefix} spec repo `#{@name}` from `#{@url}`"
+          section = "Cloning spec repo `#{@name}` from `#{@url}`"
           section << " (branch `#{@branch}`)" if @branch
           UI.section(section) do
             create_repos_dir
@@ -76,7 +68,6 @@ module Pod
         def clone_repo
           Dir.chdir(config.repos_dir) do
             command = ['clone', @url, @name]
-            command << '--depth=1' if @shallow
             git!(command)
           end
         end

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -38,7 +38,9 @@ module Pod
 
         def run
           prefix = @shallow ? 'Creating shallow clone of' : 'Cloning'
-          UI.section("#{prefix} spec repo `#{@name}` from `#{@url}`#{" (branch `#{@branch}`)" if @branch}") do
+          section = "#{prefix} spec repo `#{@name}` from `#{@url}`"
+          section << " (branch `#{@branch}`)" if @branch
+          UI.section(section) do
             create_repos_dir
             clone_repo
             checkout_branch

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -34,6 +34,10 @@ module Pod
           unless @name && @url
             help! 'Adding a repo needs a `NAME` and a `URL`.'
           end
+          if @name == 'master' || @url =~ %r{github.com[:/]+cocoapods/specs}i
+            raise Informative,
+                  'To setup the master specs repo, please run `pod setup`.'
+          end
         end
 
         def run

--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -14,19 +14,8 @@ module Pod
         If the clone already exists, it will ensure that it is up-to-date.
       DESC
 
-      def self.options
-        [
-          ['--no-shallow', 'Clone full history so push will work'],
-        ].concat(super)
-      end
-
       extend Executable
       executable :git
-
-      def initialize(argv)
-        @shallow = argv.flag?('shallow', true)
-        super
-      end
 
       def run
         UI.section 'Setting up CocoaPods master repo' do
@@ -62,7 +51,6 @@ module Pod
       #
       def add_master_repo
         cmd = ['master', url, 'master']
-        cmd << '--shallow' if @shallow
         Repo::Add.parse(cmd).run
       end
 

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -625,6 +625,7 @@ module Pod
     end
 
     def update_git_repo(show_output = false)
+      ensure_in_repo!
       Config.instance.with_changes(:verbose => show_output) do
         git!(%w(pull --ff-only))
       end
@@ -633,6 +634,18 @@ module Pod
                 "`#{name}` repo. If this is an unexpected issue " \
                 'and persists you can inspect it running ' \
                 '`pod repo update --verbose`'
+    end
+  end
+
+  class MasterSource
+    def update_git_repo(show_output = false)
+      ensure_in_repo!
+      if repo.join('.git', 'shallow').file?
+        UI.info "Performing a deep fetch of the `#{name}` specs repo to improve future performance" do
+          git!(%w(fetch --unshallow))
+        end
+      end
+      super
     end
   end
 end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -61,9 +61,11 @@ module Pod
           previous_title_level = UI.title_level
           UI.title_level = 0
           begin
-            argv = [name, url]
-            argv << '--shallow' if name =~ /^master(-\d+)?$/
-            Command::Repo::Add.new(CLAide::ARGV.new(argv)).run
+            if name =~ /^master(-\d+)?$/
+              Command::Setup.parse([]).run
+            else
+              Command::Repo::Add.parse([name, url]).run
+            end
           rescue Informative
             raise Informative, "Unable to add a source with url `#{url}` " \
               "named `#{name}`.\nYou can try adding it manually in " \

--- a/spec/functional/command/repo/add_spec.rb
+++ b/spec/functional/command/repo/add_spec.rb
@@ -28,17 +28,6 @@ module Pod
       Dir.chdir(repo2.dir) { `git symbolic-ref HEAD` }.should.include? 'my-branch'
     end
 
-    it 'adds a spec-repo by creating a shallow clone' do
-      Dir.chdir(test_repo_path) do
-        `echo 'touch' > touch && git add touch && git commit -m 'updated'`
-      end
-      # Need to use file:// to test local use of --depth=1
-      run_command('repo', 'add', 'private', '--shallow', "file://#{test_repo_path}")
-      Dir.chdir(config.repos_dir + 'private') do
-        `git log --pretty=oneline`.strip.split("\n").size.should == 1
-      end
-    end
-
     it 'raises an informative error when the repos directory fails to be created' do
       repos_dir = config.repos_dir
       def repos_dir.mkpath

--- a/spec/functional/command/repo/add_spec.rb
+++ b/spec/functional/command/repo/add_spec.rb
@@ -47,5 +47,15 @@ module Pod
       e = lambda { run_command('repo', 'add', 'private', test_repo_path) }.should.raise Informative
       e.message.should.match /Could not create '#{tmp_repos_path}', the CocoaPods repo cache directory./
     end
+
+    it 'raises an informative error when attempting to add the master repo' do
+      master = command('repo', 'add', 'master', 'https://github.com/foo/bar.git')
+      should.raise(Informative) { master.validate! }.message.should.
+        include('To setup the master specs repo, please run `pod setup`')
+
+      master = command('repo', 'add', 'foo-bar', 'https://github.com/CocoaPods/Specs.git')
+      should.raise(Informative) { master.validate! }.message.should.
+        include('To setup the master specs repo, please run `pod setup`')
+    end
   end
 end

--- a/spec/functional/command/setup_spec.rb
+++ b/spec/functional/command/setup_spec.rb
@@ -32,23 +32,11 @@ module Pod
       url.should == test_repo_path.to_s
     end
 
-    it 'creates a shallow clone of the `master` repo by default' do
+    it 'creates a full clone of the `master` repo' do
       Dir.chdir(test_repo_path) do
         `echo 'touch' > touch && git add touch && git commit -m 'updated'`
       end
-      # Need to use file:// to test local use of --depth=1
-      Command::Setup.stubs(:read_only_url).returns("file://#{test_repo_path}")
       run_command('setup')
-      Dir.chdir(config.repos_dir + 'master') do
-        `git log --pretty=oneline`.strip.split("\n").size.should == 1
-      end
-    end
-
-    it 'creates a full clone of the `master` repo if requested' do
-      Dir.chdir(test_repo_path) do
-        `echo 'touch' > touch && git add touch && git commit -m 'updated'`
-      end
-      run_command('setup', '--no-shallow')
       Dir.chdir(config.repos_dir + 'master') do
         `git log --pretty=oneline`.strip.split("\n").size.should > 1
       end

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -314,6 +314,17 @@ module Pod
         SourcesManager.update(test_repo_path.basename.to_s, true)
       end
 
+      it 'unshallows if the git repo is shallow' do
+        set_up_test_repo_for_update
+        test_repo_path.join('.git', 'shallow').open('w') { |f| f << 'a' * 40 }
+        SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+        MasterSource.any_instance.expects(:git!).with(%w(fetch --unshallow))
+        MasterSource.any_instance.expects(:git!).with(%w(pull --ff-only))
+        SourcesManager.update(test_repo_path.basename.to_s, true)
+
+        UI.output.should.match /deep fetch.+`master`.+improve future performance/
+      end
+
       it 'prints a warning if the update failed' do
         set_up_test_repo_for_update
         Source.any_instance.stubs(:git).with(%w(rev-parse HEAD)).returns('aabbccd')


### PR DESCRIPTION
Depends upon https://github.com/CocoaPods/CocoaPods/pull/5014.
Closes #5016.

- [x] CHANGELOG
- [x] Specs
- [x] Do we still want to allow shallow clones of non-master specs repos?
- [x] is `--unshallow` better than `rm && clone` ?

\c @DanielTomlinson @orta @alloy 