### PR TITLE
 [CopyResourcesScript] Rely on TARGET_BUILD_DIR to locate destination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - sudo gem install bundler
-  - bundle install
-  - bundle exec pod repo update
 
 after_install:
   - ./bin/pod repo update --silent
+
+before_script:
+  - bundle exec pod repo update --silent
 
 script: bundle exec rake
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - sudo gem install bundler
+  - bundle install
+  - bundle exec pod repo update
 
 after_install:
   - ./bin/pod repo update --silent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * None.  
 
 
+## 1.0.0.beta.7
+
+* Rely on `TARGET_BUILD_DIR` instead of `CONFIGURATION_BUILD_DIR` in the
+  generated embed resources build phase's script, so that UI test targets can
+  be run.  
+  [seaders](https://github.com/seaders)
+  [#5133](https://github.com/CocoaPods/CocoaPods/issues/5133)
+
+
 ## 1.0.0.beta.6 (2016-03-15)
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
-
-## 1.0.0.beta.7
-
 * Rely on `TARGET_BUILD_DIR` instead of `CONFIGURATION_BUILD_DIR` in the
   generated embed resources build phase's script, so that UI test targets can
   be run.  

--- a/Rakefile
+++ b/Rakefile
@@ -273,8 +273,8 @@ begin
             when :ios
               # Specifically build against the simulator SDK so we don't have to deal with code signing.
               # Need to use the iPhone 6s, since this is the default simulator paired with a watch in Xcode 7.3
-              testCmd = (scheme_name.start_with? 'Test') ? 'test' : ''
-              execute_command "xcodebuild -workspace '#{workspace_path}' -scheme '#{scheme_name}' clean build #{testCmd} ONLY_ACTIVE_ARCH=NO -destination 'platform=iOS Simulator,name=iPhone 6s'"
+              test_flag = (scheme_name.start_with? 'Test') ? 'test' : ''
+              execute_command "xcodebuild -workspace '#{workspace_path}' -scheme '#{scheme_name}' clean build #{test_flag} ONLY_ACTIVE_ARCH=NO -destination 'platform=iOS Simulator,name=iPhone 6s'"
             else
               raise "Unknown platform #{platform}"
             end

--- a/Rakefile
+++ b/Rakefile
@@ -273,7 +273,8 @@ begin
             when :ios
               # Specifically build against the simulator SDK so we don't have to deal with code signing.
               # Need to use the iPhone 6s, since this is the default simulator paired with a watch in Xcode 7.3
-              execute_command "xcodebuild -workspace '#{workspace_path}' -scheme '#{scheme_name}' clean build ONLY_ACTIVE_ARCH=NO -destination 'platform=iOS Simulator,name=iPhone 6s'"
+              testCmd = (scheme_name.start_with? 'Test') ? 'test' : ''
+              execute_command "xcodebuild -workspace '#{workspace_path}' -scheme '#{scheme_name}' clean build #{testCmd} ONLY_ACTIVE_ARCH=NO -destination 'platform=iOS Simulator,name=iPhone 6s'"
             else
               raise "Unknown platform #{platform}"
             end

--- a/examples/TestInclusions/Examples.xcworkspace/contents.xcworkspacedata
+++ b/examples/TestInclusions/Examples.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:TestInclusions.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/TestInclusions/Podfile
+++ b/examples/TestInclusions/Podfile
@@ -1,0 +1,12 @@
+workspace 'Examples.xcworkspace'
+project 'TestInclusions.xcodeproj'
+platform :ios, '6.0'
+
+abstract_target 'TestInclusionsPods' do
+    pod 'SwrveConversationSDK', '~> 4.3.0'
+
+    target 'TestInclusions'
+    target 'TestInclusionsTests' do
+        pod 'OCHamcrest', '~> 5.0'
+    end
+end

--- a/examples/TestInclusions/Podfile
+++ b/examples/TestInclusions/Podfile
@@ -6,7 +6,5 @@ abstract_target 'TestInclusionsPods' do
     pod 'SwrveConversationSDK', '~> 4.3.0'
 
     target 'TestInclusions'
-    target 'TestInclusionsTests' do
-        pod 'OCHamcrest', '~> 5.0'
-    end
+    target 'TestInclusionsTests'
 end

--- a/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
+++ b/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
@@ -1,0 +1,558 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		37B9FD9242ABCD5EF2429AD3 /* libPods-TestInclusionsPods-TestInclusions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1338D7286D640DD7B4CDE77E /* libPods-TestInclusionsPods-TestInclusions.a */; };
+		F05861C1D573CA2007DC22EB /* libPods-TestInclusionsPods-TestInclusionsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAC96B84D7D0589A84BBA14E /* libPods-TestInclusionsPods-TestInclusionsTests.a */; };
+		F58833D41CBBC0C9007D4DA4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833D31CBBC0C9007D4DA4 /* main.m */; };
+		F58833D71CBBC0C9007D4DA4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833D61CBBC0C9007D4DA4 /* AppDelegate.m */; };
+		F58833DA1CBBC0C9007D4DA4 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833D91CBBC0C9007D4DA4 /* ViewController.m */; };
+		F58833DD1CBBC0C9007D4DA4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F58833DB1CBBC0C9007D4DA4 /* Main.storyboard */; };
+		F58833DF1CBBC0C9007D4DA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F58833DE1CBBC0C9007D4DA4 /* Assets.xcassets */; };
+		F58833E21CBBC0C9007D4DA4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F58833E01CBBC0C9007D4DA4 /* LaunchScreen.storyboard */; };
+		F58833ED1CBBC0C9007D4DA4 /* TestInclusionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833EC1CBBC0C9007D4DA4 /* TestInclusionsTests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F58833E91CBBC0C9007D4DA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F58833C71CBBC0C9007D4DA4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F58833CE1CBBC0C9007D4DA4;
+			remoteInfo = TestInclusions;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1338D7286D640DD7B4CDE77E /* libPods-TestInclusionsPods-TestInclusions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestInclusionsPods-TestInclusions.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		22EF61E62849B6EE93BAF427 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig"; sourceTree = "<group>"; };
+		952FD69DE7D27CE7A7B491CF /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A71BDA6E611418519196639C /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusions.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions.debug.xcconfig"; sourceTree = "<group>"; };
+		DAC96B84D7D0589A84BBA14E /* libPods-TestInclusionsPods-TestInclusionsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestInclusionsPods-TestInclusionsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6D4DC3B826CB3DA5AC257D5 /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusions.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions.release.xcconfig"; sourceTree = "<group>"; };
+		F58833CF1CBBC0C9007D4DA4 /* TestInclusions.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestInclusions.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F58833D31CBBC0C9007D4DA4 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F58833D51CBBC0C9007D4DA4 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		F58833D61CBBC0C9007D4DA4 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		F58833D81CBBC0C9007D4DA4 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		F58833D91CBBC0C9007D4DA4 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		F58833DC1CBBC0C9007D4DA4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		F58833DE1CBBC0C9007D4DA4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F58833E11CBBC0C9007D4DA4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		F58833E31CBBC0C9007D4DA4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F58833E81CBBC0C9007D4DA4 /* TestInclusionsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestInclusionsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F58833EC1CBBC0C9007D4DA4 /* TestInclusionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestInclusionsTests.m; sourceTree = "<group>"; };
+		F58833EE1CBBC0C9007D4DA4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F58833CC1CBBC0C9007D4DA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37B9FD9242ABCD5EF2429AD3 /* libPods-TestInclusionsPods-TestInclusions.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F58833E51CBBC0C9007D4DA4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F05861C1D573CA2007DC22EB /* libPods-TestInclusionsPods-TestInclusionsTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9308296ED858B5912A81C81E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1338D7286D640DD7B4CDE77E /* libPods-TestInclusionsPods-TestInclusions.a */,
+				DAC96B84D7D0589A84BBA14E /* libPods-TestInclusionsPods-TestInclusionsTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DCB1D99C2AA4B59E1512F73F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A71BDA6E611418519196639C /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */,
+				E6D4DC3B826CB3DA5AC257D5 /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */,
+				952FD69DE7D27CE7A7B491CF /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */,
+				22EF61E62849B6EE93BAF427 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		F58833C61CBBC0C9007D4DA4 = {
+			isa = PBXGroup;
+			children = (
+				F58833D11CBBC0C9007D4DA4 /* TestInclusions */,
+				F58833EB1CBBC0C9007D4DA4 /* TestInclusionsTests */,
+				F58833D01CBBC0C9007D4DA4 /* Products */,
+				DCB1D99C2AA4B59E1512F73F /* Pods */,
+				9308296ED858B5912A81C81E /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		F58833D01CBBC0C9007D4DA4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F58833CF1CBBC0C9007D4DA4 /* TestInclusions.app */,
+				F58833E81CBBC0C9007D4DA4 /* TestInclusionsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F58833D11CBBC0C9007D4DA4 /* TestInclusions */ = {
+			isa = PBXGroup;
+			children = (
+				F58833D51CBBC0C9007D4DA4 /* AppDelegate.h */,
+				F58833D61CBBC0C9007D4DA4 /* AppDelegate.m */,
+				F58833D81CBBC0C9007D4DA4 /* ViewController.h */,
+				F58833D91CBBC0C9007D4DA4 /* ViewController.m */,
+				F58833DB1CBBC0C9007D4DA4 /* Main.storyboard */,
+				F58833DE1CBBC0C9007D4DA4 /* Assets.xcassets */,
+				F58833E01CBBC0C9007D4DA4 /* LaunchScreen.storyboard */,
+				F58833E31CBBC0C9007D4DA4 /* Info.plist */,
+				F58833D21CBBC0C9007D4DA4 /* Supporting Files */,
+			);
+			path = TestInclusions;
+			sourceTree = "<group>";
+		};
+		F58833D21CBBC0C9007D4DA4 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				F58833D31CBBC0C9007D4DA4 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		F58833EB1CBBC0C9007D4DA4 /* TestInclusionsTests */ = {
+			isa = PBXGroup;
+			children = (
+				F58833EC1CBBC0C9007D4DA4 /* TestInclusionsTests.m */,
+				F58833EE1CBBC0C9007D4DA4 /* Info.plist */,
+			);
+			path = TestInclusionsTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F58833CE1CBBC0C9007D4DA4 /* TestInclusions */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F58833F11CBBC0C9007D4DA4 /* Build configuration list for PBXNativeTarget "TestInclusions" */;
+			buildPhases = (
+				18770D25CD70A1B4F077C1A3 /* 📦 Check Pods Manifest.lock */,
+				F58833CB1CBBC0C9007D4DA4 /* Sources */,
+				F58833CC1CBBC0C9007D4DA4 /* Frameworks */,
+				F58833CD1CBBC0C9007D4DA4 /* Resources */,
+				2D7DA37C114DD6E56D290D94 /* 📦 Embed Pods Frameworks */,
+				BEB56E0CAF877FA9577BF299 /* 📦 Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestInclusions;
+			productName = TestInclusions;
+			productReference = F58833CF1CBBC0C9007D4DA4 /* TestInclusions.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F58833E71CBBC0C9007D4DA4 /* TestInclusionsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F58833F41CBBC0C9007D4DA4 /* Build configuration list for PBXNativeTarget "TestInclusionsTests" */;
+			buildPhases = (
+				FF15824F61254F4257FD78E7 /* 📦 Check Pods Manifest.lock */,
+				F58833E41CBBC0C9007D4DA4 /* Sources */,
+				F58833E51CBBC0C9007D4DA4 /* Frameworks */,
+				F58833E61CBBC0C9007D4DA4 /* Resources */,
+				6D3C9E5647F2F9BE1B8CA805 /* 📦 Embed Pods Frameworks */,
+				23FBFF6CF467540E5F102610 /* 📦 Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F58833EA1CBBC0C9007D4DA4 /* PBXTargetDependency */,
+			);
+			name = TestInclusionsTests;
+			productName = TestInclusionsTests;
+			productReference = F58833E81CBBC0C9007D4DA4 /* TestInclusionsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F58833C71CBBC0C9007D4DA4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = Swrve;
+				TargetAttributes = {
+					F58833CE1CBBC0C9007D4DA4 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					F58833E71CBBC0C9007D4DA4 = {
+						CreatedOnToolsVersion = 7.3;
+						TestTargetID = F58833CE1CBBC0C9007D4DA4;
+					};
+				};
+			};
+			buildConfigurationList = F58833CA1CBBC0C9007D4DA4 /* Build configuration list for PBXProject "TestInclusions" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F58833C61CBBC0C9007D4DA4;
+			productRefGroup = F58833D01CBBC0C9007D4DA4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F58833CE1CBBC0C9007D4DA4 /* TestInclusions */,
+				F58833E71CBBC0C9007D4DA4 /* TestInclusionsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F58833CD1CBBC0C9007D4DA4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F58833E21CBBC0C9007D4DA4 /* LaunchScreen.storyboard in Resources */,
+				F58833DF1CBBC0C9007D4DA4 /* Assets.xcassets in Resources */,
+				F58833DD1CBBC0C9007D4DA4 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F58833E61CBBC0C9007D4DA4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		18770D25CD70A1B4F077C1A3 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		23FBFF6CF467540E5F102610 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2D7DA37C114DD6E56D290D94 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6D3C9E5647F2F9BE1B8CA805 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BEB56E0CAF877FA9577BF299 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FF15824F61254F4257FD78E7 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F58833CB1CBBC0C9007D4DA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F58833DA1CBBC0C9007D4DA4 /* ViewController.m in Sources */,
+				F58833D71CBBC0C9007D4DA4 /* AppDelegate.m in Sources */,
+				F58833D41CBBC0C9007D4DA4 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F58833E41CBBC0C9007D4DA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F58833ED1CBBC0C9007D4DA4 /* TestInclusionsTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F58833EA1CBBC0C9007D4DA4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F58833CE1CBBC0C9007D4DA4 /* TestInclusions */;
+			targetProxy = F58833E91CBBC0C9007D4DA4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		F58833DB1CBBC0C9007D4DA4 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F58833DC1CBBC0C9007D4DA4 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		F58833E01CBBC0C9007D4DA4 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F58833E11CBBC0C9007D4DA4 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		F58833EF1CBBC0C9007D4DA4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F58833F01CBBC0C9007D4DA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F58833F21CBBC0C9007D4DA4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A71BDA6E611418519196639C /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = TestInclusions/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.swrve.TestInclusions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		F58833F31CBBC0C9007D4DA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E6D4DC3B826CB3DA5AC257D5 /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = TestInclusions/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.swrve.TestInclusions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		F58833F51CBBC0C9007D4DA4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 952FD69DE7D27CE7A7B491CF /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = TestInclusionsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.swrve.TestInclusionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestInclusions.app/TestInclusions";
+			};
+			name = Debug;
+		};
+		F58833F61CBBC0C9007D4DA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 22EF61E62849B6EE93BAF427 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = TestInclusionsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.swrve.TestInclusionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestInclusions.app/TestInclusions";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F58833CA1CBBC0C9007D4DA4 /* Build configuration list for PBXProject "TestInclusions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F58833EF1CBBC0C9007D4DA4 /* Debug */,
+				F58833F01CBBC0C9007D4DA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F58833F11CBBC0C9007D4DA4 /* Build configuration list for PBXNativeTarget "TestInclusions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F58833F21CBBC0C9007D4DA4 /* Debug */,
+				F58833F31CBBC0C9007D4DA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F58833F41CBBC0C9007D4DA4 /* Build configuration list for PBXNativeTarget "TestInclusionsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F58833F51CBBC0C9007D4DA4 /* Debug */,
+				F58833F61CBBC0C9007D4DA4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F58833C71CBBC0C9007D4DA4 /* Project object */;
+}

--- a/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
+++ b/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		37B9FD9242ABCD5EF2429AD3 /* libPods-TestInclusionsPods-TestInclusions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1338D7286D640DD7B4CDE77E /* libPods-TestInclusionsPods-TestInclusions.a */; };
-		F05861C1D573CA2007DC22EB /* libPods-TestInclusionsPods-TestInclusionsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAC96B84D7D0589A84BBA14E /* libPods-TestInclusionsPods-TestInclusionsTests.a */; };
+		2C7534FA0DF918F71CBB014D /* libPods-TestInclusionsPods-TestInclusionsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A07B12B5DB8260B6A622B86 /* libPods-TestInclusionsPods-TestInclusionsTests.a */; };
+		9C7597451EA874755FC00370 /* libPods-TestInclusionsPods-TestInclusions.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC574385012724E61AA86C91 /* libPods-TestInclusionsPods-TestInclusions.a */; };
 		F58833D41CBBC0C9007D4DA4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833D31CBBC0C9007D4DA4 /* main.m */; };
 		F58833D71CBBC0C9007D4DA4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833D61CBBC0C9007D4DA4 /* AppDelegate.m */; };
 		F58833DA1CBBC0C9007D4DA4 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F58833D91CBBC0C9007D4DA4 /* ViewController.m */; };
