### PR TITLE
[Generator::Plist] Ensure a CFBundleVersion is set for resource bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#5034](https://github.com/CocoaPods/CocoaPods/issues/5034)
 
-
-## 1.0.0.beta.7
-
 * Rely on `TARGET_BUILD_DIR` instead of `CONFIGURATION_BUILD_DIR` in the
   generated embed resources build phase's script, so that UI test targets can
   be run.  
   [seaders](https://github.com/seaders)
   [#5133](https://github.com/CocoaPods/CocoaPods/issues/5133)
+
 * Ensure that a `CFBundleVersion` is set for resource bundles' Info.plist
   files.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   be run.  
   [seaders](https://github.com/seaders)
   [#5133](https://github.com/CocoaPods/CocoaPods/issues/5133)
+* Ensure that a `CFBundleVersion` is set for resource bundles' Info.plist
+  files.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#4897](https://github.com/CocoaPods/CocoaPods/issues/4897)
 
 
 ## 1.0.0.beta.6 (2016-03-15)

--- a/lib/cocoapods/generator/info_plist_file.rb
+++ b/lib/cocoapods/generator/info_plist_file.rb
@@ -116,6 +116,7 @@ module Pod
         }
 
         info['CFBundleExecutable'] = '${EXECUTABLE_NAME}' if bundle_package_type != :bndl
+        info['CFBundleVersion'] = '1' if bundle_package_type == :bndl
         info['UIRequiredDeviceCapabilities'] = %w(arm64) if target.platform.name == :tvos
 
         info


### PR DESCRIPTION
Closes #4897.

I believe the integration spec failure here will act as sufficient test coverage for this.