### PR TITLE
Add a note to include a CHANGELOG entry in a PR #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -9,6 +9,24 @@
   end
 end
 
+# Ensure a clean commits history
 if commits.any? { |c| c.message =~ /^Merge branch '#{branch_for_merge}'/ }
   fail("Please rebase to get rid of the merge commits in this PR")
+end
+
+# Request a CHANGELOG entry, and give an example
+has_app_changes = !modified_files.grep(/lib/).empty?
+if !modified_files.include?("CHANGELOG.md") && has_app_changes
+  fail("Please include a CHANGELOG entry to credit yourself! \nYou can find it at [CHANGELOG.md](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md).", sticky: false)
+  markdown <<-MARKDOWN
+Here's an example of your CHANGELOG entry:
+
+```markdown
+* #{pr.title}#{' '}
+  [#{pr_author}](https://github.com/#{pr_author})
+  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
+```
+
+*note*: There are two invisible spaces after the entry's text.
+MARKDOWN
 end


### PR DESCRIPTION
Adds an example entry for the CHANGELOG entry when one isn't provided in a PR, this PR should initially fail with an example of what it looks like.