### PR TITLE
Update for the removal of Pod::SourcesManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [CocoaPods#5113](https://github.com/CocoaPods/CocoaPods/issues/5113)
 
-* Improved error messages, around the 1.0 changes when we cannot find a dependency 
-  in local sources, noting that CP > 1 doesnt run `pod repo update`
+* Improved the error message when a matching spec cannot be found,
+  mentioning that now `pod repo update` is not implicit when running `pod   
+  install`.  
   [Orta Therox](https://github.com/orta)
-  [CocoaPods#5135](https://github.com/CocoaPods/CocoaPods/issues/5135)
+  [#5135](https://github.com/CocoaPods/CocoaPods/issues/5135)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Orta Therox](https://github.com/orta)
   [#5135](https://github.com/CocoaPods/CocoaPods/issues/5135)
 
+* Add support for sharded specs directories.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#5002](https://github.com/CocoaPods/CocoaPods/issues/5002)
+
 ##### Bug Fixes
 
 * None.  

--- a/Gemfile
+++ b/Gemfile
@@ -22,12 +22,12 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core'
+  cp_gem 'cocoapods-core',        'Core', 'seg-source-metadata'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'
   cp_gem 'cocoapods-search',      'cocoapods-search'
-  cp_gem 'cocoapods-stats',       'cocoapods-stats'
+  cp_gem 'cocoapods-stats',       'cocoapods-stats', 'seg-source-metadata'
   cp_gem 'cocoapods-trunk',       'cocoapods-trunk'
   cp_gem 'cocoapods-try',         'cocoapods-try'
   cp_gem 'molinillo',             'Molinillo'

--- a/Gemfile
+++ b/Gemfile
@@ -22,12 +22,12 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core', 'seg-source-metadata'
+  cp_gem 'cocoapods-core',        'Core'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'
   cp_gem 'cocoapods-search',      'cocoapods-search'
-  cp_gem 'cocoapods-stats',       'cocoapods-stats', 'seg-source-metadata'
+  cp_gem 'cocoapods-stats',       'cocoapods-stats'
   cp_gem 'cocoapods-trunk',       'cocoapods-trunk'
   cp_gem 'cocoapods-try',         'cocoapods-try'
   cp_gem 'molinillo',             'Molinillo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: ec49c1259eabe6cdf6a9f416fc5c0ca905c4ced2
+  revision: bb1c7033bb34016da92364222fd20517c4e25d2a
   branch: seg-source-metadata
   specs:
     cocoapods-core (1.0.0.beta.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 33d5fbcfb956cfef621bfb1b03e0880d6de4a546
-  branch: master
+  revision: ec49c1259eabe6cdf6a9f416fc5c0ca905c4ced2
+  branch: seg-source-metadata
   specs:
     cocoapods-core (1.0.0.beta.6)
       activesupport (>= 4.0.2)
@@ -63,8 +63,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-stats.git
-  revision: 8569ef61bd7d52f5d6d3e91ceb299bda7b86748c
-  branch: master
+  revision: 554f95bd53dcbc53602934a25beeb6ffc2f2aee9
+  branch: seg-source-metadata
   specs:
     cocoapods-stats (1.0.0.beta.3)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: bb1c7033bb34016da92364222fd20517c4e25d2a
-  branch: seg-source-metadata
+  revision: 83d171f2b42b22bc84b6b3d1512aa99213ad163d
+  branch: master
   specs:
     cocoapods-core (1.0.0.beta.6)
       activesupport (>= 4.0.2)
@@ -63,8 +63,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-stats.git
-  revision: 554f95bd53dcbc53602934a25beeb6ffc2f2aee9
-  branch: seg-source-metadata
+  revision: fda6a8950aa49e10033002c9792da9f7fcd0e511
+  branch: master
   specs:
     cocoapods-stats (1.0.0.beta.3)
 

--- a/lib/cocoapods.rb
+++ b/lib/cocoapods.rb
@@ -49,7 +49,6 @@ module Pod
   autoload :Project,                   'cocoapods/project'
   autoload :Resolver,                  'cocoapods/resolver'
   autoload :Sandbox,                   'cocoapods/sandbox'
-  autoload :SourcesManager,            'cocoapods/sources_manager'
   autoload :Target,                    'cocoapods/target'
   autoload :Validator,                 'cocoapods/validator'
 
@@ -68,4 +67,6 @@ module Pod
     autoload :UmbrellaHeader,          'cocoapods/generator/umbrella_header'
     autoload :XCConfig,                'cocoapods/generator/xcconfig'
   end
+
+  require 'cocoapods/core_overrides'
 end

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -93,7 +93,7 @@ module Pod
     # @return [void]
     #
     def ensure_master_spec_repo_exists!
-      unless SourcesManager.master_repo_functional?
+      unless config.sources_manager.master_repo_functional?
         Setup.new(CLAide::ARGV.new([])).run
       end
     end

--- a/lib/cocoapods/command/inter_process_communication.rb
+++ b/lib/cocoapods/command/inter_process_communication.rb
@@ -81,7 +81,7 @@ module Pod
 
         def run
           require 'yaml'
-          sets = SourcesManager.aggregate.all_sets
+          sets = config.sources_manager.aggregate.all_sets
           result = {}
           sets.each do |set|
             begin
@@ -117,8 +117,8 @@ module Pod
         DESC
 
         def run
-          SourcesManager.updated_search_index
-          output_pipe.puts(SourcesManager.search_index_path)
+          config.sources_manager.updated_search_index
+          output_pipe.puts(config.sources_manager.search_index_path)
         end
       end
 

--- a/lib/cocoapods/command/list.rb
+++ b/lib/cocoapods/command/list.rb
@@ -20,7 +20,7 @@ module Pod
       def run
         update_if_necessary!
 
-        sets = SourcesManager.aggregate.all_sets
+        sets = config.sources_manager.aggregate.all_sets
         sets.each { |set| UI.pod(set, :name_and_version) }
         UI.puts "\n#{sets.count} pods were found"
       end

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -40,7 +40,7 @@ module Pod
             create_repos_dir
             clone_repo
             checkout_branch
-            SourcesManager.check_version_information(dir)
+            config.sources_manager.sources([dir.basename.to_s]).each(&:verify_compatibility!)
           end
         end
 

--- a/lib/cocoapods/command/repo/lint.rb
+++ b/lib/cocoapods/command/repo/lint.rb
@@ -36,19 +36,19 @@ module Pod
         def run
           sources = if @name
                       if File.exist?(@name)
-                        [Pathname.new(@name)]
+                        [Source.new(Pathname(@name))]
                       else
-                        SourcesManager.sources([@name]).map(&:repo)
+                        config.sources_manager.sources([@name])
                       end
                     else
-                      SourcesManager.aggregate.sources.map(&:repo)
+                      config.sources_manager.all
                     end
 
           sources.each do |source|
-            SourcesManager.check_version_information(source)
-            UI.puts "\nLinting spec repo `#{source.basename}`\n".yellow
+            source.verify_compatibility!
+            UI.puts "\nLinting spec repo `#{source.name}`\n".yellow
 
-            validator = Source::HealthReporter.new(source)
+            validator = Source::HealthReporter.new(source.repo)
             validator.pre_check do |_name, _version|
               UI.print '.'
             end

--- a/lib/cocoapods/command/repo/list.rb
+++ b/lib/cocoapods/command/repo/list.rb
@@ -30,7 +30,7 @@ module Pod
         #          - path: /Users/lascorbe/.cocoapods/repos/test
         #
         def run
-          sources = SourcesManager.all
+          sources = config.sources_manager.all
           print_sources(sources) unless @count_only
           print_count_of_sources(sources)
         end
@@ -45,7 +45,7 @@ module Pod
         # @return [void]
         #
         def print_source(source)
-          if SourcesManager.git_repo?(source.repo)
+          if source.git?
             Dir.chdir(source.repo) do
               branch_name = `git name-rev --name-only HEAD 2>/dev/null`.strip
               branch_name = 'unknown' if branch_name.empty?

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -38,8 +38,8 @@ module Pod
           @allow_warnings = argv.flag?('allow-warnings')
           @local_only = argv.flag?('local-only')
           @repo = argv.shift_argument
-          @source = SourcesManager.source_with_name_or_url(@repo)
-          @source_urls = argv.option('sources', SourcesManager.all.map(&:url).join(',')).split(',')
+          @source = config.sources_manager.source_with_name_or_url(@repo)
+          @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).join(',')).split(',')
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
           @private = argv.flag?('private', true)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -38,7 +38,7 @@ module Pod
           @allow_warnings = argv.flag?('allow-warnings')
           @local_only = argv.flag?('local-only')
           @repo = argv.shift_argument
-          @source = config.sources_manager.source_with_name_or_url(@repo)
+          @source = config.sources_manager.sources([@repo]).first
           @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).join(',')).split(',')
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
@@ -49,8 +49,14 @@ module Pod
         end
 
         def validate!
-          super
           help! 'A spec-repo name is required.' unless @repo
+          unless @source.repo.directory?
+            raise Informative,
+                  "Unable to find the `#{@repo}` repo. " \
+                  'If it has not yet been cloned, add it via `pod repo add`.'
+          end
+
+          super
         end
 
         def run
@@ -162,7 +168,7 @@ module Pod
           UI.puts "\nAdding the #{'spec'.pluralize(count)} to the `#{@repo}' repo\n".yellow
           podspec_files.each do |spec_file|
             spec = Pod::Specification.from_file(spec_file)
-            output_path = @source.specs_dir + @source.send(:pod_path, name) + version.to_s
+            output_path = @source.pod_path(spec.name) + spec.version.to_s
             if @message && !@message.empty?
               message = @message
             elsif output_path.exist?

--- a/lib/cocoapods/command/repo/update.rb
+++ b/lib/cocoapods/command/repo/update.rb
@@ -19,7 +19,7 @@ module Pod
         end
 
         def run
-          SourcesManager.update(@name, true)
+          config.sources_manager.update(@name, true)
         end
       end
     end

--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -59,7 +59,7 @@ module Pod
       # @return [void]
       #
       def update_master_repo
-        SourcesManager.update('master', true)
+        config.sources_manager.update('master', true)
       end
 
       # Sets the repo to the master branch.
@@ -95,7 +95,7 @@ module Pod
       # @return [Pathname] the directory of the master repo.
       #
       def master_repo_dir
-        SourcesManager.master_repo_dir
+        config.sources_manager.master_repo_dir
       end
     end
   end

--- a/lib/cocoapods/command/spec.rb
+++ b/lib/cocoapods/command/spec.rb
@@ -40,7 +40,7 @@ module Pod
       # @return [Pathname] the absolute path or paths of the given podspec
       #
       def get_path_of_spec(spec, show_all = false)
-        sets = SourcesManager.search_by_name(spec)
+        sets = config.sources_manager.search_by_name(spec)
 
         if sets.count == 1
           set = sets.first

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -130,6 +130,11 @@ module Pod
 
     attr_writer :repos_dir
 
+    def sources_manager
+      return @sources_manager if @sources_manager && @sources_manager.repos_dir == repos_dir
+      @sources_manager = Source::Manager.new(repos_dir)
+    end
+
     # @return [Pathname] the directory where the CocoaPods templates are stored.
     #
     def templates_dir

--- a/lib/cocoapods/core_overrides.rb
+++ b/lib/cocoapods/core_overrides.rb
@@ -1,0 +1,1 @@
+require 'cocoapods/sources_manager'

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -216,8 +216,8 @@ module Pod
       #
       def update_repositories
         sources.each do |source|
-          if SourcesManager.git_repo?(source.repo)
-            SourcesManager.update(source.name)
+          if source.git?
+            config.sources_manager.update(source.name)
           else
             UI.message "Skipping `#{source.name}` update because the repository is not a git source repository."
           end
@@ -628,7 +628,7 @@ module Pod
       #
       # When no explicit Podfile sources are defined, this defaults to the
       # master spec repository.
-      # available sources ({SourcesManager.all}).
+      # available sources ({config.sources_manager.all}).
       #
       # @return [Array<Source>] the sources to be used in finding
       #         specifications, as specified by the {#podfile} or all sources.
@@ -650,7 +650,7 @@ module Pod
           end
 
           sources.uniq.map do |source_url|
-            SourcesManager.find_or_create_source_with_url(source_url)
+            config.sources_manager.find_or_create_source_with_url(source_url)
           end
         end
       end

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -350,7 +350,7 @@ module Pod
     #
     def aggregate_for_dependency(dependency)
       if dependency && dependency.podspec_repo
-        return SourcesManager.aggregate_for_dependency(dependency)
+        return Config.instance.sources_manager.aggregate_for_dependency(dependency)
       else
         @aggregate ||= Source::Aggregate.new(sources)
       end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -1,49 +1,8 @@
+require 'cocoapods-core/source'
+
 module Pod
-  # Manages all the sources known to the running CocoaPods Instance.
-  #
-  class SourcesManager
-    class << self
-      include Config::Mixin
-
-      # @return [Source::Aggregate] The aggregate of all the sources with the
-      #         known Pods.
-      #
-      def aggregate
-        return Source::Aggregate.new([]) unless config.repos_dir.exist?
-        dirs = config.repos_dir.children.select(&:directory?)
-        aggregate_with_repos(dirs)
-      end
-
-      # @return [Source::Aggregate] The aggregate of the sources from repos.
-      #
-      # @param  [Dependency] dependency
-      #         The dependency for which to find or build the appropriate.
-      #         aggregate. If the dependency specifies a source podspec repo
-      #         then only that source will be used, otherwise all sources
-      #         will be used.
-      #
-      def aggregate_for_dependency(dependency)
-        if dependency.podspec_repo
-          source = source_with_url(dependency.podspec_repo)
-          raise StandardError, '[Bug] Failed to find known source with the URL ' \
-            "#{dependency.podspec_repo.inspect}" if source.nil?
-
-          aggregate_with_repos([source_dir(source.name)])
-        else
-          aggregate
-        end
-      end
-
-      # @return [Array<Source>] The list of the sources with the given names.
-      #
-      # @param  [Array<#to_s>] names
-      #         The names of the sources.
-      #
-      def sources(names)
-        dirs = names.map { |name| source_dir(name) }
-        dirs.map { |repo| source_from_path(repo) }
-      end
-
+  class Source
+    class Manager
       # Returns the source whose {Source#url} is equal to `url`, adding the repo
       # in a manner similarly to `pod repo add` if it is not found.
       #
@@ -66,10 +25,13 @@ module Pod
             else
               Command::Repo::Add.parse([name, url]).run
             end
-          rescue Informative
-            raise Informative, "Unable to add a source with url `#{url}` " \
-              "named `#{name}`.\nYou can try adding it manually in " \
+          rescue Informative => e
+            message = "Unable to add a source with url `#{url}` " \
+              "named `#{name}`.\n"
+            message << "(#{e})\n" if Config.instance.verbose?
+            message << 'You can try adding it manually in ' \
               '`~/.cocoapods/repos` or via `pod repo add`.'
+            raise Informative, message
           ensure
             UI.title_level = previous_title_level
           end
@@ -93,218 +55,13 @@ module Pod
           find_or_create_source_with_url(name_or_url)
       end
 
-      # @return [Array<Source>] The list of all the sources known to this
-      #         installation of CocoaPods.
-      #
-      def all
-        return [] unless config.repos_dir.exist?
-        dirs = config.repos_dir.children.select(&:directory?)
-        dirs.map { |repo| source_from_path(repo) }
-      end
-
-      # @return [Array<Source>] The CocoaPods Master Repo source.
-      #
-      def master
-        sources(['master']).select { |s| s.repo.directory? }
-      end
-
-      # Search the appropriate sources to match the set for the given dependency.
-      #
-      # @return [Set, nil] a set for a given dependency including all the
-      #         {Source} that contain the Pod. If no sources containing the
-      #         Pod where found it returns nil.
-      #
-      # @raise  If no source can be found that includes the dependency.
-      #
-      def search(dependency)
-        aggregate_for_dependency(dependency).search(dependency)
-      end
-
-      # Search all the sources with the given search term.
-      #
-      # @param  [String] query
-      #         The search term.
-      #
-      # @param  [Bool] full_text_search
-      #         Whether the search should be limited to the name of the Pod or
-      #         should include also the author, the summary, and the
-      #         description.
-      #
-      # @raise  If no source including the set can be found.
-      #
-      # @return [Array<Set>]  The sets that contain the search term.
-      #
-      def search_by_name(query, full_text_search = false)
-        query_word_regexps = query.split.map { |word| /#{word}/i }
-        if full_text_search
-          query_word_results_hash = {}
-          updated_search_index.each_value do |word_spec_hash|
-            word_spec_hash.each_pair do |word, spec_symbols|
-              query_word_regexps.each do |query_word_regexp|
-                set = (query_word_results_hash[query_word_regexp] ||= Set.new)
-                set.merge(spec_symbols) if word =~ query_word_regexp
-              end
-            end
-          end
-          found_set_symbols = query_word_results_hash.values.reduce(:&)
-          found_set_symbols ||= []
-          sets = found_set_symbols.map do |symbol|
-            aggregate.representative_set(symbol.to_s)
-          end
-          # Remove nil values because representative_set return nil if no pod is found in any of the sources.
-          sets.compact!
-        else
-          sets = aggregate.search_by_name(query, false)
-        end
-        if sets.empty?
-          extra = ', author, summary, or description' if full_text_search
-          raise Informative, "Unable to find a pod with name#{extra}" \
-            "matching `#{query}`"
-        end
-        sorted_sets(sets, query_word_regexps)
-      end
-
-      # Returns given set array by sorting it in-place.
-      #
-      # @param  [Array<Set>] sets
-      #         Array of sets to be sorted.
-      #
-      # @param  [Array<Regexp>] query_word_regexps
-      #         Array of regexp objects for user query.
-      #
-      # @return [Array<Set>]  Given sets parameter itself after sorting it in-place.
-      #
-      def sorted_sets(sets, query_word_regexps)
-        sets.sort_by! do |set|
-          pre_match_length = nil
-          found_query_index = nil
-          found_query_count = 0
-          query_word_regexps.each_with_index do |q, idx|
-            if (m = set.name.match(/#{q}/i))
-              pre_match_length ||= (m.pre_match.length)
-              found_query_index ||= idx
-              found_query_count += 1
-            end
-          end
-          pre_match_length ||= 1000
-          found_query_index ||= 1000
-          [-found_query_count, pre_match_length, found_query_index, set.name.downcase]
-        end
-        sets
-      end
-
-      # Returns the search data. If a saved search data exists, retrieves it from file and returns it.
-      # Else, creates the search data from scratch, saves it to file system, and returns it.
-      # Search data is grouped by source repos. For each source, it contains a hash where keys are words
-      # and values are the pod names containing corresponding word.
-      #
-      # For each source, list of unique words are generated from the following spec information.
-      #   - version
-      #   - summary
-      #   - description
-      #   - authors
-      #
-      # @return [Hash{String => Hash{String => Array<String>}}] The up to date search data.
-      #
-      def updated_search_index
-        index = stored_search_index || {}
-        all.each do |source|
-          source_name = source.name
-          unless index[source_name]
-            UI.print "Creating search index for spec repo '#{source_name}'.."
-            index[source_name] = aggregate.generate_search_index_for_source(source)
-            UI.puts ' Done!'
-          end
-        end
-        save_search_index(index)
-        index
-      end
-
-      # Returns the search data stored in the file system.
-      # If existing data in the file system is not valid, returns nil.
-      #
-      def stored_search_index
-        unless @updated_search_index
-          if search_index_path.exist?
-            require 'json'
-            index = JSON.parse(search_index_path.read)
-            if index && index.is_a?(Hash) # TODO: should we also check if hash has correct hierarchy?
-              return @updated_search_index = index
-            end
-          end
-          @updated_search_index = nil
-        end
-        @updated_search_index
-      end
-
-      # Stores given search data in the file system.
-      # @param [Hash] index
-      #        Index to be saved in file system
-      #
-      def save_search_index(index)
-        require 'json'
-        @updated_search_index = index
-        search_index_path.open('w') do |io|
-          io.write(@updated_search_index.to_json)
-        end
-      end
-
-      # Allows to clear the search index.
-      #
-      attr_writer :updated_search_index
-
       # @return [Pathname] The path where the search index should be stored.
       #
       def search_index_path
-        Config.instance.search_index_file
+        @search_index_path ||= Config.instance.search_index_file
       end
 
       # @!group Updating Sources
-
-      extend Executable
-      executable :git
-
-      # Updates the stored search index if there are changes in spec repos while updating them.
-      # Update is performed incrementally. Only the changed pods' search data is re-generated and updated.
-      # @param  [Hash{Source => Array<String>}] changed_spec_paths
-      #                  A hash containing changed specification paths for each source.
-      #
-      def update_search_index_if_needed(changed_spec_paths)
-        search_index = stored_search_index
-        return unless search_index
-        changed_spec_paths.each_pair do |source, spec_paths|
-          index_for_source = search_index[source.name]
-          next unless index_for_source && spec_paths.length > 0
-          updated_pods = source.pods_for_specification_paths(spec_paths)
-
-          new_index = aggregate.generate_search_index_for_changes_in_source(source, spec_paths)
-          # First traverse search_index and update existing words
-          # Removed traversed words from new_index after adding to search_index,
-          # so that only non existing words will remain in new_index after enumeration completes.
-          index_for_source.each_pair do |word, _|
-            if new_index[word]
-              index_for_source[word] |= new_index[word]
-            else
-              index_for_source[word] -= updated_pods
-            end
-          end
-          # Now add non existing words remained in new_index to search_index
-          index_for_source.merge!(new_index)
-        end
-        save_search_index(search_index)
-      end
-
-      # Updates search index for changed pods in background
-      # @param  [Hash{Source => Array<String>}] changed_spec_paths
-      #                  A hash containing changed specification paths for each source.
-      #
-      def update_search_index_if_needed_in_background(changed_spec_paths)
-        Process.fork do
-          Process.daemon
-          update_search_index_if_needed(changed_spec_paths)
-          exit
-        end
-      end
 
       # Updates the local clone of the spec-repo with the given name or of all
       # the git repos if the name is omitted.
@@ -327,298 +84,14 @@ module Pod
           UI.section "Updating spec repo `#{source.name}`" do
             changed_source_paths = source.update(show_output)
             changed_spec_paths[source] = changed_source_paths if changed_source_paths.count > 0
-            check_version_information(source.repo)
+            source.verify_compatibility!
           end
         end
         # Perform search index update operation in background.
         update_search_index_if_needed_in_background(changed_spec_paths)
       end
-
-      # Returns whether a source is a GIT repo.
-      #
-      # @param  [Pathname] dir
-      #         The directory where the source is stored.
-      #
-      # @return [Bool] Whether the given source is a GIT repo.
-      #
-      def git_repo?(dir)
-        Dir.chdir(dir) do
-          Executable.capture_command('git', %w(rev-parse), :capture => :none).success?
-        end
-      end
-
-      # Checks the version information of the source with the given directory.
-      # It raises if the source is not compatible and if there is CocoaPods
-      # update it informs the user.
-      #
-      # @param  [Pathname] dir
-      #         The directory where the source is stored.
-      #
-      # @raise  If the source is not compatible.
-      #
-      # @return [void]
-      #
-      def check_version_information(dir)
-        versions = version_information(dir)
-        unless repo_compatible?(dir)
-          min = versions['min']
-          max = versions['max']
-          version_msg = (min == max) ? min : "#{min} - #{max}"
-          raise Informative, "The `#{dir.basename}` repo requires " \
-          "CocoaPods #{version_msg} (currently using #{Pod::VERSION})\n".red +
-            'Update CocoaPods, or checkout the appropriate tag in the repo.'
-        end
-
-        if config.new_version_message? && cocoapods_update?(versions)
-          last = versions['last']
-          rc = Gem::Version.new(last).prerelease?
-          install_message = needs_sudo? ? 'sudo ' : ''
-          install_message << 'gem install cocoapods'
-          install_message << ' --pre' if rc
-          message = [
-            "CocoaPods #{last} is available.".green,
-            "To update use: `#{install_message}`".green,
-            ("[!] This is a test version we'd love you to try.".yellow if rc),
-            ("Until we reach version 1.0 the features of CocoaPods can and will change.\n" \
-             'We strongly recommend that you use the latest version at all times.'.yellow unless rc),
-            '',
-            'For more information, see https://blog.cocoapods.org ' \
-            'and the CHANGELOG for this version at ' \
-            "https://github.com/CocoaPods/CocoaPods/releases/tag/#{last}".green,
-            '',
-          ].compact.join("\n")
-          UI.puts("\n#{message}\n")
-        end
-      end
-
-      # Returns whether a source is compatible with the current version of
-      # CocoaPods.
-      #
-      # @param  [Pathname] dir
-      #         The directory where the source is stored.
-      #
-      # @return [Bool] whether the source is compatible.
-      #
-      def repo_compatible?(dir)
-        versions = version_information(dir)
-
-        min = versions['min']
-        max = versions['max']
-        bin_version  = Gem::Version.new(Pod::VERSION)
-        supports_min = !min || bin_version >= Gem::Version.new(min)
-        supports_max = !max || bin_version <= Gem::Version.new(max)
-        supports_min && supports_max
-      end
-
-      # Checks whether there is a CocoaPods given the version information of a
-      # repo.
-      #
-      # @param  [Hash] version_information
-      #         The version information of a repository.
-      #
-      # @return [Bool] whether there is an update.
-      #
-      def cocoapods_update?(version_information)
-        version = version_information['last']
-        version && Gem::Version.new(version) > Gem::Version.new(Pod::VERSION)
-      end
-
-      # Returns the contents of the `CocoaPods-version.yml` file, which stores
-      # information about CocoaPods versions.
-      #
-      # This file is a hash with the following keys:
-      #
-      # - last: the last version of CocoaPods known to the source.
-      # - min: the minimum version of CocoaPods supported by the source.
-      # - max: the maximum version of CocoaPods supported by the source.
-      #
-      # @param  [Pathname] dir
-      #         The directory where the source is stored.
-      #
-      # @return [Hash] the versions information from the repo.
-      #
-      def version_information(dir)
-        require 'yaml'
-        yaml_file = dir + 'CocoaPods-version.yml'
-        return {} unless yaml_file.exist?
-        begin
-          YAMLHelper.load_file(yaml_file)
-        rescue Informative
-          raise Informative, "There was an error reading '#{yaml_file}'.\n" \
-            'Please consult https://blog.cocoapods.org/' \
-            'Repairing-Our-Broken-Specs-Repository/ ' \
-            'for more information.'
-        end
-      end
-
-      # @!group Master repo
-
-      # @return [Pathname] The path of the master repo.
-      #
-      def master_repo_dir
-        config.repos_dir + 'master'
-      end
-
-      # @return [Bool] Checks if the master repo is usable.
-      #
-      # @note   Note this is used to automatically setup the master repo if
-      #         needed.
-      #
-      def master_repo_functional?
-        master_repo_dir.exist? && repo_compatible?(master_repo_dir)
-      end
-
-      private
-
-      # @return [Source] The Source at a given path.
-      #
-      # @param [Pathname] path
-      #        The local file path to one podspec repo.
-      #
-      def source_from_path(path)
-        return Source.new(path) unless path.basename.to_s == 'master'
-        MasterSource.new(path)
-      end
-
-      # @return [Source::Aggregate] The aggregate of the sources from repos.
-      #
-      # @param  [Array<Pathname>] repos
-      #         The local file paths to one or more podspec repo caches.
-      #
-      def aggregate_with_repos(repos)
-        sources = repos.map { |path| source_from_path(path) }
-        @aggregates_by_repos ||= {}
-        @aggregates_by_repos[repos] ||= Source::Aggregate.new(sources)
-      end
-
-      # @return [Bool] Whether the given path is writable by the current user.
-      #
-      # @param  [#to_s] path
-      #         The path.
-      #
-      def path_writable?(path)
-        Pathname(path).dirname.writable?
-      end
-
-      # @return [Bool] Whether `gem install` probably needs `sudo` to succeed.
-      #
-      def needs_sudo?
-        !path_writable?(__FILE__)
-      end
-
-      # @return [Source] The git source with the given name. If no git source
-      #         with given name is found it raises.
-      #
-      # @param  [String] name
-      #         The name of the source.
-      #
-      def git_source_named(name)
-        specified_source = aggregate.sources.find { |s| s.name == name }
-        unless specified_source
-          raise Informative, "Unable to find the `#{name}` repo."
-        end
-        unless git_repo?(specified_source.repo)
-          raise Informative, "The `#{name}` repo is not a git repo."
-        end
-        specified_source
-      end
-
-      # @return [Source] The list of the git sources.
-      #
-      def git_sources
-        all.select do |source|
-          git_repo?(source.repo)
-        end
-      end
-
-      # @return [Pathname] The path of the source with the given name.
-      #
-      # @param  [String] name
-      #         The name of the source.
-      #
-      def source_dir(name)
-        if dir = config.repos_dir + name
-          dir
-        else
-          raise Informative, "Unable to find the `#{name}` repo."
-        end
-      end
-
-      # @return [Source] The source whose {Source#url} is equal to `url`.
-      #
-      # @param  [String] url
-      #         The URL of the source.
-      #
-      def source_with_url(url)
-        url = url.downcase.gsub(/.git$/, '')
-        aggregate.sources.find do |source|
-          source.url && source.url.downcase.gsub(/.git$/, '') == url
-        end
-      end
-
-      # Returns a suitable repository name for `url`.
-      #
-      # @example A GitHub.com URL
-      #
-      #          name_for_url('https://github.com/Artsy/Specs.git')
-      #            # "artsy"
-      #          name_for_url('https://github.com/Artsy/Specs.git')
-      #            # "artsy-1"
-      #
-      # @example A non-Github.com URL
-      #
-      #          name_for_url('https://sourceforge.org/Artsy/Specs.git')
-      #            # sourceforge-artsy-specs
-      #
-      # @example A file URL
-      #
-      #           name_for_url('file:///Artsy/Specs.git')
-      #             # artsy-specs
-      #
-      # @param  [#to_s] url
-      #         The URL of the source.
-      #
-      # @return [String] A suitable repository name for `url`.
-      #
-      def name_for_url(url)
-        base_from_host_and_path = lambda do |host, path|
-          if host
-            base = host.split('.')[-2] || host
-            base += '-'
-          else
-            base = ''
-          end
-
-          base + path.gsub(/.git$/, '').gsub(/^\//, '').split('/').join('-')
-        end
-
-        case url.to_s.downcase
-        when %r{github.com[:/]+cocoapods/specs}
-          base = 'master'
-        when %r{github.com[:/]+(.+)/(.+)}
-          base = Regexp.last_match[1]
-        when /^\S+@(\S+)[:\/]+(.+)$/
-          host, path = Regexp.last_match.captures
-          base = base_from_host_and_path[host, path]
-        when URI.regexp
-          url = URI(url.downcase)
-          base = base_from_host_and_path[url.host, url.path]
-        else
-          base = url.to_s.downcase
-        end
-
-        name = base
-        infinity = 1.0 / 0
-        (1..infinity).each do |i|
-          break unless source_dir(name).exist?
-          name = "#{base}-#{i}"
-        end
-        name
-      end
     end
-  end
 
-  class Source
     extend Executable
     executable :git
 
@@ -648,6 +121,34 @@ module Pod
         end
       end
       super
+    end
+
+    def verify_compatibility!
+      super
+      latest_cocoapods_version = metadata.latest_cocoapods_version && Gem::Version.create(metadata.latest_cocoapods_version)
+      return unless Config.instance.new_version_message? &&
+        latest_cocoapods_version &&
+        latest_cocoapods_version > Gem::Version.new(Pod::VERSION)
+
+      rc = latest_cocoapods_version.prerelease?
+      install_message = !Pathname(__FILE__).dirname.writable? ? 'sudo ' : ''
+      install_message << 'gem install cocoapods'
+      install_message << ' --pre' if rc
+      message = [
+        '',
+        "CocoaPods #{latest_cocoapods_version} is available.".green,
+        "To update use: `#{install_message}`".green,
+        ("[!] This is a test version we'd love you to try.".yellow if rc),
+        ("Until we reach version 1.0 the features of CocoaPods can and will change.\n" \
+         'We strongly recommend that you use the latest version at all times.'.yellow unless rc),
+        '',
+        'For more information, see https://blog.cocoapods.org ' \
+        'and the CHANGELOG for this version at ' \
+        "https://github.com/CocoaPods/CocoaPods/releases/tag/#{latest_cocoapods_version}".green,
+        '',
+        '',
+      ].compact.join("\n")
+      UI.puts(message)
     end
   end
 end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -38,6 +38,8 @@ module Pod
           source = source_with_url(url)
         end
 
+        raise "Unable to create a source with URL #{url}" unless source
+
         source
       end
 

--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -424,6 +424,10 @@ module Pod
         UI.puts message
       end
 
+      def print(message)
+        UI.print(message)
+      end
+
       def warn(message)
         UI.warn message
       end

--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -160,7 +160,7 @@ EOS
         end
 
         def repo_information
-          SourcesManager.all.map do |source|
+          Config.instance.sources_manager.all.map do |source|
             next unless source.type == 'file system'
             repo = source.repo
             Dir.chdir(repo) do

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -30,7 +30,7 @@ module Pod
     #         the Source URLs to use in creating a {Podfile}.
     #
     def initialize(spec_or_path, source_urls)
-      @source_urls = source_urls.map { |url| SourcesManager.source_with_name_or_url(url) }.map(&:url)
+      @source_urls = source_urls.map { |url| config.sources_manager.source_with_name_or_url(url) }.map(&:url)
       @linter = Specification::Linter.new(spec_or_path)
     end
 

--- a/spec/functional/command/inter_process_communication_spec.rb
+++ b/spec/functional/command/inter_process_communication_spec.rb
@@ -51,9 +51,9 @@ module Pod
 
     describe Command::IPC::UpdateSearchIndex do
       it 'updates the search index and prints its path to STDOUT' do
-        SourcesManager.expects(:updated_search_index)
+        config.sources_manager.expects(:updated_search_index)
         out = run_command('ipc', 'update-search-index')
-        out.should.include(SourcesManager.search_index_path.to_s)
+        out.should.include(config.sources_manager.search_index_path.to_s)
       end
     end
 

--- a/spec/functional/command/list_spec.rb
+++ b/spec/functional/command/list_spec.rb
@@ -18,7 +18,7 @@ module Pod
     end
 
     it 'presents the known pods with versions' do
-      sets = SourcesManager.aggregate.all_sets
+      sets = config.sources_manager.aggregate.all_sets
       jsonkit_set = sets.find { |s| s.name == 'JSONKit' }
 
       out = run_command('list')

--- a/spec/functional/command/outdated_spec.rb
+++ b/spec/functional/command/outdated_spec.rb
@@ -58,7 +58,7 @@ module Pod
       lockfile.stubs(:version).returns(Version.new('1.0'))
       lockfile.stubs(:pod_names).returns(%w(AFNetworking))
       Command::Outdated.any_instance.stubs(:lockfile).returns(lockfile)
-      SourcesManager.expects(:update).once
+      config.sources_manager.expects(:update).once
       run_command('outdated')
     end
 
@@ -71,7 +71,7 @@ module Pod
       lockfile.stubs(:version).returns(Version.new('1.0'))
       lockfile.stubs(:pod_names).returns(%w(AFNetworking))
       Command::Outdated.any_instance.stubs(:lockfile).returns(lockfile)
-      SourcesManager.expects(:update).never
+      config.sources_manager.expects(:update).never
       run_command('outdated', '--no-repo-update')
     end
 

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -12,10 +12,8 @@ module Pod
     it "complains if it can't find the repo" do
       Dir.chdir(fixture('banana-lib')) do
         cmd = command('repo', 'push', 'missing_repo')
-        cmd.expects(:check_if_master_repo)
-        cmd.expects(:validate_podspec_files).returns(true)
-        e = lambda { cmd.run }.should.raise Informative
-        e.message.should.match(/repo not found/)
+        e = lambda { cmd.validate! }.should.raise Informative
+        e.message.should.match(/Unable to find the `missing_repo` repo/)
       end
     end
 

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -29,7 +29,7 @@ module Pod
         `git fetch -q`
         `git branch --set-upstream-to=origin/master master`
       end
-      SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+      config.sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
       lambda { command('repo', 'update').run }.should.not.raise
     end
 
@@ -38,7 +38,7 @@ module Pod
       repo2 = repo_clone('repo1', 'repo2')
       repo_make_readme_change(repo1, 'Updated')
       Dir.chdir(repo1) { `git commit -a -m "Update"` }
-      SourcesManager.expects(:update_search_index_if_needed_in_background).with do |value|
+      config.sources_manager.expects(:update_search_index_if_needed_in_background).with do |value|
         value.each_pair do |source, paths|
           source.name.should == 'repo2'
           paths.should == ['README']

--- a/spec/functional/command/spec_spec.rb
+++ b/spec/functional/command/spec_spec.rb
@@ -267,7 +267,7 @@ module Pod
         before do
           @test_source = Source.new(fixture('spec-repos/test_repo'))
           Source::Aggregate.any_instance.stubs(:sources).returns([@test_source])
-          SourcesManager.updated_search_index = nil
+          config.sources_manager.updated_search_index = nil
           yield if block_given?
         end
 

--- a/spec/functional/user_interface_spec.rb
+++ b/spec/functional/user_interface_spec.rb
@@ -6,7 +6,7 @@ module Pod
     extend SpecHelper::Command
 
     before do
-      @set = SourcesManager.search(Dependency.new('CocoaLumberjack'))
+      @set = config.sources_manager.search(Dependency.new('CocoaLumberjack'))
     end
 
     it 'presents the name, version, description, homepage and source of a specification set' do
@@ -53,14 +53,14 @@ module Pod
     end
 
     it 'should print at least one subspec' do
-      @set = SourcesManager.search(Dependency.new('RestKit'))
+      @set = config.sources_manager.search(Dependency.new('RestKit'))
       UI.pod(@set)
       output = UI.output
       output.should.include? 'RestKit/Network'
     end
 
     it 'presents only name and version of a specification set in :name_and_version mode' do
-      @set = SourcesManager.search_by_name('RestKit').first
+      @set = config.sources_manager.search_by_name('RestKit').first
       UI.pod(@set, :name_and_version)
       output = UI.output
       output.should.include? "RestKit #{@set.versions.first}"

--- a/spec/spec_helper/pre_flight.rb
+++ b/spec/spec_helper/pre_flight.rb
@@ -27,7 +27,7 @@ module Bacon
       SpecHelper.temporary_directory.mkpath
 
       # TODO
-      ::Pod::SourcesManager.stubs(:search_index_path).returns(temporary_directory + 'search_index.json')
+      ::Pod::Source::Manager.any_instance.stubs(:search_index_path).returns(temporary_directory + 'search_index.json')
 
       old_run_requirement.bind(self).call(description, spec)
     end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -6,7 +6,7 @@ module Pod
       before do
         repos = [Source.new(fixture('spec-repos/test_repo')), MasterSource.new(fixture('spec-repos/master'))]
         aggregate = Pod::Source::Aggregate.new(repos)
-        Pod::SourcesManager.stubs(:aggregate).returns(aggregate)
+        config.sources_manager.stubs(:aggregate).returns(aggregate)
         aggregate.sources.first.stubs(:url).returns(SpecHelper.test_repo_url)
 
         @podfile = Pod::Podfile.new do
@@ -66,8 +66,8 @@ module Pod
       #--------------------------------------#
 
       it 'does not update unused sources' do
-        @analyzer.stubs(:sources).returns(SourcesManager.master)
-        SourcesManager.expects(:update).once.with('master')
+        @analyzer.stubs(:sources).returns(config.sources_manager.master)
+        config.sources_manager.expects(:update).once.with('master')
         @analyzer.update_repositories
       end
 
@@ -78,7 +78,7 @@ module Pod
         end
         config.verbose = true
 
-        SourcesManager.expects(:update).never
+        config.sources_manager.expects(:update).never
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
         analyzer.update_repositories
       end
@@ -98,7 +98,7 @@ module Pod
 
         source = Source.new(non_git_repo)
 
-        SourcesManager.expects(:update).never
+        config.sources_manager.expects(:update).never
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
         analyzer.stubs(:sources).returns([source])
         analyzer.update_repositories
@@ -121,9 +121,9 @@ module Pod
         source = mock
         source.stubs(:name).returns('repo_2')
         source.stubs(:repo).returns('/repo/cache/path')
-        SourcesManager.expects(:find_or_create_source_with_url).with(repo_url).returns(source)
-        SourcesManager.stubs(:git_repo?).with(source.repo).returns(true)
-        SourcesManager.expects(:update).once.with(source.name)
+        config.sources_manager.expects(:find_or_create_source_with_url).with(repo_url).returns(source)
+        source.stubs(:git?).returns(true)
+        config.sources_manager.expects(:update).once.with(source.name)
 
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
         analyzer.update_repositories
@@ -321,7 +321,7 @@ module Pod
         before do
           repos = [Source.new(fixture('spec-repos/test_repo'))]
           aggregate = Pod::Source::Aggregate.new(repos)
-          Pod::SourcesManager.stubs(:aggregate).returns(aggregate)
+          config.sources_manager.stubs(:aggregate).returns(aggregate)
           aggregate.sources.first.stubs(:url).returns(SpecHelper.test_repo_url)
         end
 
@@ -649,7 +649,7 @@ module Pod
                 pod 'JSONKit', '1.4'
               end
               @analyzer.instance_variable_set(:@podfile, podfile)
-              SourcesManager.expects(:find_or_create_source_with_url).once
+              config.sources_manager.expects(:find_or_create_source_with_url).once
               @analyzer.send(:sources)
             end
           end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -375,13 +375,13 @@ module Pod
     describe 'Dependencies Resolution' do
       describe 'updating spec repos' do
         it 'does not updates the repositories by default' do
-          SourcesManager.expects(:update).never
+          config.sources_manager.expects(:update).never
           @installer.send(:resolve_dependencies)
         end
 
         it 'updates the repositories if that was requested' do
           @installer.repo_update = true
-          SourcesManager.expects(:update).once
+          config.sources_manager.expects(:update).once
           @installer.send(:resolve_dependencies)
         end
       end

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -20,7 +20,7 @@ module Pod
           pod 'BlocksKit', '1.5.2'
         end
         locked_deps = dependency_graph_from_array([Dependency.new('BlocksKit', '1.5.2')])
-        @resolver = Resolver.new(config.sandbox, @podfile, locked_deps, SourcesManager.all)
+        @resolver = Resolver.new(config.sandbox, @podfile, locked_deps, config.sources_manager.all)
       end
 
       it 'returns the sandbox' do
@@ -78,7 +78,7 @@ module Pod
           platform :ios
           pod 'Reachability', :podspec => podspec
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         resolver.resolve
         specs = resolver.specs_by_target.values.flatten
         specs.map(&:to_s).should == ['Reachability (3.0.0)']
@@ -88,7 +88,7 @@ module Pod
         @podfile = Podfile.new do
           platform :ios
         end
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == []
       end
@@ -102,7 +102,7 @@ module Pod
           platform :ios, '6.0'
           pod 'BlocksKit', '1.5.2'
         end
-        @resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        @resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
       end
 
       it 'cross resolves dependencies' do
@@ -112,7 +112,7 @@ module Pod
           pod 'AFQuickLookView', '=  0.1.0' # requires  'AFNetworking', '>= 0.9.0'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == ['AFNetworking (0.9.1)', 'AFQuickLookView (0.1.0)']
       end
@@ -124,7 +124,7 @@ module Pod
           pod 'AFNetworking', '~> 1.2.0'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == ['AFNetworking (1.2.1)', 'RestKit (0.20.1)',
                          'RestKit/Core (0.20.1)', 'RestKit/CoreData (0.20.1)',
@@ -140,7 +140,7 @@ module Pod
           pod 'AFOAuth2Client' # latest version (0.1.2) requires 'AFNetworking', '~> 1.3'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == ['AFAmazonS3Client (1.0.1)', 'AFNetworking (1.3.4)',
                          'AFOAuth2Client (0.1.2)', 'CargoBay (1.0.0)']
@@ -154,7 +154,7 @@ module Pod
             pod 'AFNetworking', '2.0.1'
           end
 
-          resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+          resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
           specs = resolver.resolve.values.flatten.map(&:root).map(&:to_s).uniq.sort
           specs.should == ['AFNetworking (2.0.1)', 'InstagramKit (3.5.0)']
         end
@@ -163,9 +163,9 @@ module Pod
         @resolver.resolve
         cached_sets = @resolver.send(:cached_sets)
         cached_sets.values.sort_by(&:name).should == [
-          SourcesManager.search_by_name('A2DynamicDelegate').first,
-          SourcesManager.search_by_name('BlocksKit').first,
-          SourcesManager.search_by_name('libffi').first,
+          config.sources_manager.search_by_name('A2DynamicDelegate').first,
+          config.sources_manager.search_by_name('BlocksKit').first,
+          config.sources_manager.search_by_name('libffi').first,
         ].sort_by(&:name)
       end
 
@@ -243,7 +243,7 @@ module Pod
           platform :ios, '7.0'
           pod 'RestKit', '0.10.3'
         end
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         resolver.resolve.values.flatten.map(&:name).sort.should == %w(
           FileMD5Hash
           ISO8601DateFormatter
@@ -271,7 +271,7 @@ module Pod
           platform :ios, '7.0'
           pod 'RestKit', '0.20.0-rc1'
         end
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         resolver.resolve.values.flatten.map(&:to_s).sort.should == [
           'AFNetworking (1.1.0)',
           'RestKit (0.20.0-rc1)',
@@ -300,7 +300,7 @@ module Pod
           end
         end
         config.sandbox.expects(:specification).with('MainSpec').returns(spec)
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:name).sort
         specs.should == %w(
           MainSpec/FirstSubSpec MainSpec/FirstSubSpec/SecondSubSpec
@@ -319,7 +319,7 @@ module Pod
           s.platform     = :ios
         end
         config.sandbox.expects(:specification).with('MainSpec').returns(spec)
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == [
           'MainSpec (1.2.3-pre)',
@@ -332,7 +332,7 @@ module Pod
           pod 'JSONKit', '1.4'
           pod 'JSONKit', '1.5pre'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/Unable to satisfy the following requirements/)
         e.message.should.match(/`JSONKit \(= 1.4\)` required by `Podfile`/)
@@ -345,7 +345,7 @@ module Pod
           pod 'RestKit', '0.23.3' # dependends on AFNetworking ~> 1.3.0
           pod 'AFNetworking', '> 2'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/Unable to satisfy the following requirements/)
         e.message.should.match(/`AFNetworking \(~> 1.3.0\)` required by `RestKit\/Network \(.*\)`/)
@@ -357,7 +357,7 @@ module Pod
           platform :ios
           pod 'AFNetworking', '3.0.1'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/Unable to satisfy the following requirements/)
         e.message.should.match(/`AFNetworking \(= 3.0.1\)` required by `Podfile`/)
@@ -374,12 +374,12 @@ module Pod
           platform :ios
           pod 'JSONKit', '<= 1.5pre'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         version = resolver.resolve.values.flatten.first.version
         version.to_s.should == '1.5pre'
 
         locked_deps = dependency_graph_from_array([Dependency.new('JSONKit', '= 1.4')])
-        resolver = Resolver.new(config.sandbox, podfile, locked_deps, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, locked_deps, config.sources_manager.all)
         version = resolver.resolve.values.flatten.first.version
         version.to_s.should == '1.4'
       end
@@ -392,7 +392,7 @@ module Pod
           pod 'CocoaLumberjack'
         end
         locked_deps = dependency_graph_from_array([Dependency.new('CocoaLumberjack', '= 2.0.0-beta2')])
-        resolver = Resolver.new(config.sandbox, podfile, locked_deps, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, locked_deps, config.sources_manager.all)
         e = lambda { puts resolver.resolve.values.flatten }.should.raise Informative
         e.message.should.match(/you were using a pre-release version of `CocoaLumberjack`/)
         e.message.should.match(/`pod 'CocoaLumberjack', '= 2.0.0-beta2'`/)
@@ -401,7 +401,7 @@ module Pod
 
       describe 'concerning dependencies that are scoped by consumer platform' do
         def resolve
-          Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all).resolve
+          Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all).resolve
         end
 
         # AFNetworking Has an 'AFNetworking/UIKit' iOS-only default subspec
@@ -475,13 +475,13 @@ module Pod
           pod 'JSONKit', '> 2'
         end
         file = fixture('spec-repos/test_repo/JSONKit/999.999.999/JSONKit.podspec')
-        sources = SourcesManager.sources(%w(master test_repo))
+        sources = config.sources_manager.sources(%w(master test_repo))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         spec = resolver.resolve.values.flatten.first
         spec.version.to_s.should == '999.999.999'
         spec.defined_in_file.should == file
 
-        sources = SourcesManager.sources(%w(test_repo master))
+        sources = config.sources_manager.sources(%w(test_repo master))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         spec = resolver.resolve.values.flatten.first
         spec.version.to_s.should == '999.999.999'
@@ -494,13 +494,13 @@ module Pod
           platform :ios
           pod 'JSONKit', '1.4'
         end
-        sources = SourcesManager.sources(%w(master test_repo))
+        sources = config.sources_manager.sources(%w(master test_repo))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         spec = resolver.resolve.values.flatten.first
         spec.version.to_s.should == '1.4'
         spec.defined_in_file.should == fixture('spec-repos/master/Specs/JSONKit/1.4/JSONKit.podspec.json')
 
-        sources = SourcesManager.sources(%w(test_repo master))
+        sources = config.sources_manager.sources(%w(test_repo master))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         spec = resolver.resolve.values.flatten.first
         spec.version.to_s.should == '1.4'
@@ -511,13 +511,13 @@ module Pod
 
       it 'does not warn when multiple sources contain a pod but a dependency ' \
          'has an explicit source specified' do
-        test_repo_url = SourcesManager.source_with_name_or_url('test_repo').url
+        test_repo_url = config.sources_manager.source_with_name_or_url('test_repo').url
         podfile = Podfile.new do
           platform :ios
           pod 'JSONKit', '1.4', :source => test_repo_url
         end
 
-        sources = SourcesManager.sources(%w(master test_repo))
+        sources = config.sources_manager.sources(%w(master test_repo))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         resolver.resolve
 
@@ -526,13 +526,13 @@ module Pod
 
       it 'fails to resolve a dependency with an explicit source even if it can be ' \
          'resolved using the global sources' do
-        test_repo_url = SourcesManager.source_with_name_or_url('test_repo').url
+        test_repo_url = config.sources_manager.source_with_name_or_url('test_repo').url
         podfile = Podfile.new do
           platform :ios
           pod 'JSONKit', '1.5pre', :source => test_repo_url
         end
 
-        sources = SourcesManager.sources(%w(master))
+        sources = config.sources_manager.sources(%w(master))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/None of your spec sources contain a spec/)
@@ -542,13 +542,13 @@ module Pod
 
       it 'resolves a dependency with an explicit source even if it can\'t be ' \
          'resolved using the global sources' do
-        master_repo_url = SourcesManager.source_with_name_or_url('master').url
+        master_repo_url = config.sources_manager.source_with_name_or_url('master').url
         podfile = Podfile.new do
           platform :ios
           pod 'JSONKit', '1.5pre', :source => master_repo_url
         end
 
-        sources = SourcesManager.sources(%w(test_repo))
+        sources = config.sources_manager.sources(%w(test_repo))
         sources.map(&:url).should.not.include(master_repo_url)
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         spec = resolver.resolve.values.flatten.first
@@ -557,8 +557,8 @@ module Pod
       end
 
       it 'uses explicit source repos for a dependency even when it\'s transitive' do
-        master_repo_url = SourcesManager.source_with_name_or_url('master').url
-        test_repo_url = SourcesManager.source_with_name_or_url('test_repo').url
+        master_repo_url = config.sources_manager.source_with_name_or_url('master').url
+        test_repo_url = config.sources_manager.source_with_name_or_url('test_repo').url
 
         podfile = Podfile.new do
           platform :ios
@@ -567,7 +567,7 @@ module Pod
           pod 'JSONKit', '1.4', :source => test_repo_url
         end
 
-        sources = SourcesManager.sources(%w(master test_repo))
+        sources = config.sources_manager.sources(%w(master test_repo))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         resolver.resolve
 
@@ -581,14 +581,14 @@ module Pod
 
       it 'uses global source repos for resolving a transitive dependency even ' \
          'if the root dependency has an explicit source' do
-        test_repo_url = SourcesManager.source_with_name_or_url('test_repo').url
+        test_repo_url = config.sources_manager.source_with_name_or_url('test_repo').url
         podfile = Podfile.new do
           platform :ios, '6.0'
           pod 'CrossRepoDependent', '1.0', :source => test_repo_url
         end
 
         # CrossRepoDependent depends on AFNetworking which is only available in the master repo.
-        sources = SourcesManager.sources(%w(master))
+        sources = config.sources_manager.sources(%w(master))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
         resolver.resolve
 
@@ -603,7 +603,7 @@ module Pod
         afnetworking_spec.defined_in_file.should == fixture('spec-repos/master/Specs/AFNetworking/2.4.0/AFNetworking.podspec.json')
 
         # Check that if the master source is not available the dependency cannot be resolved.
-        sources = SourcesManager.sources(%w(test_repo))
+        sources = config.sources_manager.sources(%w(test_repo))
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, sources)
 
         e = lambda { resolver.resolve }.should.raise Informative
@@ -621,7 +621,7 @@ module Pod
           pod 'AFNetworking', '1.0RC3'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == ['AFNetworking (1.0RC3)']
       end
@@ -632,7 +632,7 @@ module Pod
           pod 'AFNetworking', '~> 1.0RC3'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.3.4)']
@@ -644,7 +644,7 @@ module Pod
           pod 'AFNetworking', '1.0'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.0)']
