### PR TITLE
Patch to workaround the Build Phases name matching with emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#5313](https://github.com/CocoaPods/CocoaPods/issues/5313)
 
+* Removed emojis in Build Phases names — as it seems that some third party tools have trouble with them.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#5382](https://github.com/CocoaPods/CocoaPods/pull/5382)
+
 * Ensure `Set` is defined before using it.  
   [Samuel Giddins](https://github.com/segiddins)
   [#5287](https://github.com/CocoaPods/CocoaPods/issues/5287)

--- a/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1A2265312C5CBC89CD477BF8 /* libPods-AFNetworking Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53BDE93051BED183E9F4D921 /* libPods-AFNetworking Example.a */; };
+		A63161F703812E838A66D108 /* libPods-AFNetworking Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01ED403DCA1D362A7A1B607E /* libPods-AFNetworking Example.a */; };
 		B304CCE8177D58DD00F4FC85 /* adn.cer in Resources */ = {isa = PBXBuildFile; fileRef = B304CCE7177D58DD00F4FC85 /* adn.cer */; };
 		F8129C001591061B009BFE23 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8129BFF1591061B009BFE23 /* Cocoa.framework */; };
 		F8129C321591073C009BFE23 /* AFAppDotNetAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8129C251591073C009BFE23 /* AFAppDotNetAPIClient.m */; };
@@ -19,10 +19,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3C79D6B3AA6A1DBBAE48A944 /* Pods-AFNetworking Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example.debug.xcconfig"; sourceTree = "<group>"; };
-		53BDE93051BED183E9F4D921 /* libPods-AFNetworking Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AFNetworking Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A67B777556EF5D95EAFA5CF8 /* Pods-AFNetworking Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example.release.xcconfig"; sourceTree = "<group>"; };
+		01ED403DCA1D362A7A1B607E /* libPods-AFNetworking Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AFNetworking Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		694801CD9796D99F3BDD0D95 /* Pods-AFNetworking Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example.release.xcconfig"; sourceTree = "<group>"; };
 		B304CCE7177D58DD00F4FC85 /* adn.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = adn.cer; sourceTree = SOURCE_ROOT; };
+		B47968EF64ED4169C658E405 /* Pods-AFNetworking Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example.debug.xcconfig"; sourceTree = "<group>"; };
 		F8129BFB1591061B009BFE23 /* AFNetworking Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AFNetworking Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8129BFF1591061B009BFE23 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		F8129C021591061B009BFE23 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -47,18 +47,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8129C001591061B009BFE23 /* Cocoa.framework in Frameworks */,
