### PR TITLE
[Repo Push] Help validation

### DIFF
--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -49,14 +49,13 @@ module Pod
         end
 
         def validate!
+          super
           help! 'A spec-repo name is required.' unless @repo
           unless @source.repo.directory?
             raise Informative,
                   "Unable to find the `#{@repo}` repo. " \
                   'If it has not yet been cloned, add it via `pod repo add`.'
           end
-
-          super
         end
 
         def run


### PR DESCRIPTION
`super` should be first in the case that the help flag is passed in.
https://github.com/CocoaPods/CLAide/blob/master/lib/claide/command.rb#L543-L550