@@ -656,7 +656,7 @@ module Pod
           pod 'AFNetworking', '< 1.0'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (0.10.1)']
@@ -668,7 +668,7 @@ module Pod
           pod 'AFNetworking', '<= 1.0'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.0)']
@@ -680,7 +680,7 @@ module Pod
           pod 'AFNetworking', '> 1.0', '< 1.3'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.2.1)']
@@ -692,7 +692,7 @@ module Pod
           pod 'AFNetworking', '>= 1.0', '< 1.3'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.2.1)']
@@ -704,7 +704,7 @@ module Pod
           pod 'AFNetworking', '~> 1.0', '< 1.3'
         end
 
-        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, @podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should != ['AFNetworking (1.0RC3)']
         specs.should == ['AFNetworking (1.2.1)']
@@ -715,7 +715,7 @@ module Pod
           platform :ios
           pod 'PrereleaseMonkey'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/There are only pre-release versions available satisfying the following requirements/)
         e.message.should.match(/PrereleaseMonkey.*>= 0/)
@@ -727,7 +727,7 @@ module Pod
           platform :ios
           pod 'AFNetworking', '< 1.0', '> 0.10.1'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
         e.message.should.match(/There are only pre-release versions available satisfying the following requirements/)
         e.message.should.match(/AFNetworking.*< 1\.0, > 0\.10\.1/)