-				1A2265312C5CBC89CD477BF8 /* libPods-AFNetworking Example.a in Frameworks */,
+				A63161F703812E838A66D108 /* libPods-AFNetworking Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		A052BC91C16D94336357A93A /* Pods */ = {
+		008008D9EF6A9117F2D42119 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3C79D6B3AA6A1DBBAE48A944 /* Pods-AFNetworking Example.debug.xcconfig */,
-				A67B777556EF5D95EAFA5CF8 /* Pods-AFNetworking Example.release.xcconfig */,
+				B47968EF64ED4169C658E405 /* Pods-AFNetworking Example.debug.xcconfig */,
+				694801CD9796D99F3BDD0D95 /* Pods-AFNetworking Example.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -70,7 +70,7 @@
 				F8129C051591061B009BFE23 /* Classes */,
 				F8129BFE1591061B009BFE23 /* Frameworks */,
 				F8129BFC1591061B009BFE23 /* Products */,
-				A052BC91C16D94336357A93A /* Pods */,
+				008008D9EF6A9117F2D42119 /* Pods */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -90,7 +90,7 @@
 			children = (
 				F8129BFF1591061B009BFE23 /* Cocoa.framework */,
 				F8129C011591061B009BFE23 /* Other Frameworks */,
-				53BDE93051BED183E9F4D921 /* libPods-AFNetworking Example.a */,
+				01ED403DCA1D362A7A1B607E /* libPods-AFNetworking Example.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -148,12 +148,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8129C191591061B009BFE23 /* Build configuration list for PBXNativeTarget "AFNetworking Example" */;
 			buildPhases = (
-				2C1C2E504B564F0D90A4E1D2 /* 📦 Check Pods Manifest.lock */,
+				2C1C2E504B564F0D90A4E1D2 /* [CP] Check Pods Manifest.lock */,
 				F8129BF71591061B009BFE23 /* Sources */,
 				F8129BF81591061B009BFE23 /* Frameworks */,
 				F8129BF91591061B009BFE23 /* Resources */,
-				CC1632E381344B54BA63986B /* 📦 Copy Pods Resources */,
-				F0DC30B6798CF042746A5614 /* 📦 Embed Pods Frameworks */,
+				CC1632E381344B54BA63986B /* [CP] Copy Pods Resources */,
+				F0DC30B6798CF042746A5614 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -202,14 +202,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2C1C2E504B564F0D90A4E1D2 /* 📦 Check Pods Manifest.lock */ = {
+		2C1C2E504B564F0D90A4E1D2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -217,14 +217,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		CC1632E381344B54BA63986B /* 📦 Copy Pods Resources */ = {
+		CC1632E381344B54BA63986B /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -232,14 +232,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F0DC30B6798CF042746A5614 /* 📦 Embed Pods Frameworks */ = {
+		F0DC30B6798CF042746A5614 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -332,7 +332,7 @@
 		};
 		F8129C1A1591061B009BFE23 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C79D6B3AA6A1DBBAE48A944 /* Pods-AFNetworking Example.debug.xcconfig */;
+			baseConfigurationReference = B47968EF64ED4169C658E405 /* Pods-AFNetworking Example.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -347,7 +347,7 @@
 		};
 		F8129C1B1591061B009BFE23 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A67B777556EF5D95EAFA5CF8 /* Pods-AFNetworking Example.release.xcconfig */;
+			baseConfigurationReference = 694801CD9796D99F3BDD0D95 /* Pods-AFNetworking Example.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;

--- a/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2982AD3217107C0000FFF048 /* adn.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2982AD3117107C0000FFF048 /* adn.cer */; };
-		9A67BEDAF4D3529C5380A3E2 /* libPods-AFNetworking iOS Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB1F7D464FF374F6931E274F /* libPods-AFNetworking iOS Example.a */; };
+		D316A4584424A267872C6208 /* libPods-AFNetworking iOS Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C0AE9D618FB17D8FBD760E /* libPods-AFNetworking iOS Example.a */; };
 		F8129C7415910C37009BFE23 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F8129C7215910C37009BFE23 /* AppDelegate.m */; };
 		F818101615E6A0C600EF93C2 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ABD6EC159FC2CE001BE42C /* MobileCoreServices.framework */; };
 		F88812F016C533D6003C8B8C /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E469E013957DF100DB05C8 /* Security.framework */; };
@@ -33,11 +33,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0678DF4121D5956B85653CB1 /* Pods-AFNetworking iOS Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking iOS Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example.release.xcconfig"; sourceTree = "<group>"; };
 		2982AD3117107C0000FFF048 /* adn.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = adn.cer; sourceTree = SOURCE_ROOT; };
 		50ABD6EC159FC2CE001BE42C /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
-		7669B6F3267891B0317A0167 /* Pods-AFNetworking iOS Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking iOS Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example.debug.xcconfig"; sourceTree = "<group>"; };
-		BEA3D3BDD12996573240F05F /* Pods-AFNetworking iOS Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking iOS Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example.release.xcconfig"; sourceTree = "<group>"; };
-		DB1F7D464FF374F6931E274F /* libPods-AFNetworking iOS Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AFNetworking iOS Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5723FFCCA3CB8D6E467F174B /* Pods-AFNetworking iOS Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFNetworking iOS Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example.debug.xcconfig"; sourceTree = "<group>"; };
+		F3C0AE9D618FB17D8FBD760E /* libPods-AFNetworking iOS Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AFNetworking iOS Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8129C3815910830009BFE23 /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = SOURCE_ROOT; };
 		F8129C7215910C37009BFE23 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = SOURCE_ROOT; };
 		F8129C7315910C37009BFE23 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = SOURCE_ROOT; };
@@ -81,18 +81,18 @@
 				F8E469DF13957DD500DB05C8 /* CoreLocation.framework in Frameworks */,
 				F8D0701B14310F4A00653FD3 /* SystemConfiguration.framework in Frameworks */,
 				F818101615E6A0C600EF93C2 /* MobileCoreServices.framework in Frameworks */,
