### PR TITLE
Fix non-modular header errors for vendored frameworks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Headers from vendored frameworks no longer end up in the HEADER_SEARCH_PATH when 
+  using frameworks. They are assumed to be already present as modular headers in the
+  framework itself.  
+  [Mark Spanbroek](https://github.com/markspanbroek)
+  [#5146](https://github.com/CocoaPods/CocoaPods/pull/5146)
 
 ## 1.0.0.beta.7 (2016-04-15)
 

--- a/examples/Vendored Framework Example/Example Pods/VendoredFrameworkExample.podspec
+++ b/examples/Vendored Framework Example/Example Pods/VendoredFrameworkExample.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name                    = "VendoredFrameworkExample"
+  s.version                 = "0.0.1"
+  s.summary                 = "Vendored Framework in a spec test pod."
+  s.description             = "This spec specifies a vendored framework."
+
+  s.ios.deployment_target   = '8.0'
+  s.homepage                = "https://cocoapods.org"
+  s.license                 = { :type => "MIT", :file => "../../../../LICENSE" }
+  s.author                  = "Mark Spanbroek"
+  s.source                  = { :http => "https://github.com/AFNetworking/AFNetworking/releases/download/3.1.0/AFNetworking.framework.zip" }
+  s.ios.vendored_frameworks = "**/iOS/AFNetworking.framework"
+end
+

--- a/examples/Vendored Framework Example/Examples.xcworkspace/contents.xcworkspacedata
+++ b/examples/Vendored Framework Example/Examples.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Vendored Framework Example.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/Vendored Framework Example/Podfile
+++ b/examples/Vendored Framework Example/Podfile
@@ -1,0 +1,10 @@
+platform :ios, '8.0'
+use_frameworks!
+
+workspace 'Examples.xcworkspace'
+project 'Vendored Framework Example.xcodeproj'
+
+target 'Vendored Framework Example' do
+  pod 'VendoredFrameworkExample', :podspec =>  'Example Pods/VendoredFrameworkExample.podspec'
+end
+

--- a/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/project.pbxproj
+++ b/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/project.pbxproj
@@ -1,0 +1,373 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2E0EE21DE208AA3DACDEE54C /* Pods_Vendored_Framework_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96EFE8B18DE5C33B7F9ADC2A /* Pods_Vendored_Framework_Example.framework */; };
+		5CAF4FEC1CC1125900B44520 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF4FEB1CC1125900B44520 /* AppDelegate.swift */; };
+		5CAF4FEE1CC1125900B44520 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF4FED1CC1125900B44520 /* ViewController.swift */; };
+		5CAF4FF11CC1125900B44520 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5CAF4FEF1CC1125900B44520 /* Main.storyboard */; };
+		5CAF4FF31CC1125900B44520 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5CAF4FF21CC1125900B44520 /* Assets.xcassets */; };
+		5CAF4FF61CC1125900B44520 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5CAF4FF41CC1125900B44520 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		57D9D0A9E402C4C20EF1132A /* Pods-Vendored Framework Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vendored Framework Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example.release.xcconfig"; sourceTree = "<group>"; };
+		5CAF4FE81CC1125900B44520 /* Vendored Framework Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Vendored Framework Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CAF4FEB1CC1125900B44520 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		5CAF4FED1CC1125900B44520 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		5CAF4FF01CC1125900B44520 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		5CAF4FF21CC1125900B44520 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5CAF4FF51CC1125900B44520 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		5CAF4FF71CC1125900B44520 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		96EFE8B18DE5C33B7F9ADC2A /* Pods_Vendored_Framework_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Vendored_Framework_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A8A706EB2A5031760E4C935B /* Pods-Vendored Framework Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vendored Framework Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5CAF4FE51CC1125900B44520 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2E0EE21DE208AA3DACDEE54C /* Pods_Vendored_Framework_Example.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2FA61ADC940DF1417005AC4E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A8A706EB2A5031760E4C935B /* Pods-Vendored Framework Example.debug.xcconfig */,
+				57D9D0A9E402C4C20EF1132A /* Pods-Vendored Framework Example.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4DB9B2875EE9F40EE36D9317 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				96EFE8B18DE5C33B7F9ADC2A /* Pods_Vendored_Framework_Example.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5CAF4FDF1CC1125900B44520 = {
+			isa = PBXGroup;
+			children = (
+				5CAF4FEA1CC1125900B44520 /* Vendored Framework Example */,
+				5CAF4FE91CC1125900B44520 /* Products */,
+				2FA61ADC940DF1417005AC4E /* Pods */,
+				4DB9B2875EE9F40EE36D9317 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		5CAF4FE91CC1125900B44520 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5CAF4FE81CC1125900B44520 /* Vendored Framework Example.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5CAF4FEA1CC1125900B44520 /* Vendored Framework Example */ = {
+			isa = PBXGroup;
+			children = (
+				5CAF4FEB1CC1125900B44520 /* AppDelegate.swift */,
+				5CAF4FED1CC1125900B44520 /* ViewController.swift */,
+				5CAF4FEF1CC1125900B44520 /* Main.storyboard */,
+				5CAF4FF21CC1125900B44520 /* Assets.xcassets */,
+				5CAF4FF41CC1125900B44520 /* LaunchScreen.storyboard */,
+				5CAF4FF71CC1125900B44520 /* Info.plist */,
+			);
+			path = "Vendored Framework Example";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5CAF4FE71CC1125900B44520 /* Vendored Framework Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5CAF4FFA1CC1125900B44520 /* Build configuration list for PBXNativeTarget "Vendored Framework Example" */;
+			buildPhases = (
+				25E42247833F1966ABF463BE /* 📦 Check Pods Manifest.lock */,
+				5CAF4FE41CC1125900B44520 /* Sources */,
+				5CAF4FE51CC1125900B44520 /* Frameworks */,
+				5CAF4FE61CC1125900B44520 /* Resources */,
+				4697BF2DD055B93C3DE0E375 /* 📦 Embed Pods Frameworks */,
+				9C2933733E94154FB1F30218 /* 📦 Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Vendored Framework Example";
+			productName = "Vendored Framework Example";
+			productReference = 5CAF4FE81CC1125900B44520 /* Vendored Framework Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5CAF4FE01CC1125900B44520 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = CocoaPods;
+				TargetAttributes = {
+					5CAF4FE71CC1125900B44520 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 5CAF4FE31CC1125900B44520 /* Build configuration list for PBXProject "Vendored Framework Example" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5CAF4FDF1CC1125900B44520;
+			productRefGroup = 5CAF4FE91CC1125900B44520 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5CAF4FE71CC1125900B44520 /* Vendored Framework Example */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5CAF4FE61CC1125900B44520 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CAF4FF61CC1125900B44520 /* LaunchScreen.storyboard in Resources */,
+				5CAF4FF31CC1125900B44520 /* Assets.xcassets in Resources */,
+				5CAF4FF11CC1125900B44520 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		25E42247833F1966ABF463BE /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		4697BF2DD055B93C3DE0E375 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9C2933733E94154FB1F30218 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5CAF4FE41CC1125900B44520 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CAF4FEE1CC1125900B44520 /* ViewController.swift in Sources */,
+				5CAF4FEC1CC1125900B44520 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		5CAF4FEF1CC1125900B44520 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5CAF4FF01CC1125900B44520 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		5CAF4FF41CC1125900B44520 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5CAF4FF51CC1125900B44520 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		5CAF4FF81CC1125900B44520 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5CAF4FF91CC1125900B44520 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5CAF4FFB1CC1125900B44520 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A8A706EB2A5031760E4C935B /* Pods-Vendored Framework Example.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "Vendored Framework Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.Vendored-Framework-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		5CAF4FFC1CC1125900B44520 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 57D9D0A9E402C4C20EF1132A /* Pods-Vendored Framework Example.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "Vendored Framework Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.Vendored-Framework-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5CAF4FE31CC1125900B44520 /* Build configuration list for PBXProject "Vendored Framework Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CAF4FF81CC1125900B44520 /* Debug */,
+				5CAF4FF91CC1125900B44520 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5CAF4FFA1CC1125900B44520 /* Build configuration list for PBXNativeTarget "Vendored Framework Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5CAF4FFB1CC1125900B44520 /* Debug */,
+				5CAF4FFC1CC1125900B44520 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5CAF4FE01CC1125900B44520 /* Project object */;
+}

--- a/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/xcshareddata/xcschemes/Vendored Framework Example.xcscheme
+++ b/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/xcshareddata/xcschemes/Vendored Framework Example.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CAF4FE71CC1125900B44520"
+               BuildableName = "Vendored Framework Example.app"
+               BlueprintName = "Vendored Framework Example"
+               ReferencedContainer = "container:Vendored Framework Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CAF4FE71CC1125900B44520"
+            BuildableName = "Vendored Framework Example.app"
+            BlueprintName = "Vendored Framework Example"
+            ReferencedContainer = "container:Vendored Framework Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CAF4FE71CC1125900B44520"
+            BuildableName = "Vendored Framework Example.app"
+            BlueprintName = "Vendored Framework Example"
+            ReferencedContainer = "container:Vendored Framework Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CAF4FE71CC1125900B44520"
+            BuildableName = "Vendored Framework Example.app"
+            BlueprintName = "Vendored Framework Example"
+            ReferencedContainer = "container:Vendored Framework Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/Vendored Framework Example/Vendored Framework Example/AppDelegate.swift
+++ b/examples/Vendored Framework Example/Vendored Framework Example/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Vendored Framework Example
+//
+//  Created by Mark Spanbroek on 15/04/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/examples/Vendored Framework Example/Vendored Framework Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/Vendored Framework Example/Vendored Framework Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/Vendored Framework Example/Vendored Framework Example/Base.lproj/LaunchScreen.storyboard
+++ b/examples/Vendored Framework Example/Vendored Framework Example/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/Vendored Framework Example/Vendored Framework Example/Base.lproj/Main.storyboard
+++ b/examples/Vendored Framework Example/Vendored Framework Example/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Vendored_Framework_Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/Vendored Framework Example/Vendored Framework Example/Info.plist
+++ b/examples/Vendored Framework Example/Vendored Framework Example/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/Vendored Framework Example/Vendored Framework Example/ViewController.swift
+++ b/examples/Vendored Framework Example/Vendored Framework Example/ViewController.swift
@@ -1,0 +1,26 @@
+//
+//  ViewController.swift
+//  Vendored Framework Example
+//
+//  Created by Mark Spanbroek on 15/04/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import AFNetworking
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/lib/cocoapods/installer/file_references_installer.rb
+++ b/lib/cocoapods/installer/file_references_installer.rb
@@ -135,8 +135,10 @@ module Pod
                 end
               end
 
-              vendored_frameworks_header_mappings(headers_sandbox, file_accessor).each do |namespaced_path, files|
-                sandbox.public_headers.add_files(namespaced_path, files)
+              unless pod_target.requires_frameworks?
+                vendored_frameworks_header_mappings(headers_sandbox, file_accessor).each do |namespaced_path, files|
+                  sandbox.public_headers.add_files(namespaced_path, files)
+                end
               end
             end
           end

--- a/spec/unit/installer/file_references_installer_spec.rb
+++ b/spec/unit/installer/file_references_installer_spec.rb
@@ -106,6 +106,14 @@ module Pod
         monkey_header = headers_root + 'monkey/monkey.h'
         monkey_header.should.exist
       end
+
+      it "doesn't link public headers from vendored framework, when frameworks required" do
+        Target.any_instance.stubs(:requires_frameworks?).returns(true)
+        @installer.install!
+        headers_root = config.sandbox.public_headers.root
+        framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
+        framework_header.should.not.exist
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
:rainbow:

Currently when including a vendored_framework in your podspec, its headers will be linked into the Pods/Headers/Public directory. This directory is added to the HEADER_SEARCH_PATH of any pod target that depends on it. Which will lead to a "Include of non-modular header inside framework module" error, because Xcode doesn't like it when header files are both available through header search paths and framework search paths (https://forums.developer.apple.com/thread/23554#81066).

This pull request fixes this issue. It is basically doing for vendored frameworks what already has been done for the build headers in PR #4476.

It is also likely fixes #4805.