@@ -739,7 +739,7 @@ module Pod
           platform :ios
           pod 'PrereleaseMonkey', '1.0-beta1'
         end
-        resolver = Resolver.new(config.sandbox, podfile, empty_graph, SourcesManager.all)
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         specs = resolver.resolve.values.flatten.map(&:to_s).sort
         specs.should == ['PrereleaseMonkey (1.0-beta1)']
       end

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -56,9 +56,8 @@ module Pod
 
           it 'handles repositories without a remote url' do # for #2965
             Command::Repo::Add.any_instance.stubs(:run).once
-            Source.any_instance.stubs(:url).returns(nil)
-            e = lambda { @sources_manager.find_or_create_source_with_url('url') }
-            e.should.not.raise
+            Source.any_instance.stubs(:url).returns(nil).then.returns('URL')
+            @sources_manager.find_or_create_source_with_url('URL').url.should == 'URL'
           end
         end
 

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -12,279 +12,67 @@ def set_up_test_repo_for_update
     `git branch --set-upstream-to=origin/master master`
     `git config branch.master.rebase true`
   end
-  config.repos_dir = SpecHelper.tmp_repos_path
-end
-
-def merge_conflict_version_yaml
-  <<-VERSION.strip_heredoc
-    ---
-    <<<<<<< HEAD
-    min: 0.18.1
-    =======
-    min: 0.29.0
-    >>>>>>> 8365d0ad18508175bbde31b9dd2bdaf1be49214f
-    last: 0.29.0
-  VERSION
+  @sources_manager.stubs(:repos_dir).returns(SpecHelper.tmp_repos_path)
 end
 
 module Pod
