### PR TITLE
[Cache] Use `git ls-remote` to skip full clones for branch dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Peter Ryszkiewicz](https://github.com/pRizz)
   [#5414](https://github.com/CocoaPods/CocoaPods/pull/5414)
 
+* Use `git ls-remote` to skip full clones for branch dependencies.  
+  [Juan Civile](https://github.com/champo)
+  [#5376](https://github.com/CocoaPods/CocoaPods/issues/5376)
+
+
 ##### Bug Fixes
 
 * Fix installing pods with `use_frameworks` when deduplication is disabled.  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-downloader.git
-  revision: 272c56dbde497a48a7310098989ed25d0cc0bc6d
+  revision: 0803d2280c14347e03cc5753efdca04e3697552c
   branch: master
   specs:
     cocoapods-downloader (1.0.0)

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -124,6 +124,7 @@ module Pod
       def cached_pod(request)
         cached_spec = cached_spec(request)
         path = path_for_pod(request)
+
         return unless cached_spec && path.directory?
         spec = request.spec || cached_spec
         Response.new(path, spec, request.params)

--- a/spec/unit/downloader_spec.rb
+++ b/spec/unit/downloader_spec.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Pod
+  describe Downloader do
+    before do
+      @target_path = Pathname.new(Dir.mktmpdir)
+
+      source = { :git => SpecHelper.fixture('banana-lib'), :branch => 'master' }
+      @request = Downloader::Request.new(:name => 'BananaLib', :params => source)
+    end
+
+    after do
+      @target_path.rmtree if @target_path.directory?
+    end
+
+    it 'preprocesses requests' do
+      Downloader.expects(:preprocess_request).returns(@request)
+      Downloader.download(@request, @target_path, :can_cache => false)
+    end
+  end
+end


### PR DESCRIPTION
This adds the posibility of caches hits for git branch dependencies.
Previously, since pods didn't know the commit the branch points it
always did a full clone of the repo. Using `ls-remote` we can check the
commit the branch points to and reuse cached version of the pods if
available.

Related to https://github.com/CocoaPods/CocoaPods/issues/5376

## TODO

- [x] Merge https://github.com/CocoaPods/cocoapods-downloader/pull/57
- [x] Merge https://github.com/CocoaPods/cocoapods-integration-specs/pull/71
- [x] Update changelog
- [x] Tests