### PR TITLE
[Config] Normalize installation_root to ensure same character encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Jan Berkel](https://github.com/jberkel)
   [#5319](https://github.com/CocoaPods/CocoaPods/pull/5319)
 
+* Avoid removing all files when root directory contains unicode characters.  
+  [Marc Boquet](https://github.com/marcboquet)
+  [#5294](https://github.com/CocoaPods/CocoaPods/issues/5294)
+
+
 ## 1.0.0 (2016-05-10)
 
 ##### Enhancements

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -1,3 +1,5 @@
+require 'active_support/multibyte/unicode'
+
 module Pod
   # Stores the global configuration of CocoaPods.
   #
@@ -145,7 +147,8 @@ module Pod
     #         Podfile is located.
     #
     def installation_root
-      current_path = Pathname.pwd
+      current_dir = ActiveSupport::Multibyte::Unicode.normalize(Dir.pwd)
+      current_path = Pathname.new(current_dir)
       unless @installation_root
         until current_path.root?
           if podfile_path_in_dir(current_path)

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -112,6 +112,15 @@ module Pod
         end
       end
 
+      it 'returns the working directory correctly when it includes unicode characters' do
+        unicode_directory = temporary_directory + "ü"
+        FileUtils.mkdir(unicode_directory)
+        Dir.chdir(unicode_directory) do
+          File.open('Podfile', 'w') {}
+          @config.installation_root.to_s.should == unicode_directory.to_s
+        end
+      end
+
       before do
         @config.installation_root = temporary_directory
       end


### PR DESCRIPTION
Some characters like "ü" where being represented as `["u", "̈"]` in ruby < 2.3.0 and it caused errors down the line.

I tried using `String#unicode_normalize` but turns out it's only available since ruby 2.2.0, so I'm using ActiveSupport normalization.
I don't know how this kinds of workarounds need to be documented? In the future if CocoaPods moves to ruby >= 2.3.0 this normalization wouldn't be needed anymore.

Fixes #5294 