-  describe SourcesManager do
+  describe Source::Manager do
     before do
       @test_source = Source.new(fixture('spec-repos/test_repo'))
+      @sources_manager = Source::Manager.new(config.repos_dir)
     end
 
     #-------------------------------------------------------------------------#
 
     describe 'In general' do
       before do
-        SourcesManager.stubs(:all).returns([@test_source])
+        @sources_manager.stubs(:all).returns([@test_source])
       end
 
       #--------------------------------------#
 
-      it 'does not fail if the repos directory does not exist' do
-        config.stubs(:repos_dir).returns(Pathname.new('/foo/bar'))
-        SourcesManager.unstub(:all)
-        SourcesManager.aggregate.sources.should == []
-        SourcesManager.all.should == []
-      end
-
-      it 'returns all the sources' do
-        SourcesManager.unstub(:all)
-        SourcesManager.all.map(&:name).should == %w(master test_repo)
-      end
-
-      it 'includes all sources in an aggregate for a dependency if no source is specified' do
-        dependency = Dependency.new('JSONKit', '1.4')
-        aggregate = SourcesManager.aggregate_for_dependency(dependency)
-        aggregate.sources.map(&:name).should == %w(master test_repo)
-      end
-
-      it 'includes only the one source in an aggregate for a dependency if a source is specified' do
-        repo_url = 'https://url/to/specs.git'
-        dependency = Dependency.new('JSONKit', '1.4', :source => repo_url)
-
-        source = mock
-        source.stubs(:name).returns('repo')
-
-        SourcesManager.expects(:source_with_url).with(repo_url).returns(source)
-
-        aggregate = SourcesManager.aggregate_for_dependency(dependency)
-        aggregate.sources.map(&:name).should == [source.name]
-      end
-
-      it 'searches for the set of a dependency' do
-        set = SourcesManager.search(Dependency.new('BananaLib'))
-        set.class.should == Specification::Set
-        set.name.should == 'BananaLib'
-      end
-
-      it 'returns nil if it is not able to find a pod for the given dependency' do
-        set = SourcesManager.search(Dependency.new('Windows-Lib'))
-        set.should.be.nil
-      end
-
-      it 'searches sets by name' do
-        sets = SourcesManager.search_by_name('BananaLib')
-        sets.all? { |s| s.class == Specification::Set }.should.be.true
-        sets.any? { |s| s.name == 'BananaLib' }.should.be.true
-      end
-
-      it 'can perform a full text search of the sets' do
-        SourcesManager.stubs(:all).returns([@test_source])
-        sets = SourcesManager.search_by_name('Chunky', true)
-        sets.all? { |s| s.class == Specification::Set }.should.be.true
-        sets.any? { |s| s.name == 'BananaLib' }.should.be.true
-      end
-
-      it 'can perform a full text regexp search of the sets' do
-        SourcesManager.stubs(:all).returns([@test_source])
-        sets = SourcesManager.search_by_name('Ch[aeiou]nky', true)
-        sets.all? { |s| s.class == Specification::Set }.should.be.true
-        sets.any? { |s| s.name == 'BananaLib' }.should.be.true
-      end
-
-      describe 'Sorting algorithm' do
-        before do
-          @test_search_results = %w(HockeyKit DLSuit VCLReachability NPReachability AVReachability PYNetwork
-                                    SCNetworkReachability AFNetworking Networking).map do |name|
-            Specification::Set.new(name)
-          end
-        end
-
-        it 'puts pod with exact match at the first index while sorting' do
-          regexps = [/networking/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets[0].name.should == 'Networking'
-        end
-
-        it 'puts pod with less prefix length before pods with more prefix length in search results' do
-          regexps = [/reachability/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets.index { |s| s.name == 'AVReachability' }.should.be < sets.index { |s| s.name == 'VCLReachability' }
-        end
-
-        it 'puts pod with more query word match before pods with less match in multi word query search results' do
-          regexps = [/network/i, /reachability/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets.index { |s| s.name == 'SCNetworkReachability' }.should.be < sets.index { |s| s.name == 'AVReachability' }
-        end
-
-        it 'puts pod matching first query word before pods matching later words in multi word query search results' do
-          regexps = [/network/i, /reachability/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets.index { |s| s.name == 'PYNetwork' }.should.be < sets.index { |s| s.name == 'AVReachability' }
-        end
-
-        it 'puts pod matching first query word before pods matching later words in multi word query search results' do
-          regexps = [/network/i, /reachability/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets.index { |s| s.name == 'PYNetwork' }.should.be < sets.index { |s| s.name == 'AVReachability' }
-        end
-
-        it 'alphabetically sorts pods having exact other conditions' do
-          regexps = [/reachability/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets.index { |s| s.name == 'AVReachability' }.should.be < sets.index { |s| s.name == 'NPReachability' }
-        end
-
-        it 'alphabetically sorts pods whose names does not match query' do
-          regexps = [/reachability/i]
-          sets = SourcesManager.sorted_sets(@test_search_results, regexps)
-          sets.index { |s| s.name == 'DLSuit' }.should.be < sets.index { |s| s.name == 'HockeyKit' }
-        end
-      end
-
-      it "generates the search index before performing a search if it doesn't exist" do
-        SourcesManager.stubs(:all).returns([@test_source])
-        Source::Aggregate.any_instance.expects(:generate_search_index_for_source).with(@test_source).returns('BananaLib' => ['BananaLib'])
-        SourcesManager.updated_search_index = nil
-        SourcesManager.search_by_name('BananaLib', true)
-      end
-
       it 'returns the path of the search index' do
-        SourcesManager.unstub(:search_index_path)
+        Source::Manager.any_instance.unstub(:search_index_path)
         config.cache_root = Config::DEFAULTS[:cache_root]
-        path = SourcesManager.search_index_path.to_s
-        path.should.match %r{Library/Caches/CocoaPods/search_index.json}
+        path = @sources_manager.search_index_path.to_s
+        path.should.end_with 'Library/Caches/CocoaPods/search_index.json'
       end
 
       describe 'managing sources by URL' do
-        describe 'generating a repo name from a URL' do
-          it 'uses `master` for the master CocoaPods repository' do
-            url = 'https://github.com/CocoaPods/Specs.git'
-            Pathname.any_instance.stubs(:exist?).
-              returns(false).then.returns(true)
-            SourcesManager.send(:name_for_url, url).should == 'master'
-
-            url = 'git@github.com:CocoaPods/Specs.git'
-            Pathname.any_instance.stubs(:exist?).
-              returns(false).then.returns(true)
-            SourcesManager.send(:name_for_url, url).should == 'master'
-
-            url = 'git@github.com:/CocoaPods/Specs.git'
-            Pathname.any_instance.stubs(:exist?).
-              returns(false).then.returns(true)
-            SourcesManager.send(:name_for_url, url).should == 'master'
-          end
-
-          it 'uses the organization name for github.com URLs' do
-            url = 'https://github.com/segiddins/banana.git'
-            SourcesManager.send(:name_for_url, url).should == 'segiddins'
-          end
-
-          it 'uses a combination of host and path for other URLs' do
-            url = 'https://sourceforge.org/Artsy/Specs.git'
-            SourcesManager.send(:name_for_url, url).
-              should == 'sourceforge-artsy-specs'
-          end
-
-          it 'supports scp-style URLs' do
-            url = 'git@git-host.com:specs.git'
-            SourcesManager.send(:name_for_url, url).
-              should == 'git-host-specs'
-
-            url = 'git@git-host.com/specs.git'
-            SourcesManager.send(:name_for_url, url).
-              should == 'git-host-specs'
-
-            url = 'git@git-host.com:/specs.git'
-            SourcesManager.send(:name_for_url, url).
-              should == 'git-host-specs'
-          end
-
-          it 'supports ssh URLs with an aliased hostname' do
-            url = 'ssh://user@companyalias/pod-specs'
-            SourcesManager.send(:name_for_url, url).
-              should == 'companyalias-pod-specs'
-          end
-
-          it 'supports file URLs' do
-            url = 'file:///Users/kurrytran/pod-specs'
-            SourcesManager.send(:name_for_url, url).
-              should == 'users-kurrytran-pod-specs'
-          end
-
-          it 'uses the repo name if no parent directory' do
-            url = 'file:///pod-specs'
-            SourcesManager.send(:name_for_url, url).
-              should == 'pod-specs'
-          end
-
-          it 'supports ssh URLs with no user component' do
-            url = 'ssh://company.com/pods/specs.git'
-            SourcesManager.send(:name_for_url, url).
-              should == 'company-pods-specs'
-          end
-
-          it 'appends a number to the name if the base name dir exists' do
-            url = 'https://github.com/segiddins/banana.git'
-            Pathname.any_instance.stubs(:exist?).
-              returns(true).then.returns(false)
-            SourcesManager.send(:name_for_url, url).should == 'segiddins-1'
-
-            url = 'https://sourceforge.org/Artsy/Specs.git'
-            Pathname.any_instance.stubs(:exist?).
-              returns(true).then.returns(false)
-            SourcesManager.send(:name_for_url, url).
-              should == 'sourceforge-artsy-specs-1'
-          end
-        end
-
         describe 'finding or creating a source by URL' do
           it 'returns an existing matching source' do
             Source.any_instance.stubs(:url).returns('url')
-            SourcesManager.expects(:name_for_url).never
-            SourcesManager.find_or_create_source_with_url('url').url.
+            @sources_manager.expects(:name_for_url).never
+            @sources_manager.find_or_create_source_with_url('url').url.
               should == 'url'
           end
 
           it 'runs `pod repo add` when there is no matching source' do
             Command::Repo::Add.any_instance.stubs(:run).once
-            SourcesManager.stubs(:source_with_url).returns(nil).then.returns(Source.new('Source'))
-            SourcesManager.find_or_create_source_with_url('https://github.com/artsy/Specs.git').name.
+            @sources_manager.stubs(:source_with_url).returns(nil).then.returns(Source.new('Source'))
+            @sources_manager.find_or_create_source_with_url('https://github.com/artsy/Specs.git').name.
               should == 'Source'
           end
 
           it 'handles repositories without a remote url' do # for #2965
             Command::Repo::Add.any_instance.stubs(:run).once
             Source.any_instance.stubs(:url).returns(nil)
-            e = lambda { SourcesManager.find_or_create_source_with_url('url') }
+            e = lambda { @sources_manager.find_or_create_source_with_url('url') }
             e.should.not.raise
           end
         end
 
         describe 'finding or creating a source by name or URL' do
           it 'returns an existing source with a matching name' do
-            SourcesManager.expects(:name_for_url).never
-            SourcesManager.source_with_name_or_url('test_repo').name.
+            @sources_manager.expects(:name_for_url).never
+            @sources_manager.source_with_name_or_url('test_repo').name.
               should == 'test_repo'
           end
 
           it 'tries by url when there is no matching name' do
             Command::Repo::Add.any_instance.stubs(:run).once
-            SourcesManager.stubs(:source_with_url).returns(nil).then.returns('Source')
-            SourcesManager.source_with_name_or_url('https://github.com/artsy/Specs.git').
+            @sources_manager.stubs(:source_with_url).returns(nil).then.returns('Source')
+            @sources_manager.source_with_name_or_url('https://github.com/artsy/Specs.git').
               should == 'Source'
           end
         end
@@ -302,25 +90,25 @@ module Pod
 
       it 'updates source backed by a git repository' do
         set_up_test_repo_for_update
-        SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+        @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
         MasterSource.any_instance.expects(:git!).with(%w(pull --ff-only))
-        SourcesManager.update(test_repo_path.basename.to_s, true)
+        @sources_manager.update(test_repo_path.basename.to_s, true)
       end
 
       it 'uses the only fast forward git option' do
         set_up_test_repo_for_update
         MasterSource.any_instance.expects(:git!).with { |options| options.should.include? '--ff-only' }
-        SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
-        SourcesManager.update(test_repo_path.basename.to_s, true)
+        @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+        @sources_manager.update(test_repo_path.basename.to_s, true)
       end
 
       it 'unshallows if the git repo is shallow' do
         set_up_test_repo_for_update
         test_repo_path.join('.git', 'shallow').open('w') { |f| f << 'a' * 40 }
-        SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+        @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
         MasterSource.any_instance.expects(:git!).with(%w(fetch --unshallow))
         MasterSource.any_instance.expects(:git!).with(%w(pull --ff-only))
-        SourcesManager.update(test_repo_path.basename.to_s, true)
+        @sources_manager.update(test_repo_path.basename.to_s, true)
 
         UI.output.should.match /deep fetch.+`master`.+improve future performance/
       end
@@ -336,131 +124,31 @@ fatal: Could not read from remote repository.
 Please make sure you have the correct access rights
 and the repository exists.
         EOS
-        SourcesManager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
-        SourcesManager.update(test_repo_path.basename.to_s, true)
+        @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
+        @sources_manager.update(test_repo_path.basename.to_s, true)
         UI.warnings.should.include('not able to update the `master` repo')
       end
 
-      it 'updates search index for changed paths if source is updated' do
-        prev_index = { @test_source.name => {} }
-        SourcesManager.expects(:stored_search_index).returns(prev_index)
-
-        SourcesManager.expects(:save_search_index).with do |value|
-          value[@test_source.name]['BananaLib'].should.include(:BananaLib)
-          value[@test_source.name]['JSONKit'].should.include(:JSONKit)
-        end
-        changed_paths = { @test_source => %w(BananaLib/1.0/BananaLib.podspec JSONKit/1.4/JSONKit.podspec) }
-        SourcesManager.update_search_index_if_needed(changed_paths)
-      end
-
-      it 'does not update search index if it does not contain source even if there are changes in source' do
-        prev_index = {}
-        SourcesManager.expects(:stored_search_index).returns(prev_index)
-
-        SourcesManager.expects(:save_search_index).with do |value|
-          value[@test_source.name].should.be.nil
-        end
-        changed_paths = { @test_source => %w(BananaLib/1.0/BananaLib.podspec JSONKit/1.4/JSONKit.podspec) }
-        SourcesManager.update_search_index_if_needed(changed_paths)
-      end
-
-      it 'returns whether a source is backed by a git repo' do
-        SourcesManager.git_repo?(SourcesManager.master_repo_dir).should.be.true
-        SourcesManager.git_repo?(Pathname.new('/tmp')).should.be.false
-      end
-
       it 'informs the user if there is an update for CocoaPods' do
-        SourcesManager.stubs(:version_information).returns('last' => '999.0')
-        SourcesManager.check_version_information(temporary_directory)
+        master = @sources_manager.master.first
+        master.stubs(:metadata).returns(Source::Metadata.new('last' => '999.0'))
+        master.verify_compatibility!
         UI.output.should.match /CocoaPods 999.0 is available/
       end
 
       it 'recommends the user to use the latest stable version' do
-        SourcesManager.stubs(:version_information).returns('last' => '999.0')
-        SourcesManager.check_version_information(temporary_directory)
+        master = @sources_manager.master.first
+        master.stubs(:metadata).returns(Source::Metadata.new('last' => '999.0'))
+        master.verify_compatibility!
         UI.output.should.match /We strongly recommend that you use the/
       end
 
       it 'skips the update message if the user disabled the notification' do
         config.new_version_message = false
-        SourcesManager.stubs(:version_information).returns('last' => '999.0')
-        SourcesManager.check_version_information(temporary_directory)
+        master = @sources_manager.master.first
+        master.stubs(:metadata).returns(Source::Metadata.new('last' => '999.0'))
+        master.verify_compatibility!
         UI.output.should.not.match /CocoaPods 999.0 is available/
-      end
-
-      it 'raises while asked to version information of a source if it is not compatible' do
-        SourcesManager.stubs(:version_information).returns('min' => '999.0')
-        e = lambda { SourcesManager.check_version_information(temporary_directory) }.should.raise Informative
-        e.message.should.match /Update CocoaPods/
-        e.message.should.match /(currently using #{Pod::VERSION})/
-        SourcesManager.stubs(:version_information).returns('max' => '0.0.1')
-        e = lambda { SourcesManager.check_version_information(temporary_directory) }.should.raise Informative
-        e.message.should.match /Update CocoaPods/
-        e.message.should.match /(currently using #{Pod::VERSION})/
-      end
-
-      it 'raises when reading version information with merge conflict' do
-        File.stubs(:read).returns(merge_conflict_version_yaml)
-        e = lambda { SourcesManager.version_information(SourcesManager.master_repo_dir) }.should.raise Informative
-        e.message.should.match /Repairing-Our-Broken-Specs-Repository/
-      end
-
-      it 'returns whether a path is writable' do
-        path = '/Users/'
-        Pathname.any_instance.stubs(:writable?).returns(true)
-        SourcesManager.send(:path_writable?, path).should.be.true
-      end
-
-      it 'knows when sudo is needed' do
-        SourcesManager.stubs(:path_writable?).returns(false)
-        SourcesManager.send(:needs_sudo?).should.be.true
-      end
-
-      it 'knows when sudo is not needed' do
-        SourcesManager.stubs(:path_writable?).returns(true)
-        SourcesManager.send(:needs_sudo?).should.be.false
-      end
-
-      it 'returns whether a repository is compatible' do
-        SourcesManager.stubs(:version_information).returns('min' => '0.0.1')
-        SourcesManager.repo_compatible?('stub').should.be.true
-
-        SourcesManager.stubs(:version_information).returns('max' => '999.0')
-        SourcesManager.repo_compatible?('stub').should.be.true
-
-        SourcesManager.stubs(:version_information).returns('min' => '999.0')
-        SourcesManager.repo_compatible?('stub').should.be.false
-
-        SourcesManager.stubs(:version_information).returns('max' => '0.0.1')
-        SourcesManager.repo_compatible?('stub').should.be.false
-      end
-
-      it 'returns whether there is a CocoaPods update available' do
-        SourcesManager.cocoapods_update?('last' => '0.0.1').should.be.false
-        SourcesManager.cocoapods_update?('last' => '999.0').should.be.true
-      end
-
-      it "it returns an empty array for the version information if the file can't be found" do
-        SourcesManager.version_information(temporary_directory).should == {}
-      end
-    end
-
-    #-------------------------------------------------------------------------#
-
-    describe 'Master repo' do
-      it 'returns the master repo dir' do
-        SourcesManager.master_repo_dir.to_s.should.match %r{fixtures/spec-repos/master}
-      end
-
-      it 'returns an empty array for master sources when the master repo has not been set up' do
-        Pathname.any_instance.stubs(:directory?).returns(false)
-        SourcesManager.master.should == []
-      end
-
-      it 'returns whether the master repo is functional' do
-        SourcesManager.master_repo_functional?.should.be.true
-        config.repos_dir = SpecHelper.temporary_directory
-        SourcesManager.master_repo_functional?.should.be.false
       end
     end
   end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -47,7 +47,7 @@ module Pod
 
     describe 'Quick mode' do
       it 'validates a correct podspec' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.quick = true
         validator.validate
         validator.results.should == []
@@ -57,7 +57,7 @@ module Pod
       it 'lints the podspec during validation' do
         podspec = stub_podspec(/.*name.*/, '"name": "TEST",')
         file = write_podspec(podspec)
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.quick = true
         validator.validate
         validator.results.map(&:to_s).first.should.match /should match the name/
@@ -66,7 +66,7 @@ module Pod
 
       it 'respects quick mode' do
         file = write_podspec(stub_podspec)
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.quick = true
         validator.expects(:perform_extensive_analysis).never
         validator.validate
@@ -75,7 +75,7 @@ module Pod
       it 'respects the allow warnings option' do
         podspec = stub_podspec(/.*summary.*/, '"summary": "A short description of",')
         file = write_podspec(podspec)
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.quick = true
         validator.allow_warnings = true
         validator.validate
@@ -85,7 +85,7 @@ module Pod
 
       it 'handles symlinks' do
         file = write_podspec(stub_podspec)
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.quick = true
         validator.stubs(:validate_url)
         validator.validate
@@ -95,7 +95,7 @@ module Pod
       describe '#only_subspec' do
         before do
           podspec = fixture('spec-repos') + 'master/Specs/RestKit/0.22.0/RestKit.podspec.json'
-          @validator = Validator.new(podspec, SourcesManager.master.map(&:url))
+          @validator = Validator.new(podspec, config.sources_manager.master.map(&:url))
           @validator.quick = true
         end
 
@@ -128,7 +128,7 @@ module Pod
     describe 'Extensive analysis' do
       describe 'URL validation' do
         before do
-          @validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+          @validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
           @validator.stubs(:download_pod)
           @validator.stubs(:check_file_patterns)
           @validator.stubs(:install_pod)
@@ -269,7 +269,7 @@ module Pod
 
       it 'respects the no clean option' do
         file = write_podspec(stub_podspec)
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.stubs(:validate_url)
         validator.no_clean = true
         validator.validate
@@ -278,7 +278,7 @@ module Pod
 
       it 'builds the pod per platform' do
         file = write_podspec(stub_podspec)
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.stubs(:validate_url)
         validator.expects(:install_pod).times(4)
         validator.expects(:build_pod).times(4)
@@ -288,7 +288,7 @@ module Pod
 
       it 'builds the pod only once if the first fails with fail_fast' do
         Validator.any_instance.unstub(:xcodebuild)
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)
         validator.fail_fast = true
@@ -298,7 +298,7 @@ module Pod
       end
 
       it 'uses the deployment target of the specification' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:validate_url)
         validator.stubs(:validate_screenshots)
         podfile = validator.send(:podfile_from_spec, :ios, '5.0')
@@ -307,7 +307,7 @@ module Pod
       end
 
       it 'uses the deployment target of the current subspec' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.instance_variable_set(:@results, [])
         validator.stubs(:validate_url)
         validator.stubs(:validate_screenshots)
@@ -333,7 +333,7 @@ module Pod
 
       describe '#podfile_from_spec' do
         before do
-          @validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+          @validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
           @validator.stubs(:validate_url)
         end
 
@@ -370,7 +370,7 @@ module Pod
       end
 
       it 'uses xcodebuild to generate warnings' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:xcodebuild).returns("file.m:1:1: warning: 'dataFromPropertyList:format:errorDescription:' is deprecated: first deprecated in iOS 8.0 - Use dataWithPropertyList:format:options:error: instead. [-Wdeprecated-declarations]")
         validator.stubs(:validate_url)
@@ -381,7 +381,7 @@ module Pod
       end
 
       it 'uses xcodebuild to generate notes' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:xcodebuild).returns("file.m:1:1: note: 'dataFromPropertyList:format:errorDescription:' has been explicitly marked deprecated here")
         validator.stubs(:validate_url)
@@ -394,7 +394,7 @@ module Pod
       it 'checks if xcodebuild returns a successful status code' do
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)
         git = Executable.which(:git)
@@ -413,7 +413,7 @@ module Pod
       it 'runs xcodebuild with correct arguments for code signing' do
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)
         git = Executable.which(:git)
@@ -433,7 +433,7 @@ module Pod
       end
 
       it 'sets the -Wincomplete-umbrella compiler flag for pod targets' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.no_clean = true
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)
@@ -447,7 +447,7 @@ module Pod
       end
 
       it 'does filter InputFile errors completely' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:xcodebuild).returns("2014-10-01 06:27:36.693 xcodebuild[61207:2007] error: InputFile    Target Support Files/Pods-OneUpFoundation/Pods-OneUpFoundation-prefix.pch 0 1412159238 77 33188... malformed line 10; 'InputFile' should have exactly five arguments")
         validator.stubs(:validate_url)