@@ -29,12 +29,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1338D7286D640DD7B4CDE77E /* libPods-TestInclusionsPods-TestInclusions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestInclusionsPods-TestInclusions.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		22EF61E62849B6EE93BAF427 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig"; sourceTree = "<group>"; };
-		952FD69DE7D27CE7A7B491CF /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig"; sourceTree = "<group>"; };
-		A71BDA6E611418519196639C /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusions.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions.debug.xcconfig"; sourceTree = "<group>"; };
-		DAC96B84D7D0589A84BBA14E /* libPods-TestInclusionsPods-TestInclusionsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestInclusionsPods-TestInclusionsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E6D4DC3B826CB3DA5AC257D5 /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusions.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions.release.xcconfig"; sourceTree = "<group>"; };
+		1FCF8BAEE357AA92F190B2B4 /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		608A450DCBC2FE115679CA41 /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusions.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions.debug.xcconfig"; sourceTree = "<group>"; };
+		6A07B12B5DB8260B6A622B86 /* libPods-TestInclusionsPods-TestInclusionsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestInclusionsPods-TestInclusionsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB3F583724B0611C9FF1D90A /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusions.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions.release.xcconfig"; sourceTree = "<group>"; };
+		D8D5B29CD27C0B3126780CA0 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig"; sourceTree = "<group>"; };
+		EC574385012724E61AA86C91 /* libPods-TestInclusionsPods-TestInclusions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestInclusionsPods-TestInclusions.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F58833CF1CBBC0C9007D4DA4 /* TestInclusions.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestInclusions.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F58833D31CBBC0C9007D4DA4 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F58833D51CBBC0C9007D4DA4 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37B9FD9242ABCD5EF2429AD3 /* libPods-TestInclusionsPods-TestInclusions.a in Frameworks */,
+				9C7597451EA874755FC00370 /* libPods-TestInclusionsPods-TestInclusions.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,31 +63,31 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F05861C1D573CA2007DC22EB /* libPods-TestInclusionsPods-TestInclusionsTests.a in Frameworks */,
+				2C7534FA0DF918F71CBB014D /* libPods-TestInclusionsPods-TestInclusionsTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		9308296ED858B5912A81C81E /* Frameworks */ = {
+		63A7217266BF3E279E57CA71 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				1338D7286D640DD7B4CDE77E /* libPods-TestInclusionsPods-TestInclusions.a */,
-				DAC96B84D7D0589A84BBA14E /* libPods-TestInclusionsPods-TestInclusionsTests.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		DCB1D99C2AA4B59E1512F73F /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				A71BDA6E611418519196639C /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */,
-				E6D4DC3B826CB3DA5AC257D5 /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */,
-				952FD69DE7D27CE7A7B491CF /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */,
-				22EF61E62849B6EE93BAF427 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */,
+				608A450DCBC2FE115679CA41 /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */,
+				BB3F583724B0611C9FF1D90A /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */,
+				1FCF8BAEE357AA92F190B2B4 /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */,
+				D8D5B29CD27C0B3126780CA0 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		C1232D40125B8536BD98182B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EC574385012724E61AA86C91 /* libPods-TestInclusionsPods-TestInclusions.a */,
+				6A07B12B5DB8260B6A622B86 /* libPods-TestInclusionsPods-TestInclusionsTests.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		F58833C61CBBC0C9007D4DA4 = {
@@ -96,8 +96,8 @@
 				F58833D11CBBC0C9007D4DA4 /* TestInclusions */,
 				F58833EB1CBBC0C9007D4DA4 /* TestInclusionsTests */,
 				F58833D01CBBC0C9007D4DA4 /* Products */,
-				DCB1D99C2AA4B59E1512F73F /* Pods */,
-				9308296ED858B5912A81C81E /* Frameworks */,
+				63A7217266BF3E279E57CA71 /* Pods */,
+				C1232D40125B8536BD98182B /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -472,7 +472,7 @@
 		};
 		F58833F21CBBC0C9007D4DA4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A71BDA6E611418519196639C /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */;
