### PR TITLE
[Validator] Validate that header files are in source_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#5016](https://github.com/CocoaPods/CocoaPods/issues/5016)
 
+* The validator will check that all `public_header_files` and
+  `private_header_files` are also present in `source_files`.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#4936](https://github.com/CocoaPods/CocoaPods/issues/4936)
+
 ##### Bug Fixes
 
 * The master specs repository can no longer be added via `pod repo add`, but
@@ -35,6 +40,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   embed frameworks build phase's script, so that UI test targets can be run.  
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#5022](https://github.com/CocoaPods/CocoaPods/issues/5022)
+
 
 ## 1.0.0.beta.5 (2016-03-08)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -560,11 +560,17 @@ module Pod
     # Ensures that a list of header files only contains header files.
     #
     def _validate_header_files(attr_name)
-      non_header_files = file_accessor.send(attr_name).
+      header_files = file_accessor.send(attr_name)
+      non_header_files = header_files.
         select { |f| !Sandbox::FileAccessor::HEADER_EXTENSIONS.include?(f.extname) }.
         map { |f| f.relative_path_from(file_accessor.root) }
       unless non_header_files.empty?
         error(attr_name, "The pattern matches non-header files (#{non_header_files.join(', ')}).")
+      end
+      non_source_files = header_files - file_accessor.source_files
+      unless non_source_files.empty?
+        error(attr_name, 'The pattern includes header files that are not listed' \
+          "in source_files (#{non_source_files.join(', ')}).")
       end
     end
 


### PR DESCRIPTION
Closes #4936.

Hard to test because the current validator specs all use JSONKit, which doesn't have enough source files to reproduce the issues.