### PR TITLE
[InstallationOptions] Add #share_schemes_for_development_pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Orta Therox](https://github.com/orta)
   [#5260](https://github.com/CocoaPods/CocoaPods/issues/5260)
 
+* Make sharing schemes for development pods an installation option
+  (`share_schemes_for_development_pods`) and disable sharing schemes
+  by default.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -703,7 +703,26 @@ module Pod
     #
     def share_development_pod_schemes
       development_pod_targets.select(&:should_build?).each do |pod_target|
+        next unless share_scheme_for_development_pod?(pod_target.pod_name)
         Xcodeproj::XCScheme.share_scheme(pods_project.path, pod_target.label)
+      end
+    end
+
+    # @param  [String] pod The root name of the development pod.
+    #
+    # @return [Bool] whether the scheme for the given development pod should be
+    #         shared.
+    #
+    def share_scheme_for_development_pod?(pod)
+      case dev_pods_to_share = installation_options.share_schemes_for_development_pods
+      when TrueClass, FalseClass, NilClass
+        dev_pods_to_share
+      when Array
+        dev_pods_to_share.any? { |dev_pod| dev_pod === pod } # rubocop:disable Style/CaseEquality
+      else
+        raise Informative, 'Unable to handle share_schemes_for_development_pods ' \
+          "being set to #{dev_pods_to_share.inspect} -- please set it to true, " \
+          'false, or an array of pods to share schemes for.'
       end
     end
 

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -106,6 +106,7 @@ module Pod
       option :deterministic_uuids, true
       option :integrate_targets, true
       option :lock_pod_sources, true
+      option :share_schemes_for_development_pods, true
 
       module Mixin
         module ClassMethods

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -106,7 +106,7 @@ module Pod
       option :deterministic_uuids, true
       option :integrate_targets, true
       option :lock_pod_sources, true
-      option :share_schemes_for_development_pods, true
+      option :share_schemes_for_development_pods, false
 
       module Mixin
         module ClassMethods

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -62,6 +62,7 @@ module Pod
           'deterministic_uuids' => false,
           'integrate_targets' => true,
           'lock_pod_sources' => true,
+          'share_schemes_for_development_pods' => true,
         }
       end
 

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -9,6 +9,7 @@ module Pod
         'deterministic_uuids' => true,
         'integrate_targets' => true,
         'lock_pod_sources' => true,
+        'share_schemes_for_development_pods' => false,
       }.each do |option, default|
         it "includes `#{option}` defaulting to `#{default}`" do
           Installer::InstallationOptions.defaults.fetch(option).should == default
@@ -62,7 +63,7 @@ module Pod
           'deterministic_uuids' => false,
           'integrate_targets' => true,
           'lock_pod_sources' => true,
-          'share_schemes_for_development_pods' => true,
+          'share_schemes_for_development_pods' => false,
         }
       end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -758,7 +758,16 @@ module Pod
             @installer.sandbox.stubs(:development_pods).returns('BananaLib' => nil)
           end
 
-          it 'shares by default' do
+          it 'does not share by default' do
+            Xcodeproj::XCScheme.expects(:share_scheme).never
+            @installer.send(:share_development_pod_schemes)
+          end
+
+          it 'can share all schemes' do
+            @installer.installation_options.
+              stubs(:share_schemes_for_development_pods).
+              returns(true)
+
             Xcodeproj::XCScheme.expects(:share_scheme).with(
               @installer.pods_project.path,
               'BananaLib')


### PR DESCRIPTION
This allows for opting out of sharing schemes for development pods.
By default, the current behavior is kept -- all dev pods have their
schemes shared. By setting the option to `nil` or `false`, no schemes
are shared. Otherwise, an array can be passed, and only dev pod names that
match elements of that array will have their schemes shared.

@neonichu @orta how do we feel about providing this as an option?

- [x] CHANGELOG