### PR TITLE
[XCConfigHelper] Add the ability to inhibit swift warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add the ability to inhibit swift warnings.
+  [Peter Ryszkiewicz](https://github.com/pRizz)
+  [#5414](https://github.com/CocoaPods/CocoaPods/pull/5414)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -284,7 +284,7 @@ module Pod
         def self.add_language_specific_settings(target, xcconfig)
           if target.uses_swift?
             other_swift_flags = ['$(inherited)', quote(%w(-D COCOAPODS))]
-            other_swift_flags += [quote(%w(-suppress-warnings))] if target.try(:inhibit_warnings?)
+            other_swift_flags << quote(%w(-suppress-warnings)) if target.try(:inhibit_warnings?)
             build_settings = { 'OTHER_SWIFT_FLAGS' => other_swift_flags.join(' ') }
             xcconfig.merge!(build_settings)
           end

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -287,7 +287,7 @@ module Pod
               'OTHER_SWIFT_FLAGS' => [
                 '$(inherited)',
                 quote(%w(-D COCOAPODS)),
-                (quote(["-suppress-warnings"]) if target.try(:inhibit_warnings?) || false),
+                (quote(%w(-suppress-warnings)) if target.try(:inhibit_warnings?) || false),
               ].compact.join(' '),
             }
             xcconfig.merge!(build_settings)

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -284,7 +284,11 @@ module Pod
         def self.add_language_specific_settings(target, xcconfig)
           if target.uses_swift?
             build_settings = {
-              'OTHER_SWIFT_FLAGS' => '$(inherited) ' + quote(%w(-D COCOAPODS)),
+              'OTHER_SWIFT_FLAGS' => [
+                '$(inherited)',
+                quote(%w(-D COCOAPODS)),
+                (quote(["-suppress-warnings"]) if target.try(:inhibit_warnings?) || false),
+              ].compact.join(' '),
             }
             xcconfig.merge!(build_settings)
           end

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -284,7 +284,7 @@ module Pod
         def self.add_language_specific_settings(target, xcconfig)
           if target.uses_swift?
             other_swift_flags = ['$(inherited)', quote(%w(-D COCOAPODS))]
-            other_swift_flags += [quote(%w(-suppress-warnings))] if target.try(:inhibit_warnings?) || false
+            other_swift_flags += [quote(%w(-suppress-warnings))] if target.try(:inhibit_warnings?)
             build_settings = { 'OTHER_SWIFT_FLAGS' => other_swift_flags.join(' ') }
             xcconfig.merge!(build_settings)
           end

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -283,13 +283,9 @@ module Pod
         #
         def self.add_language_specific_settings(target, xcconfig)
           if target.uses_swift?
-            build_settings = {
-              'OTHER_SWIFT_FLAGS' => [
-                '$(inherited)',
-                quote(%w(-D COCOAPODS)),
-                (quote(%w(-suppress-warnings)) if target.try(:inhibit_warnings?) || false),
-              ].compact.join(' '),
-            }
+            other_swift_flags = ['$(inherited)', quote(%w(-D COCOAPODS))]
+            other_swift_flags += [quote(%w(-suppress-warnings))] if target.try(:inhibit_warnings?) || false
+            build_settings = { 'OTHER_SWIFT_FLAGS' => other_swift_flags.join(' ') }
             xcconfig.merge!(build_settings)
           end
         end

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -194,27 +194,27 @@ module Pod
         end
 
         #---------------------------------------------------------------------#
-        
+
         describe '::add_language_specific_settings' do
           it 'does not add OTHER_SWIFT_FLAGS to the xcconfig if the target does not use swift' do
             target = stub(:uses_swift? => false)
-            xcconfig = Xcodeproj::Config.new()
+            xcconfig = Xcodeproj::Config.new
             @sut.add_language_specific_settings(target, xcconfig)
             other_swift_flags = xcconfig.to_hash['OTHER_SWIFT_FLAGS']
-            other_swift_flags.should == nil
+            other_swift_flags.should.nil?
           end
-          
+
           it 'does not add the -suppress-warnings flag to the xcconfig if the target uses swift, but does not inhibit warnings' do
             target = stub(:uses_swift? => true, :inhibit_warnings? => false)
-            xcconfig = Xcodeproj::Config.new()
+            xcconfig = Xcodeproj::Config.new
             @sut.add_language_specific_settings(target, xcconfig)
             other_swift_flags = xcconfig.to_hash['OTHER_SWIFT_FLAGS']
             other_swift_flags.should.not.include?('-suppress-warnings')
           end
-          
+
           it 'adds the -suppress-warnings flag to the xcconfig if the target uses swift and inhibits warnings' do
             target = stub(:uses_swift? => true, :inhibit_warnings? => true)
-            xcconfig = Xcodeproj::Config.new()
+            xcconfig = Xcodeproj::Config.new
             @sut.add_language_specific_settings(target, xcconfig)
             other_swift_flags = xcconfig.to_hash['OTHER_SWIFT_FLAGS']
             other_swift_flags.should.include?('-suppress-warnings')

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -194,6 +194,34 @@ module Pod
         end
 
         #---------------------------------------------------------------------#
+        
+        describe '::add_language_specific_settings' do
+          it 'does not add OTHER_SWIFT_FLAGS to the xcconfig if the target does not use swift' do
+            target = stub(:uses_swift? => false)
+            xcconfig = Xcodeproj::Config.new()
+            @sut.add_language_specific_settings(target, xcconfig)
+            other_swift_flags = xcconfig.to_hash['OTHER_SWIFT_FLAGS']
+            other_swift_flags.should == nil
+          end
+          
+          it 'does not add the -suppress-warnings flag to the xcconfig if the target uses swift, but does not inhibit warnings' do
+            target = stub(:uses_swift? => true, :inhibit_warnings? => false)
+            xcconfig = Xcodeproj::Config.new()
+            @sut.add_language_specific_settings(target, xcconfig)
+            other_swift_flags = xcconfig.to_hash['OTHER_SWIFT_FLAGS']
+            other_swift_flags.should.not.include?('-suppress-warnings')
+          end
+          
+          it 'adds the -suppress-warnings flag to the xcconfig if the target uses swift and inhibits warnings' do
+            target = stub(:uses_swift? => true, :inhibit_warnings? => true)
+            xcconfig = Xcodeproj::Config.new()
+            @sut.add_language_specific_settings(target, xcconfig)
+            other_swift_flags = xcconfig.to_hash['OTHER_SWIFT_FLAGS']
+            other_swift_flags.should.include?('-suppress-warnings')
+          end
+        end
+
+        #---------------------------------------------------------------------#
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability to inhibit swift warnings for pod targets. This is related to [issue 5290](https://github.com/CocoaPods/CocoaPods/issues/5290).

Even without my changes, many unit tests fail locally. Why is that?