### PR TITLE
[EmbedFrameworksScript] Rely on TARGET_BUILD_DIR to locate destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#4790](https://github.com/CocoaPods/CocoaPods/issues/4790)
 
+* Rely on `TARGET_BUILD_DIR` instead of `CONFIGURATION_BUILD_DIR` in the generated
+  embed frameworks build phase's script, so that UI test targets can be run.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#5022](https://github.com/CocoaPods/CocoaPods/issues/5022)
 
 ## 1.0.0.beta.5 (2016-03-08)
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -53,7 +53,7 @@ module Pod
               local source="$1"
             fi
 
-            local destination="${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+            local destination="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 
             if [ -L "${source}" ]; then
                 echo "Symlinked..."

--- a/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/target_installer/aggregate_target_installer.rb
@@ -154,7 +154,7 @@ module Pod
           end
           frameworks_by_config[config] = relevant_pod_targets.flat_map do |pod_target|
             frameworks = pod_target.file_accessors.flat_map(&:vendored_dynamic_artifacts).map { |fw| "${PODS_ROOT}/#{fw.relative_path_from(sandbox.root)}" }
-            frameworks << pod_target.build_product_path if pod_target.should_build? && pod_target.requires_frameworks?
+            frameworks << pod_target.build_product_path('$BUILT_PRODUCTS_DIR') if pod_target.should_build? && pod_target.requires_frameworks?
             frameworks
           end
         end


### PR DESCRIPTION
Fixes #5022. Xcode overwrites this variable for UI test apps, but not the previously used `CONFIGURATION_BUILD_DIR`. While `USES_XCTRUNNER` is not documented as effector of this variable (:tada:), the [build settings reference](https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW88) confirms that this is the variable to rely on.

>Run Script build phases that operate on product files of the target that defines them should use the value of this build setting.

Just to be sure to conform closer to the documentation, use also `BUILT_PRODUCTS_DIR` instead of `CONFIGURATION_BUILD_DIR` for the origin, because:

>But Run Script build phases that operate on product files of other targets should use [BUILT_PRODUCTS_DIR](https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW42) instead.