### PR TITLE
Update an info message for 1.x: Change xcodeproj → project

### DIFF
--- a/lib/cocoapods/installer/analyzer/target_inspector.rb
+++ b/lib/cocoapods/installer/analyzer/target_inspector.rb
@@ -72,7 +72,7 @@ module Pod
             else
               raise Informative, 'Could not automatically select an Xcode project. ' \
                 "Specify one in your Podfile like so:\n\n" \
-                "    xcodeproj 'path/to/Project.xcodeproj'\n"
+                "    project 'path/to/Project.xcodeproj'\n"
             end
           end
           path


### PR DESCRIPTION
Fixes an informative message that appears when the project can't be found.

This is what was seeing before:

<pre>[!] Could not automatically select an Xcode project. Specify one in your Podfile like so:

    xcodeproj 'path/to/Project.xcodeproj'

[...]

[!] xcodeproj was renamed to `project`. Please use that from now on.</pre>