### PR TITLE
Sort Dir.glob result in PathList case insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Sort files from Dir.glob explicitly to produce same result on case sensitive
+  file system as result on case insensitive file system.  
+  [Soutaro Matsumoto](https://github.com/soutaro)
 
 
 ## 1.0.0.beta.6 (2016-03-15)

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -49,7 +49,7 @@ module Pod
         end
         root_length  = root.to_s.length + 1
         escaped_root = escape_path_for_glob(root)
-        paths = Dir.glob(escaped_root + '**/*', File::FNM_DOTMATCH)
+        paths = Dir.glob(escaped_root + '**/*', File::FNM_DOTMATCH).sort_by(&:upcase)
         absolute_dirs  = paths.select { |path| File.directory?(path) }
         relative_dirs  = absolute_dirs.map  { |p| p[root_length..-1] }
         absolute_paths = paths.reject { |p| p == "#{root}/." || p == "#{root}/.." }

--- a/spec/unit/sandbox/path_list_spec.rb
+++ b/spec/unit/sandbox/path_list_spec.rb
@@ -166,6 +166,20 @@ module Pod
       end
     end
 
+    describe 'Reading file system' do
+      it 'orders paths case insensitively' do
+        root = fixture('banana-lib')
+
+        # Let Dir.glob result be ordered case-sensitively
+        Dir.stubs(:glob).returns(["#{root}/Classes/NSFetchRequest+Banana.h",
+                                  "#{root}/Classes/NSFetchedResultsController+Banana.h"])
+        File.stubs(:directory?).returns(false)
+
+        path_list = Sandbox::PathList.new(fixture('banana-lib'))
+        path_list.files.should == %w(Classes/NSFetchedResultsController+Banana.h Classes/NSFetchRequest+Banana.h)
+      end
+    end
+
     #-------------------------------------------------------------------------#
 
     describe 'Private Helpers' do


### PR DESCRIPTION
`Dir.glob` result on case sensitive file system may be different from the result on case insensitive file system. This would cause unintentional diffs on `-umbrella.h` files depending on the config of file system in which `pod install` is done, when `Pods` directory is in the repository.

1. `pod install` on case insensitive file system → files are sorted case insensitively
2. `git commit && git push`
3. `pod install` on case sensitive file system → files are sorted case sensitively
4. Diffs may appear on `-umbrella.h` files

This pull request is to fix this issue by sorting `Dir.glob` result explicitly.