### PR TITLE
Fix URL in changelog pointing to a wrong pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Fix for `pod repo push --help` throwing an error.  
   [Boris Bügling](https://github.com/neonichu)
-  [#5214](https://github.com/CocoaPods/CocoaPods/pull/5199)
+  [#5214](https://github.com/CocoaPods/CocoaPods/pull/5214)
 
 * The warning for not having utf-8 set as the default encoding for a
   terminal now properly respects the `--no-ansi` argument.  


### PR DESCRIPTION
The URL was copy-pasted and nobody updated the suffix with the pull request id