@@ -456,7 +456,7 @@ module Pod
       end
 
       it 'does filter embedded frameworks warnings' do
-        validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:xcodebuild).returns('ld: warning: embedded dylibs/frameworks only run on iOS 8 or later.')
         validator.stubs(:validate_url)
@@ -466,7 +466,7 @@ module Pod
 
       describe 'import validation' do
         before do
-          @validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+          @validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
           @validator.stubs(:validate_url)
           @consumer = Specification.from_file(podspec_path).consumer(:ios)
           @validator.instance_variable_set(:@consumer, @consumer)
@@ -585,7 +585,7 @@ module Pod
       describe 'file pattern validation' do
         it 'checks for file patterns' do
           file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "wrong_paht.*",'))
-          validator = Validator.new(file, SourcesManager.master.map(&:url))
+          validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:build_pod)
           validator.stubs(:validate_url)
           validator.validate
@@ -595,7 +595,7 @@ module Pod
 
         it 'checks private_header_files matches only headers' do
           file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "JSONKit.*", "private_header_files": "JSONKit.m",'))
-          validator = Validator.new(file, SourcesManager.master.map(&:url))
+          validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:build_pod)
           validator.stubs(:validate_url)
           validator.validate
@@ -605,7 +605,7 @@ module Pod
 
         it 'checks public_header_files matches only headers' do
           file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "JSONKit.*", "public_header_files": "JSONKit.m",'))
