### PR TITLE
Cache read_file_system invocations globally

### DIFF
--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -51,9 +51,9 @@ module Pod
         unless root.exist?
           raise Informative, "Attempt to read non existent folder `#{root}`."
         end
-        if @@file_system_cache.has_key?(root)
-          @files = @@file_system_cache[root]["files"]
-          @dirs = @@file_system_cache[root]["dirs"]
+        if @@file_system_cache.key?(root)
+          @files = @@file_system_cache[root]['files']
+          @dirs = @@file_system_cache[root]['dirs']
           @glob_cache = {}
           return
         end
@@ -68,7 +68,7 @@ module Pod
         @dirs  = relative_dirs.map { |d| d.gsub(/\/\.\.?$/, '') }.reject { |d| d == '.' || d == '..' } .uniq
         @glob_cache = {}
 
-        @@file_system_cache[root] = { "files" => @files, "dirs" => @dirs }
+        @@file_system_cache[root] = { 'files' => @files, 'dirs' => @dirs }
       end
 
       #-----------------------------------------------------------------------#

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -10,6 +10,10 @@ module Pod
     #         {#read_file_system}
     #
     class PathList
+      # Global cache of file system globbing. Keys are root path objects, values are
+      # Hash including "files" and "dirs".
+      @@file_system_cache = {}
+
       # @return [Pathname] The root of the list whose files and directories
       #         are used to perform the matching operations.
       #
@@ -47,6 +51,12 @@ module Pod
         unless root.exist?
           raise Informative, "Attempt to read non existent folder `#{root}`."
         end
+        if @@file_system_cache.has_key?(root)
+          @files = @@file_system_cache[root]["files"]
+          @dirs = @@file_system_cache[root]["dirs"]
+          @glob_cache = {}
+          return
+        end
         root_length  = root.to_s.length + 1
         escaped_root = escape_path_for_glob(root)
         paths = Dir.glob(escaped_root + '**/*', File::FNM_DOTMATCH)
@@ -57,6 +67,8 @@ module Pod
         @files = relative_paths - relative_dirs
         @dirs  = relative_dirs.map { |d| d.gsub(/\/\.\.?$/, '') }.reject { |d| d == '.' || d == '..' } .uniq
         @glob_cache = {}
+
+        @@file_system_cache[root] = { "files" => @files, "dirs" => @dirs }
       end
 
       #-----------------------------------------------------------------------#


### PR DESCRIPTION
Context: My repository includes a couple git repositories that include a few thousand files/folders.
I was finding that `pod install` times were creeping to upwards of 1 minute. After this change `pod install` takes ~20 seconds, or roughly a 2/3 reduction.

## How I profiled the problem

I profiled a local checkout of the 0.39.0 pod command with ruby-prof:

    ruby-prof -p call_stack pod -- install --no-repo-update > rubyprof.html
    open rubyprof.html

The results pointed to `Pod::Installer::FileReferencesInstaller#refresh_file_accessors` being the most expensive call.

I added logging statements to `refresh_file_accessors` and saw that the method was being called multiple times on the same root path. Each call took a few seconds.

Based on the above information I implemented this change.

## The change

The change introduces a static Hash in the `PathList` object. The Hash caches results from `read_file_system` and allows `read_file_system` to reuse previously-calculated results for identical paths.