### PR TITLE
Respect OTHER_CODE_SIGN_FLAGS setting

### DIFF
--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -96,8 +96,8 @@ module Pod
             if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
-              echo "/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \\"$1\\""
-              /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
+              echo "/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements \\"$1\\""
+              /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements "$1"
             fi
           }
 


### PR DESCRIPTION
Pass the `OTHER_CODE_SIGN_FLAGS` variable (aka "Other Code Signing Flags") to `codesign`, as Xcode does when signing natively.

This setting can be used e.g. to speed up (& enable offline) debug builds by skipping timestamping with `--timestamp=none`, which is how I noticed: no-changes builds were taking suspiciously long. (There's still some ~500ms wasted in "📦 Embed Pods Frameworks" for me when nothing changes, but that's another story.)