+			baseConfigurationReference = 608A450DCBC2FE115679CA41 /* Pods-TestInclusionsPods-TestInclusions.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = TestInclusions/Info.plist;
@@ -485,7 +485,7 @@
 		};
 		F58833F31CBBC0C9007D4DA4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E6D4DC3B826CB3DA5AC257D5 /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */;
+			baseConfigurationReference = BB3F583724B0611C9FF1D90A /* Pods-TestInclusionsPods-TestInclusions.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = TestInclusions/Info.plist;
@@ -498,7 +498,7 @@
 		};
 		F58833F51CBBC0C9007D4DA4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 952FD69DE7D27CE7A7B491CF /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */;
+			baseConfigurationReference = 1FCF8BAEE357AA92F190B2B4 /* Pods-TestInclusionsPods-TestInclusionsTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = TestInclusionsTests/Info.plist;
@@ -511,7 +511,7 @@
 		};
 		F58833F61CBBC0C9007D4DA4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 22EF61E62849B6EE93BAF427 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */;
+			baseConfigurationReference = D8D5B29CD27C0B3126780CA0 /* Pods-TestInclusionsPods-TestInclusionsTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = TestInclusionsTests/Info.plist;

--- a/examples/TestInclusions/TestInclusions.xcodeproj/xcshareddata/xcschemes/TestInclusions.xcscheme
+++ b/examples/TestInclusions/TestInclusions.xcodeproj/xcshareddata/xcschemes/TestInclusions.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F58833CE1CBBC0C9007D4DA4"
+               BuildableName = "TestInclusions.app"
+               BlueprintName = "TestInclusions"
+               ReferencedContainer = "container:TestInclusions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F58833E71CBBC0C9007D4DA4"
+               BuildableName = "TestInclusionsTests.xctest"
+               BlueprintName = "TestInclusionsTests"
+               ReferencedContainer = "container:TestInclusions.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F58833CE1CBBC0C9007D4DA4"
+            BuildableName = "TestInclusions.app"
+            BlueprintName = "TestInclusions"
+            ReferencedContainer = "container:TestInclusions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F58833CE1CBBC0C9007D4DA4"
+            BuildableName = "TestInclusions.app"
+            BlueprintName = "TestInclusions"
+            ReferencedContainer = "container:TestInclusions.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F58833CE1CBBC0C9007D4DA4"
+            BuildableName = "TestInclusions.app"
+            BlueprintName = "TestInclusions"
+            ReferencedContainer = "container:TestInclusions.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/TestInclusions/TestInclusions/AppDelegate.h
+++ b/examples/TestInclusions/TestInclusions/AppDelegate.h
@@ -1,0 +1,34 @@
+//
+//  AppDelegate.h
+//  TestInclusionsTests
+//
+//  Created by seaders on 11/04/2016.
+//  Copyright (c) 2016 Swrve https://www.swrve.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/examples/TestInclusions/TestInclusions/AppDelegate.m
+++ b/examples/TestInclusions/TestInclusions/AppDelegate.m
@@ -1,0 +1,62 @@
+//
+//  AppDelegate.m
+//  TestInclusionsTests
+//
+//  Created by seaders on 11/04/2016.
+//  Copyright (c) 2016 Swrve https://www.swrve.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/examples/TestInclusions/TestInclusions/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/TestInclusions/TestInclusions/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/TestInclusions/TestInclusions/Base.lproj/LaunchScreen.storyboard
+++ b/examples/TestInclusions/TestInclusions/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/TestInclusions/TestInclusions/Base.lproj/Main.storyboard
+++ b/examples/TestInclusions/TestInclusions/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/TestInclusions/TestInclusions/Info.plist
+++ b/examples/TestInclusions/TestInclusions/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/TestInclusions/TestInclusions/ViewController.h
+++ b/examples/TestInclusions/TestInclusions/ViewController.h
@@ -1,0 +1,32 @@
+//
+//  ViewController.h
+//  TestInclusionsTests
+//
+//  Created by seaders on 11/04/2016.
+//  Copyright (c) 2016 Swrve https://www.swrve.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/examples/TestInclusions/TestInclusions/ViewController.m
+++ b/examples/TestInclusions/TestInclusions/ViewController.m
@@ -1,0 +1,44 @@
+//
+//  ViewController.m
+//  TestInclusionsTests
+//
+//  Created by seaders on 11/04/2016.
+//  Copyright (c) 2016 Swrve https://www.swrve.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/examples/TestInclusions/TestInclusions/main.m
+++ b/examples/TestInclusions/TestInclusions/main.m
@@ -1,0 +1,33 @@
+//
+//  main.m
+//  TestInclusionsTests
+//
+//  Created by seaders on 11/04/2016.
+//  Copyright (c) 2016 Swrve https://www.swrve.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/examples/TestInclusions/TestInclusionsTests/Info.plist
+++ b/examples/TestInclusions/TestInclusionsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/examples/TestInclusions/TestInclusionsTests/TestInclusionsTests.m
+++ b/examples/TestInclusions/TestInclusionsTests/TestInclusionsTests.m
@@ -25,7 +25,6 @@
 
 
 #import <XCTest/XCTest.h>
-#import <OCHamcrest/OCHamcrest.h>
 
 @interface TestInclusionsTests : XCTestCase
 
@@ -49,7 +48,7 @@
     @catch (NSException *exception) {
         NSLog(@"Unable to load SwrveConversation storyboard. %@", exception);
     }
-    assertThat(storyboard, notNilValue());
+    XCTAssertNotNil(storyboard);
 }
 
 @end

--- a/examples/TestInclusions/TestInclusionsTests/TestInclusionsTests.m
+++ b/examples/TestInclusions/TestInclusionsTests/TestInclusionsTests.m
@@ -1,0 +1,55 @@
+//
+//  TestInclusionsTests.m
+//  TestInclusionsTests
+//
+//  Created by seaders on 11/04/2016.
+//  Copyright (c) 2016 Swrve https://www.swrve.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import <XCTest/XCTest.h>
+#import <OCHamcrest/OCHamcrest.h>
+
+@interface TestInclusionsTests : XCTestCase
+
+@end
+
+@implementation TestInclusionsTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testStoryboardInclusion {
+    UIStoryboard* storyboard = nil;
+    @try {
+         storyboard = [UIStoryboard storyboardWithName:@"SwrveConversation" bundle:[NSBundle bundleForClass:self.class]];
+    }
+    @catch (NSException *exception) {
+        NSLog(@"Unable to load SwrveConversation storyboard. %@", exception);
+    }
+    assertThat(storyboard, notNilValue());
+}
+
+@end

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -97,7 +97,7 @@ module Pod
 #!/bin/sh
 set -e
 
-mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+mkdir -p "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
 RESOURCES_TO_COPY=${PODS_ROOT}/resources-to-copy-${TARGETNAME}.txt
 > "$RESOURCES_TO_COPY"
@@ -140,30 +140,30 @@ EOM
   fi
   case $RESOURCE_PATH in
     *\.storyboard)
-      echo "ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .storyboard`.storyboardc $RESOURCE_PATH --sdk ${SDKROOT} ${TARGET_DEVICE_ARGS}"
-      ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .storyboard`.storyboardc" "$RESOURCE_PATH" --sdk "${SDKROOT}" ${TARGET_DEVICE_ARGS}
+      echo "ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .storyboard`.storyboardc $RESOURCE_PATH --sdk ${SDKROOT} ${TARGET_DEVICE_ARGS}"
+      ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .storyboard`.storyboardc" "$RESOURCE_PATH" --sdk "${SDKROOT}" ${TARGET_DEVICE_ARGS}
       ;;
     *\.xib)
-      echo "ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .xib`.nib $RESOURCE_PATH --sdk ${SDKROOT}"
-      ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .xib`.nib" "$RESOURCE_PATH" --sdk "${SDKROOT}"
+      echo "ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .xib`.nib $RESOURCE_PATH --sdk ${SDKROOT}"
+      ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target ${!DEPLOYMENT_TARGET_SETTING_NAME} --output-format human-readable-text --compile "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename \\"$RESOURCE_PATH\\" .xib`.nib" "$RESOURCE_PATH" --sdk "${SDKROOT}"
       ;;
     *.framework)
-      echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-      mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-      echo "rsync -av $RESOURCE_PATH ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-      rsync -av "$RESOURCE_PATH" "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+      echo "mkdir -p ${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+      mkdir -p "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+      echo "rsync -av $RESOURCE_PATH ${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+      rsync -av "$RESOURCE_PATH" "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
       ;;
     *.xcdatamodel)
-      echo "xcrun momc \\"$RESOURCE_PATH\\" \\"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH"`.mom\\""
-      xcrun momc "$RESOURCE_PATH" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcdatamodel`.mom"
+      echo "xcrun momc \\"$RESOURCE_PATH\\" \\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH"`.mom\\""
+      xcrun momc "$RESOURCE_PATH" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcdatamodel`.mom"
       ;;
     *.xcdatamodeld)
-      echo "xcrun momc \\"$RESOURCE_PATH\\" \\"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcdatamodeld`.momd\\""
-      xcrun momc "$RESOURCE_PATH" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcdatamodeld`.momd"
+      echo "xcrun momc \\"$RESOURCE_PATH\\" \\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcdatamodeld`.momd\\""
+      xcrun momc "$RESOURCE_PATH" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcdatamodeld`.momd"
       ;;
     *.xcmappingmodel)
-      echo "xcrun mapc \\"$RESOURCE_PATH\\" \\"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcmappingmodel`.cdm\\""
-      xcrun mapc "$RESOURCE_PATH" "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcmappingmodel`.cdm"
+      echo "xcrun mapc \\"$RESOURCE_PATH\\" \\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcmappingmodel`.cdm\\""
+      xcrun mapc "$RESOURCE_PATH" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcmappingmodel`.cdm"
       ;;
     *.xcassets)
       ABSOLUTE_XCASSET_FILE=$(realpath "$RESOURCE_PATH")
@@ -179,8 +179,8 @@ EOS
 
       RSYNC_CALL = <<EOS
 
-mkdir -p "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
-rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+mkdir -p "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 if [[ "${ACTION}" == "install" ]] && [[ "${SKIP_INSTALL}" == "NO" ]]; then
   mkdir -p "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   rsync -avr --copy-links --no-relative --exclude '*/.svn/*' --files-from="$RESOURCES_TO_COPY" / "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/CocoaPods/issues/5133.  It seems the new destination for Unit Tests in XCode 7.3 has changed, and resources like storyboards need to come from `DESTINATION/Plugins/UnitTests.xctest`.  Without the change to TARGET_BUILD_DIR, resources get built to just `DESTINATION` and the tests can't find the resources at runtime.