-				9A67BEDAF4D3529C5380A3E2 /* libPods-AFNetworking iOS Example.a in Frameworks */,
+				D316A4584424A267872C6208 /* libPods-AFNetworking iOS Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		9CE17E7C344B0E75BC0723EA /* Pods */ = {
+		F894B3D9070680CE51C9C4F8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				7669B6F3267891B0317A0167 /* Pods-AFNetworking iOS Example.debug.xcconfig */,
-				BEA3D3BDD12996573240F05F /* Pods-AFNetworking iOS Example.release.xcconfig */,
+				5723FFCCA3CB8D6E467F174B /* Pods-AFNetworking iOS Example.debug.xcconfig */,
+				0678DF4121D5956B85653CB1 /* Pods-AFNetworking iOS Example.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -140,7 +140,7 @@
 				F8E469ED1395812A00DB05C8 /* Images */,
 				F8E469631395739D00DB05C8 /* Frameworks */,
 				F8E469611395739C00DB05C8 /* Products */,
-				9CE17E7C344B0E75BC0723EA /* Pods */,
+				F894B3D9070680CE51C9C4F8 /* Pods */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -165,7 +165,7 @@
 				F8E469641395739D00DB05C8 /* UIKit.framework */,
 				F8E469661395739D00DB05C8 /* Foundation.framework */,
 				F8E469681395739D00DB05C8 /* CoreGraphics.framework */,
-				DB1F7D464FF374F6931E274F /* libPods-AFNetworking iOS Example.a */,
+				F3C0AE9D618FB17D8FBD760E /* libPods-AFNetworking iOS Example.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -223,12 +223,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8E469811395739D00DB05C8 /* Build configuration list for PBXNativeTarget "AFNetworking iOS Example" */;
 			buildPhases = (
-				E4419DF1E8B742E49777FFE0 /* 📦 Check Pods Manifest.lock */,
+				E4419DF1E8B742E49777FFE0 /* [CP] Check Pods Manifest.lock */,
 				F8E4695C1395739C00DB05C8 /* Sources */,
 				F8E4695D1395739C00DB05C8 /* Frameworks */,
 				F8E4695E1395739C00DB05C8 /* Resources */,
-				226FE837057C4F98AD9FFB32 /* 📦 Copy Pods Resources */,
-				CB0CF751F97DB411456460D5 /* 📦 Embed Pods Frameworks */,
+				226FE837057C4F98AD9FFB32 /* [CP] Copy Pods Resources */,
+				CB0CF751F97DB411456460D5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -284,14 +284,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		226FE837057C4F98AD9FFB32 /* 📦 Copy Pods Resources */ = {
+		226FE837057C4F98AD9FFB32 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -299,14 +299,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CB0CF751F97DB411456460D5 /* 📦 Embed Pods Frameworks */ = {
+		CB0CF751F97DB411456460D5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -314,14 +314,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E4419DF1E8B742E49777FFE0 /* 📦 Check Pods Manifest.lock */ = {
+		E4419DF1E8B742E49777FFE0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -382,7 +382,7 @@
 		};
 		F8E469821395739D00DB05C8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7669B6F3267891B0317A0167 /* Pods-AFNetworking iOS Example.debug.xcconfig */;
+			baseConfigurationReference = 5723FFCCA3CB8D6E467F174B /* Pods-AFNetworking iOS Example.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -404,7 +404,7 @@
 		};
 		F8E469831395739D00DB05C8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BEA3D3BDD12996573240F05F /* Pods-AFNetworking iOS Example.release.xcconfig */;
+			baseConfigurationReference = 0678DF4121D5956B85653CB1 /* Pods-AFNetworking iOS Example.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/examples/Alamofire Example/iOS Example.xcodeproj/project.pbxproj
+++ b/examples/Alamofire Example/iOS Example.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		951B3FAD58824E9B86E74AD3 /* Pods_iOS_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EEEDE5D19C6F39708A8F116 /* Pods_iOS_Example.framework */; };
+		C82071AF343C55D6645B5448 /* Pods_iOS_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F6B1B2EDDA11E881E41FEC2 /* Pods_iOS_Example.framework */; };
 		F8111E0B19A951050040E7D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E0A19A951050040E7D1 /* AppDelegate.swift */; };
 		F8111E0D19A951050040E7D1 /* MasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E0C19A951050040E7D1 /* MasterViewController.swift */; };
 		F8111E0F19A951050040E7D1 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8111E0E19A951050040E7D1 /* DetailViewController.swift */; };
