### PR TITLE
Make the utf-8 warning message respect --no-ansi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* The warning for not having utf-8 set as the default encoding for a
+  terminal now properly respects the `--no-ansi` argument.  
+  [Joshua Kalpin](https://github.com/Kapin)
+  [#5199](https://github.com/CocoaPods/CocoaPods/pull/5199)
 
 
 ## 1.0.0.beta.8 (2016-04-15)

--- a/bin/pod
+++ b/bin/pod
@@ -1,13 +1,24 @@
 #!/usr/bin/env ruby
 
 if Encoding.default_external != Encoding::UTF_8
-  STDERR.puts <<-DOC
-\e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
-Consider adding the following to ~/.profile:
 
-export LANG=en_US.UTF-8
-\e[0m
-DOC
+  if ARGV.include? '--no-ansi'
+    STDERR.puts <<-DOC
+    WARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
+    Consider adding the following to ~/.profile:
+
+    export LANG=en_US.UTF-8
+    DOC
+  else
+    STDERR.puts <<-DOC
+    \e[33mWARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
+    Consider adding the following to ~/.profile:
+
+    export LANG=en_US.UTF-8
+    \e[0m
+    DOC
+  end
+
 end
 
 if $PROGRAM_NAME == __FILE__ && !ENV['COCOAPODS_NO_BUNDLER']


### PR DESCRIPTION
Closes #5013 

Just prints a different docstring now if we find --no-ansi in ARGV. I tried just printing the colour codes conditionally but it didn't seem to work in my local terminal. I'm sure there is a more "ruby" way to do this 😛 