### PR TITLE
Add support for CP1.0 style target inheritence in `pod init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* The `pod init` command now uses target inheritance for test targets
+  in the generated Podfile.  
+  [Orta Therox](https://github.com/orta)
+  [#4714](https://github.com/CocoaPods/CocoaPods/issue/4714)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/init.rb
+++ b/lib/cocoapods/command/init.rb
@@ -62,31 +62,52 @@ module Pod
           # use_frameworks!
         PLATFORM
 
-        project.native_targets.each do |target|
-          podfile << target_module(target)
+        # Split out the targets into app and test targets
+        all_app_targets = project.native_targets.reject { |t| t.name =~ /tests?/i }
+        all_tests_targets = project.native_targets.select { |t| t.name =~ /tests?/i }
+
+        # Create an array of [app, (optional)test] target pairs
+        app_test_pairs = all_app_targets.map do |target|
+          test = all_tests_targets.find { |t| t.name.start_with? target.name }
+          [target, test].compact
         end
-        podfile << "\n"
+
+        app_test_pairs.each do |target_pair|
+          podfile << target_module(target_pair)
+        end
       end
 
-      # @param  [Xcodeproj::PBXTarget] target
-      #         A target to generate a Podfile target module for.
+      # @param  [[Xcodeproj::PBXTarget]] targets
+      #         An array which always has a target as it's first item
+      #         and may optionally contain a second target as its test target
       #
       # @return [String] the text for the target module
       #
-      def target_module(target)
-        target_module = "\ntarget '#{target.name.gsub(/'/, "\\\\\'")}' do\n"
+      def target_module(targets)
+        app = targets.first
+        target_module = "\ntarget '#{app.name.gsub(/'/, "\\\\\'")}' do\n"
+        target_module << template_contents(config.default_podfile_path, "  ")
 
-        if target.name =~ /tests?/i
-          target_module << template_contents(config.default_test_podfile_path)
-        else
-          target_module << template_contents(config.default_podfile_path)
+        test = targets[1]
+        if test
+          target_module << "\n  target '#{test.name.gsub(/'/, "\\\\\'")}' do\n"
+          target_module << "        inherit! :search_paths\n"
+          target_module << template_contents(config.default_test_podfile_path, "    ")
+          target_module << "\n  end\n"
         end
+
         target_module << "\nend\n"
       end
 
-      def template_contents(path)
+      # @param  [[Xcodeproj::PBXTarget]] targets
+      #         An array which always has a target as it's first item
+      #         and may optionally contain a second target as its test target
+      #
+      # @return [String] the text for the target module
+      #
+      def template_contents(path, prefix)
         if path.exist?
-          path.read.chomp.lines.map { |line| "  #{line}" }.join("\n")
+          path.read.chomp.lines.map { |line| "#{prefix}#{line}" }.join("\n")
         else
           ''
         end

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -96,30 +96,29 @@ module Pod
 
         run_command('init')
 
-        podfile_text = File.read(temporary_directory + "Podfile")
-        podfile_exact = <<-PODFILE.strip_heredoc
-        # Uncomment this line to define a global platform for your project
-        # platform :ios, '9.0'
-        # Uncomment this line if you're using Swift
-        # use_frameworks!
+        expected_podfile = <<-RUBY.strip_heredoc
+          # Uncomment this line to define a global platform for your project
+          # platform :ios, '9.0'
+          # Uncomment this line if you're using Swift
+          # use_frameworks!
 
-        target 'App' do
-          # Pods for App
+          target 'App' do
+            # Pods for App
 
-          target 'AppTests' do
-            inherit! :search_paths
-            # Pods for testing
+            target 'AppTests' do
+              inherit! :search_paths
+              # Pods for testing
+            end
+
+            target 'AppFeatureTests' do
+              inherit! :search_paths
+              # Pods for testing
+            end
+
           end
+        RUBY
 
-          target 'AppFeatureTests' do
-            inherit! :search_paths
-            # Pods for testing
-          end
-
-        end
-        PODFILE
-
-        podfile_text.should == podfile_exact
+        File.read('Podfile').should == expected_podfile
       end
     end
 

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -91,7 +91,8 @@ module Pod
         project = Xcodeproj::Project.new(temporary_directory + 'test.xcodeproj')
         project.new_target(:application, 'App', :ios)
         project.new_target(:application, 'AppTests', :ios)
-        project.new_target(:application, "AppFeatureTests", :ios)
+        project.new_target(:application, 'AppFeatureTests', :ios)
+        project.new_target(:application, 'Swifty App', :osx, nil, nil, :swift)
         project.save
 
         run_command('init')
@@ -99,21 +100,30 @@ module Pod
         expected_podfile = <<-RUBY.strip_heredoc
           # Uncomment this line to define a global platform for your project
           # platform :ios, '9.0'
-          # Uncomment this line if you're using Swift
-          # use_frameworks!
 
           target 'App' do
+            # Uncomment this line if you're using Swift or would like to use dynamic frameworks
+            # use_frameworks!
+
             # Pods for App
+
+            target 'AppFeatureTests' do
+              inherit! :search_paths
+              # Pods for testing
+            end
 
             target 'AppTests' do
               inherit! :search_paths
               # Pods for testing
             end
 
-            target 'AppFeatureTests' do
-              inherit! :search_paths
-              # Pods for testing
-            end
+          end
+
+          target 'Swifty App' do
+            # Comment this line if you're not using Swift and don't want to use dynamic frameworks
+            use_frameworks!
+
+            # Pods for Swifty App
 
           end
         RUBY
@@ -121,7 +131,6 @@ module Pod
         File.read('Podfile').should == expected_podfile
       end
     end
-
 
     it 'includes default test pods in test targets in a Podfile' do
       Dir.chdir(temporary_directory) do

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -86,6 +86,44 @@ module Pod
       end
     end
 
+    fit 'handles hooking up mulitple test targets based on an xcodeproj project' do
+      Dir.chdir(temporary_directory) do
+        project = Xcodeproj::Project.new(temporary_directory + 'test.xcodeproj')
+        project.new_target(:application, 'App', :ios)
+        project.new_target(:application, 'AppTests', :ios)
+        project.new_target(:application, "AppFeatureTests", :ios)
+        project.save
+
+        run_command('init')
+
+        podfile_text = File.read(temporary_directory + "Podfile")
+        podfile_exact = <<-PODFILE.strip_heredoc
+        # Uncomment this line to define a global platform for your project
+        # platform :ios, '9.0'
+        # Uncomment this line if you're using Swift
+        # use_frameworks!
+
+        target 'App' do
+          # Pods for App
+
+          target 'AppTests' do
+            inherit! :search_paths
+            # Pods for testing
+          end
+
+          target 'AppFeatureTests' do
+            inherit! :search_paths
+            # Pods for testing
+          end
+
+        end
+        PODFILE
+
+        podfile_text.should == podfile_exact
+      end
+    end
+
+
     it 'includes default test pods in test targets in a Podfile' do
       Dir.chdir(temporary_directory) do
         tmp_templates_dir = Pathname.pwd + 'templates_dir'

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -95,6 +95,7 @@ module Pod
         open(config.default_test_podfile_path, 'w') { |f| f << "pod 'Kiwi'" }
 
         project = Xcodeproj::Project.new(temporary_directory + 'test.xcodeproj')
+        project.new_target(:application, 'App', :ios)
         project.new_target(:application, 'AppTests', :ios)
         project.save
 

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -86,7 +86,7 @@ module Pod
       end
     end
 
-    fit 'handles hooking up mulitple test targets based on an xcodeproj project' do
+    it 'handles hooking up mulitple test targets based on an xcodeproj project' do
       Dir.chdir(temporary_directory) do
         project = Xcodeproj::Project.new(temporary_directory + 'test.xcodeproj')
         project.new_target(:application, 'App', :ios)


### PR DESCRIPTION
From 
``` ruby
target "Thing" do
end
target "ThingTests" do
end
```

to 
``` ruby
target "Thing" do
  target "ThingTests" do
      inherit! :search_paths
  end
end
```

Current tests were already covering that apps were generating Podfiles that generated the same kind of  project, wasn't sure whether to add some plaintext checks, but it seemed that because no tests were doing it so far. Thus we were relying on the integrations working, which it does.