### PR TITLE
Update pod setup to show git progress

### DIFF
--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -19,6 +19,7 @@ module Pod
 
       def run
         UI.section 'Setting up CocoaPods master repo' do
+          UI.puts 'This may take a while'.yellow
           if master_repo_dir.exist?
             set_master_repo_url
             set_master_repo_branch


### PR DESCRIPTION
Setting up the master repo can take a while for people on slower
wireless networks. This small change adds a note that it may take a
while to let users know to just sit tight, and that their command is
not stuck.