-          validator = Validator.new(file, SourcesManager.master.map(&:url))
+          validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:build_pod)
           validator.stubs(:validate_url)
           validator.validate
@@ -615,7 +615,7 @@ module Pod
 
         it 'checks presence of license file' do
           file = write_podspec(stub_podspec(/.*license.*$/, '"license": "MIT",'))
-          validator = Validator.new(file, SourcesManager.master.map(&:url))
+          validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:build_pod)
           validator.stubs(:validate_url)
           validator.validate
@@ -625,7 +625,7 @@ module Pod
 
         it 'checks module_map must exist if specified' do
           file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "JSONKit.*", "module_map": "JSONKit.modulemap",'))
-          validator = Validator.new(file, SourcesManager.master.map(&:url))
+          validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:build_pod)
           validator.stubs(:validate_url)
           validator.validate
@@ -635,7 +635,7 @@ module Pod
 
         it 'checks module_map accepts only modulemaps' do
           file = write_podspec(stub_podspec(/.*source_files.*/, '"source_files": "JSONKit.*", "module_map": "JSONKit.m",'))
-          validator = Validator.new(file, SourcesManager.master.map(&:url))
+          validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:build_pod)
           validator.stubs(:validate_url)
           validator.validate
@@ -657,7 +657,7 @@ module Pod
         file = write_podspec(podspec, 'ZKit.podspec.json')
 
         spec = Specification.from_file(file)
