### PR TITLE
[Validator] Add analyze build action to validator xcodebuild command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   will suggest the build configurations found in the user project.  
   [Samuel Giddins](https://github.com/segiddins)
   [CocoaPods#5113](https://github.com/CocoaPods/CocoaPods/issues/5113)
+* Add analyze build action to CocoaPods linter xcodebuild command
+  [Renzo Crisóstomo](https://github.com/Ruenzuo)
+  [#5127](https://github.com/CocoaPods/CocoaPods/pull/5127)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/lib.rb
+++ b/lib/cocoapods/command/lib.rb
@@ -127,6 +127,7 @@ module Pod
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
             ['--private', 'Lint skips checks that apply only to public specs'],
+            ['--analyze', 'Use analyze build action'],
           ].concat(super)
         end
 
@@ -140,6 +141,7 @@ module Pod
           @use_frameworks  = !argv.flag?('use-libraries')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
           @private         = argv.flag?('private', false)
+          @analyze         = argv.flag?('analyze', false)
           @podspecs_paths  = argv.arguments!
           super
         end
@@ -161,6 +163,7 @@ module Pod
             validator.only_subspec   = @only_subspec
             validator.use_frameworks = @use_frameworks
             validator.ignore_public_only_results = @private
+            validator.analyze        = @analyze
             validator.validate
 
             unless @clean

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -27,6 +27,7 @@ module Pod
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
             ['--private', 'Lint skips checks that apply only to public specs'],
+            ['--analyze', 'Use analyze build action'],
           ].concat(super)
         end
 
@@ -40,6 +41,7 @@ module Pod
           @use_frameworks  = !argv.flag?('use-libraries')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
           @private         = argv.flag?('private', false)
+          @analyze         = argv.flag?('analyze', false)
           @podspecs_paths  = argv.arguments!
           super
         end
@@ -57,6 +59,7 @@ module Pod
             validator.only_subspec   = @only_subspec
             validator.use_frameworks = @use_frameworks
             validator.ignore_public_only_results = @private
+            validator.analyze        = @analyze
             validator.validate
             failure_reasons << validator.failure_reason
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -196,6 +196,10 @@ module Pod
     #
     attr_accessor :ignore_public_only_results
 
+    # @return [Boolean] Whether the analyze build action will be added to xcodebuild command.
+    #
+    attr_accessor :analyze
+
     #-------------------------------------------------------------------------#
 
     # !@group Lint results
@@ -703,7 +707,9 @@ module Pod
     #         returns its output (both STDOUT and STDERR).
     #
     def xcodebuild
-      command = %w(clean build -workspace App.xcworkspace -scheme App -configuration Release)
+      command = %w(clean build)
+      command += %w(analyze) if analyze
+      command += %w(-workspace App.xcworkspace -scheme App -configuration Release)
       case consumer.platform_name
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)


### PR DESCRIPTION
This adds a new option to both `pod lib lint` and `pod spec lint` to optionally run xcodebuild analyze build action. Tests are missing, I wanted to check what do you guys think about this first.