@@ -17,9 +17,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4EEEDE5D19C6F39708A8F116 /* Pods_iOS_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E72AAD1560ED38C6203AE071 /* Pods-iOS Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Example/Pods-iOS Example.release.xcconfig"; sourceTree = "<group>"; };
-		F787F2A3625E02D003BE2209 /* Pods-iOS Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Example/Pods-iOS Example.debug.xcconfig"; sourceTree = "<group>"; };
+		32E57E48A641215EE938A9F4 /* Pods-iOS Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Example/Pods-iOS Example.debug.xcconfig"; sourceTree = "<group>"; };
+		4F6B1B2EDDA11E881E41FEC2 /* Pods_iOS_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E5904356E33E2E78515F010 /* Pods-iOS Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS Example/Pods-iOS Example.release.xcconfig"; sourceTree = "<group>"; };
 		F8111E0519A951050040E7D1 /* iOS Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E0919A951050040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8111E0A19A951050040E7D1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -35,28 +35,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				951B3FAD58824E9B86E74AD3 /* Pods_iOS_Example.framework in Frameworks */,
+				C82071AF343C55D6645B5448 /* Pods_iOS_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2D42BDE636F2C5E26D98A0B6 /* Pods */ = {
+		8AE89EDB3E4608D5851224F5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F787F2A3625E02D003BE2209 /* Pods-iOS Example.debug.xcconfig */,
-				E72AAD1560ED38C6203AE071 /* Pods-iOS Example.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		D8ADE35CA568F7C97750679B /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				4EEEDE5D19C6F39708A8F116 /* Pods_iOS_Example.framework */,
+				4F6B1B2EDDA11E881E41FEC2 /* Pods_iOS_Example.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E8DBABB31D3A1E1E4FC8DC4B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				32E57E48A641215EE938A9F4 /* Pods-iOS Example.debug.xcconfig */,
+				7E5904356E33E2E78515F010 /* Pods-iOS Example.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		F8111DFC19A951050040E7D1 = {
@@ -64,8 +64,8 @@
 			children = (
 				F8111E0719A951050040E7D1 /* Source */,
 				F8111E0619A951050040E7D1 /* Products */,
-				2D42BDE636F2C5E26D98A0B6 /* Pods */,
-				D8ADE35CA568F7C97750679B /* Frameworks */,
+				E8DBABB31D3A1E1E4FC8DC4B /* Pods */,
+				8AE89EDB3E4608D5851224F5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -107,12 +107,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8111E2319A951050040E7D1 /* Build configuration list for PBXNativeTarget "iOS Example" */;
 			buildPhases = (
-				6540B3CA5F945114F2BD9C7B /* 📦 Check Pods Manifest.lock */,
+				6540B3CA5F945114F2BD9C7B /* [CP] Check Pods Manifest.lock */,
 				F8111E0119A951050040E7D1 /* Sources */,
 				F8111E0219A951050040E7D1 /* Frameworks */,
 				F8111E0319A951050040E7D1 /* Resources */,
-				232F8168EB8673C9D2405BA7 /* 📦 Embed Pods Frameworks */,
-				B81850C1CB84CCCCFC8FFC52 /* 📦 Copy Pods Resources */,
+				232F8168EB8673C9D2405BA7 /* [CP] Embed Pods Frameworks */,
+				B81850C1CB84CCCCFC8FFC52 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -169,14 +169,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		232F8168EB8673C9D2405BA7 /* 📦 Embed Pods Frameworks */ = {
+		232F8168EB8673C9D2405BA7 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -184,14 +184,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOS Example/Pods-iOS Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6540B3CA5F945114F2BD9C7B /* 📦 Check Pods Manifest.lock */ = {
+		6540B3CA5F945114F2BD9C7B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -199,14 +199,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		B81850C1CB84CCCCFC8FFC52 /* 📦 Copy Pods Resources */ = {
+		B81850C1CB84CCCCFC8FFC52 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -323,7 +323,7 @@
 		};
 		F8111E2419A951050040E7D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F787F2A3625E02D003BE2209 /* Pods-iOS Example.debug.xcconfig */;
+			baseConfigurationReference = 32E57E48A641215EE938A9F4 /* Pods-iOS Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -335,7 +335,7 @@
 		};
 		F8111E2519A951050040E7D1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E72AAD1560ED38C6203AE071 /* Pods-iOS Example.release.xcconfig */;
+			baseConfigurationReference = 7E5904356E33E2E78515F010 /* Pods-iOS Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
@@ -86,12 +86,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 295BB56B1CEA95DE00E79F82 /* Build configuration list for PBXNativeTarget "App" */;
 			buildPhases = (
-				62E9CD52D31153978437D4C2 /* 📦 Check Pods Manifest.lock */,
+				62E9CD52D31153978437D4C2 /* [CP] Check Pods Manifest.lock */,
 				295BB55A1CEA95DE00E79F82 /* Sources */,
 				295BB55B1CEA95DE00E79F82 /* Frameworks */,
 				295BB55C1CEA95DE00E79F82 /* Resources */,
-				6E2B4891468DB661A63F8065 /* 📦 Embed Pods Frameworks */,
-				0B71E1EA08FB405324201E97 /* 📦 Copy Pods Resources */,
+				6E2B4891468DB661A63F8065 /* [CP] Embed Pods Frameworks */,
+				0B71E1EA08FB405324201E97 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -147,14 +147,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0B71E1EA08FB405324201E97 /* 📦 Copy Pods Resources */ = {
+		0B71E1EA08FB405324201E97 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -162,14 +162,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-App/Pods-App-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		62E9CD52D31153978437D4C2 /* 📦 Check Pods Manifest.lock */ = {
+		62E9CD52D31153978437D4C2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -177,14 +177,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		6E2B4891468DB661A63F8065 /* 📦 Embed Pods Frameworks */ = {
+		6E2B4891468DB661A63F8065 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
+++ b/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
@@ -110,12 +110,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A8C77C661C9DA931000AFF69 /* Build configuration list for PBXNativeTarget "Resource Bundle Example" */;
 			buildPhases = (
-				8FB5EE32BFE997FC437DE638 /* 📦 Check Pods Manifest.lock */,
+				8FB5EE32BFE997FC437DE638 /* [CP] Check Pods Manifest.lock */,
 				A8C77C4B1C9DA931000AFF69 /* Sources */,
 				A8C77C4C1C9DA931000AFF69 /* Frameworks */,
 				A8C77C4D1C9DA931000AFF69 /* Resources */,
-				E1D153F1317B0ED8A0A98DE0 /* 📦 Embed Pods Frameworks */,
-				41F27F05FA87A7FE9EA1A2BF /* 📦 Copy Pods Resources */,
+				E1D153F1317B0ED8A0A98DE0 /* [CP] Embed Pods Frameworks */,
+				41F27F05FA87A7FE9EA1A2BF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -172,14 +172,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		41F27F05FA87A7FE9EA1A2BF /* 📦 Copy Pods Resources */ = {
+		41F27F05FA87A7FE9EA1A2BF /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = '[CP] Copy Pods Resources';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -187,14 +187,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Resource Bundle Example/Pods-Resource Bundle Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8FB5EE32BFE997FC437DE638 /* 📦 Check Pods Manifest.lock */ = {
+		8FB5EE32BFE997FC437DE638 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = '[CP] Check Pods Manifest.lock';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -202,14 +202,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		E1D153F1317B0ED8A0A98DE0 /* 📦 Embed Pods Frameworks */ = {
+		E1D153F1317B0ED8A0A98DE0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = '[CP] Embed Pods Frameworks';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
+++ b/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
@@ -150,12 +150,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F58833F11CBBC0C9007D4DA4 /* Build configuration list for PBXNativeTarget "TestInclusions" */;
 			buildPhases = (
-				18770D25CD70A1B4F077C1A3 /* 📦 Check Pods Manifest.lock */,
+				18770D25CD70A1B4F077C1A3 /* [CP] Check Pods Manifest.lock */,
 				F58833CB1CBBC0C9007D4DA4 /* Sources */,
 				F58833CC1CBBC0C9007D4DA4 /* Frameworks */,
 				F58833CD1CBBC0C9007D4DA4 /* Resources */,
-				2D7DA37C114DD6E56D290D94 /* 📦 Embed Pods Frameworks */,
-				BEB56E0CAF877FA9577BF299 /* 📦 Copy Pods Resources */,
+				2D7DA37C114DD6E56D290D94 /* [CP] Embed Pods Frameworks */,
+				BEB56E0CAF877FA9577BF299 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -170,12 +170,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F58833F41CBBC0C9007D4DA4 /* Build configuration list for PBXNativeTarget "TestInclusionsTests" */;
 			buildPhases = (
-				FF15824F61254F4257FD78E7 /* 📦 Check Pods Manifest.lock */,
+				FF15824F61254F4257FD78E7 /* [CP] Check Pods Manifest.lock */,
 				F58833E41CBBC0C9007D4DA4 /* Sources */,
 				F58833E51CBBC0C9007D4DA4 /* Frameworks */,
 				F58833E61CBBC0C9007D4DA4 /* Resources */,
-				6D3C9E5647F2F9BE1B8CA805 /* 📦 Embed Pods Frameworks */,
-				23FBFF6CF467540E5F102610 /* 📦 Copy Pods Resources */,
+				6D3C9E5647F2F9BE1B8CA805 /* [CP] Embed Pods Frameworks */,
+				23FBFF6CF467540E5F102610 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -245,14 +245,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		18770D25CD70A1B4F077C1A3 /* 📦 Check Pods Manifest.lock */ = {
+		18770D25CD70A1B4F077C1A3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = '[CP] Check Pods Manifest.lock';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -260,14 +260,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		23FBFF6CF467540E5F102610 /* 📦 Copy Pods Resources */ = {
+		23FBFF6CF467540E5F102610 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = '[CP] Copy Pods Resources';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -275,14 +275,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2D7DA37C114DD6E56D290D94 /* 📦 Embed Pods Frameworks */ = {
+		2D7DA37C114DD6E56D290D94 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = '[CP] Embed Pods Frameworks';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -290,14 +290,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6D3C9E5647F2F9BE1B8CA805 /* 📦 Embed Pods Frameworks */ = {
+		6D3C9E5647F2F9BE1B8CA805 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = '[CP] Embed Pods Frameworks';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -305,14 +305,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BEB56E0CAF877FA9577BF299 /* 📦 Copy Pods Resources */ = {
+		BEB56E0CAF877FA9577BF299 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = '[CP] Copy Pods Resources';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -320,14 +320,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FF15824F61254F4257FD78E7 /* 📦 Check Pods Manifest.lock */ = {
+		FF15824F61254F4257FD78E7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = '[CP] Check Pods Manifest.lock';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/project.pbxproj
+++ b/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/project.pbxproj
@@ -95,12 +95,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5CAF4FFA1CC1125900B44520 /* Build configuration list for PBXNativeTarget "Vendored Framework Example" */;
 			buildPhases = (
-				25E42247833F1966ABF463BE /* 📦 Check Pods Manifest.lock */,
+				25E42247833F1966ABF463BE /* [CP] Check Pods Manifest.lock */,
 				5CAF4FE41CC1125900B44520 /* Sources */,
 				5CAF4FE51CC1125900B44520 /* Frameworks */,
 				5CAF4FE61CC1125900B44520 /* Resources */,
-				4697BF2DD055B93C3DE0E375 /* 📦 Embed Pods Frameworks */,
-				9C2933733E94154FB1F30218 /* 📦 Copy Pods Resources */,
+				4697BF2DD055B93C3DE0E375 /* [CP] Embed Pods Frameworks */,
+				9C2933733E94154FB1F30218 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -158,14 +158,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		25E42247833F1966ABF463BE /* 📦 Check Pods Manifest.lock */ = {
+		25E42247833F1966ABF463BE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = '[CP] Check Pods Manifest.lock';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -173,14 +173,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		4697BF2DD055B93C3DE0E375 /* 📦 Embed Pods Frameworks */ = {
+		4697BF2DD055B93C3DE0E375 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = '[CP] Embed Pods Frameworks';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -188,14 +188,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9C2933733E94154FB1F30218 /* 📦 Copy Pods Resources */ = {
+		9C2933733E94154FB1F30218 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = '[CP] Copy Pods Resources';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
+++ b/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
@@ -200,13 +200,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A129F8F71B2CA81700EBC1DD /* Build configuration list for PBXNativeTarget "watchOSsample" */;
 			buildPhases = (
-				1E8987D060C89B71B6F2E504 /* 📦 Check Pods Manifest.lock */,
+				1E8987D060C89B71B6F2E504 /* [CP] Check Pods Manifest.lock */,
 				A129F8BC1B2CA81600EBC1DD /* Sources */,
 				A129F8BD1B2CA81600EBC1DD /* Frameworks */,
 				A129F8BE1B2CA81600EBC1DD /* Resources */,
 				A129F8F61B2CA81700EBC1DD /* Embed Watch Content */,
-				B55D105F75FDCEAD4A12BE64 /* 📦 Embed Pods Frameworks */,
-				1E232F64274BFFA8F587E155 /* 📦 Copy Pods Resources */,
+				B55D105F75FDCEAD4A12BE64 /* [CP] Embed Pods Frameworks */,
+				1E232F64274BFFA8F587E155 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -240,12 +240,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A865B2891CAF18FF0031EFC6 /* Build configuration list for PBXNativeTarget "watchOSsample WatchKit Extension" */;
 			buildPhases = (
-				80D5F6FDF4441AF84D902FA8 /* 📦 Check Pods Manifest.lock */,
+				80D5F6FDF4441AF84D902FA8 /* [CP] Check Pods Manifest.lock */,
 				A865B2761CAF18FF0031EFC6 /* Sources */,
 				A865B2771CAF18FF0031EFC6 /* Frameworks */,
 				A865B2781CAF18FF0031EFC6 /* Resources */,
-				766BB1279F3F20E30F8D82AC /* 📦 Embed Pods Frameworks */,
-				9404B5E651690A16E40B8F95 /* 📦 Copy Pods Resources */,
+				766BB1279F3F20E30F8D82AC /* [CP] Embed Pods Frameworks */,
+				9404B5E651690A16E40B8F95 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -328,14 +328,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1E232F64274BFFA8F587E155 /* 📦 Copy Pods Resources */ = {
+		1E232F64274BFFA8F587E155 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = '[CP] Copy Pods Resources';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -343,14 +343,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-watchOSsample/Pods-watchOSsample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1E8987D060C89B71B6F2E504 /* 📦 Check Pods Manifest.lock */ = {
+		1E8987D060C89B71B6F2E504 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = '[CP] Check Pods Manifest.lock';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -358,14 +358,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		766BB1279F3F20E30F8D82AC /* 📦 Embed Pods Frameworks */ = {
+		766BB1279F3F20E30F8D82AC /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = '[CP] Embed Pods Frameworks';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -373,14 +373,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-watchOSsample WatchKit Extension/Pods-watchOSsample WatchKit Extension-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		80D5F6FDF4441AF84D902FA8 /* 📦 Check Pods Manifest.lock */ = {
+		80D5F6FDF4441AF84D902FA8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = '[CP] Check Pods Manifest.lock';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -388,14 +388,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		9404B5E651690A16E40B8F95 /* 📦 Copy Pods Resources */ = {
+		9404B5E651690A16E40B8F95 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = '[CP] Copy Pods Resources';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -403,14 +403,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-watchOSsample WatchKit Extension/Pods-watchOSsample WatchKit Extension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B55D105F75FDCEAD4A12BE64 /* 📦 Embed Pods Frameworks */ = {
+		B55D105F75FDCEAD4A12BE64 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = '[CP] Embed Pods Frameworks';
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -11,7 +11,7 @@ module Pod
 
         # @return [String] the PACKAGE emoji to use as prefix for every build phase aded to the user project
         #
-        BUILD_PHASE_PREFIX = "\u{1F4E6} ".freeze
+        BUILD_PHASE_PREFIX = '[CP] '.freeze
 
         # @return [String] the name of the check manifest phase
         #
@@ -215,8 +215,7 @@ module Pod
         def create_or_update_build_phase(target, phase_name, phase_class = Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
           prefixed_phase_name = BUILD_PHASE_PREFIX + phase_name
           build_phases = target.build_phases.grep(phase_class)
-          build_phases.find { |phase| phase.name == prefixed_phase_name } ||
-            build_phases.find { |phase| phase.name == phase_name }.tap { |p| p.name = prefixed_phase_name if p } ||
+          build_phases.find { |phase| phase.name && phase.name.end_with?(phase_name) }.tap { |p| p.name = prefixed_phase_name if p } ||
             target.project.new(phase_class).tap do |phase|
               UI.message("Adding Build Phase '#{prefixed_phase_name}' to project.") do
                 phase.name = prefixed_phase_name


### PR DESCRIPTION
Some tools not handling emojis properly might alter the Build Phase names, making it change the 📦 emoji into some <Uxxx> sequence instead.
This patch intend to workaround that issue those tools generate, so that users of such tools have a less painful experience with CocoaPods until that Unicode issue is fixed at its source in AppCode et al.

--- 

This PR is **open for discussion** as the debate is still not finished about if we should accept workarounds like that… to fix bugs that are in fact in other softwares like AppCode and not CocoaPods issues per se.

_(Specs and CHANGELOG will be added only if we agree on this workaround and consider merging)_