### PR TITLE
Remove 'Until we reach 1.0' from upgrading message since this happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Removed a message informing users that until CocoaPods 1.0, features of
+  CocoaPods will frequently change while being informed about future versions.  
+  [Kyle Fuller](https://github.com/kylef)
 
 
 ## 1.0.0 (2016-05-10)

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -141,8 +141,6 @@ module Pod
         "CocoaPods #{latest_cocoapods_version} is available.".green,
         "To update use: `#{install_message}`".green,
         ("[!] This is a test version we'd love you to try.".yellow if rc),
-        ("Until we reach version 1.0 the features of CocoaPods can and will change.\n" \
-         'We strongly recommend that you use the latest version at all times.'.yellow unless rc),
         '',
         'For more information, see https://blog.cocoapods.org ' \
         'and the CHANGELOG for this version at ' \


### PR DESCRIPTION
It's no longer necessary to inform users that versions of CocoaPods less than 1 will frequently change when they are already running 1.0.0.

> Until we reach version 1.0 the features of CocoaPods can and will change.