### PR TITLE
[SourcesManager] Provide a deprecation path for access to Pod::SourcesManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   `Pod::Config.instance.sources_manager` in some manner as soon as possible.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Running `pod repo update --silent` will now properly silence git output while
+  updating the repository.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.0.0.beta.7 (2016-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Mark Spanbroek](https://github.com/markspanbroek)
   [#5146](https://github.com/CocoaPods/CocoaPods/pull/5146)
 
+* Access to the `Pod::SourcesManager` constant has been restored, though its use
+  is considered deprecated and subject to removal at any time. Migrate to use
+  `Pod::Config.instance.sources_manager` in some manner as soon as possible.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.0.0.beta.7 (2016-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Headers from vendored frameworks no longer end up in the HEADER_SEARCH_PATH when 
-  using frameworks. They are assumed to be already present as modular headers in the
-  framework itself.  
+* Headers from vendored frameworks no longer end up in the `HEADER_SEARCH_PATH`
+  when using frameworks. They are now assumed to be already present as modular
+  headers in the framework itself.  
   [Mark Spanbroek](https://github.com/markspanbroek)
   [#5146](https://github.com/CocoaPods/CocoaPods/pull/5146)
+
 
 ## 1.0.0.beta.7 (2016-04-15)
 

--- a/lib/cocoapods/command/repo/update.rb
+++ b/lib/cocoapods/command/repo/update.rb
@@ -19,7 +19,8 @@ module Pod
         end
 
         def run
-          config.sources_manager.update(@name, true)
+          show_output = !config.silent?
+          config.sources_manager.update(@name, show_output)
         end
       end
     end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -153,4 +153,37 @@ module Pod
       UI.puts(message)
     end
   end
+
+  # @!visibility private
+  SOURCES_MANAGER_CONSTANT_WARNINGS = Set.new
+
+  # @!visibility private
+  #
+  # Warn about deprecated use of `Pod::SourcesManager` and return the config's
+  # Source::Manager
+  #
+  # @return [Pod::Source::Manager]
+  #
+  def self.sources_manager_constant
+    calling_line = caller[1]
+    if SOURCES_MANAGER_CONSTANT_WARNINGS.add?(calling_line)
+      warn 'Usage of the constant `Pod::SourcesManager` is deprecated, ' \
+           'use `Pod::Config.instance.sources_manager` instead ' \
+           "(called from #{calling_line})"
+    end
+    Config.instance.sources_manager
+  end
+end
+
+def Pod.const_missing(const)
+  return super unless const.to_sym == :SourcesManager
+  ::Pod.sources_manager_constant
+end
+
+def Object.const_missing(const)
+  unless const.to_sym == :SourcesManager &&
+      ancestors.any? { |a| a == ::Pod || a.name.start_with?('Pod::') }
+    return super
+  end
+  ::Pod.sources_manager_constant
 end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -161,6 +161,8 @@ module Pod
     # Warn about deprecated use of `Pod::SourcesManager` and return the config's
     # Source::Manager
     #
+    # @param  [#to_sym] const the missing constant
+    #
     # @return [Pod::Source::Manager]
     #
     def const_missing(const)


### PR DESCRIPTION
Who said a constant should be constant?

This is evil, but I think its necessary to ease the pain for third-party transition to CocoaPods 1.0. We will remove this hack very very soon, I promise.

\c @alloy @mrackwitz 