-        validator = Validator.new(spec, SourcesManager.master.map(&:url))
+        validator = Validator.new(spec, config.sources_manager.master.map(&:url))
         validator.stubs(:validate_url)
         validator.stubs(:build_pod)
         validator.validate
@@ -667,7 +667,7 @@ module Pod
 
     describe 'frameworks' do
       before do
-        @validator = Validator.new(podspec_path, SourcesManager.master.map(&:url))
+        @validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
       end
 
       def setup_validator
@@ -715,7 +715,7 @@ module Pod
         file = write_podspec(podspec)
 
         Pod::Sandbox::FileAccessor.any_instance.stubs(:vendored_libraries).returns([fixture('empty.dylib')])
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.stubs(:build_pod)
         validator.stubs(:validate_url)
         validator.validate
@@ -734,7 +734,7 @@ module Pod
 
         Podfile::TargetDefinition.any_instance.stubs(:uses_frameworks?).returns(true)
         Pod::Sandbox::FileAccessor.any_instance.stubs(:source_files).returns([pathname])
-        validator = Validator.new(file, SourcesManager.master.map(&:url))
+        validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.stubs(:build_pod)
         validator.stubs(:validate_url)
         validator.validate


### PR DESCRIPTION
Depends upon https://github.com/CocoaPods/Core/pull/316.

- [x] CHANGELOG

This removes `Pod::SourcesManager` (a singleton) and uses the new `Source::Manager` class (the relevant tests now also live in Core). This branch of CocoaPods supports sharded specs repo directories, and as such fixes #5002.