### PR TITLE
Add a license type to generated acknowledgements file in plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add a license type to generated acknowledgements file in plist.  
+  [Naoto Kaneko](https://github.com/naoty)
+  [#5436](https://github.com/CocoaPods/CocoaPods/pull/5436)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/acknowledgements/plist.rb
+++ b/lib/cocoapods/generator/acknowledgements/plist.rb
@@ -37,6 +37,7 @@ module Pod
             :Type => 'PSGroupSpecifier',
             :Title => sanitize_encoding(spec.name),
             :FooterText => sanitize_encoding(license),
+            :License => spec.license[:type],
           }
         end
       end

--- a/lib/cocoapods/generator/acknowledgements/plist.rb
+++ b/lib/cocoapods/generator/acknowledgements/plist.rb
@@ -37,7 +37,7 @@ module Pod
             :Type => 'PSGroupSpecifier',
             :Title => sanitize_encoding(spec.name),
             :FooterText => sanitize_encoding(license),
-            :License => spec.license[:type],
+            :License => sanitize_encoding(spec.license[:type]),
           }
         end
       end

--- a/spec/unit/generator/acknowledgements/plist_spec.rb
+++ b/spec/unit/generator/acknowledgements/plist_spec.rb
@@ -8,6 +8,7 @@ describe Pod::Generator::Plist do
     @spec = @file_accessor.spec
     @generator = Pod::Generator::Plist.new([@file_accessor])
     @spec.stubs(:name).returns('POD_NAME')
+    @spec.stubs(:license).returns(:type => 'MIT')
     @generator.stubs(:license_text).returns('LICENSE_TEXT')
   end
 
@@ -24,6 +25,7 @@ describe Pod::Generator::Plist do
       :Type => 'PSGroupSpecifier',
       :Title => 'POD_NAME',
       :FooterText => 'LICENSE_TEXT',
+      :License => 'MIT',
     }
   end
 
@@ -34,6 +36,7 @@ describe Pod::Generator::Plist do
       :Type => 'PSGroupSpecifier',
       :Title => 'POD_NAME',
       :FooterText => license_text,
+      :License => 'MIT',
     }
   end
 


### PR DESCRIPTION
This pull request adds a license, such as `MIT` or `Commercial`, to generated `Pods-{Project}-acknowledgements.plist`. I send this PR because I want to filter some licenses by their types. It is useful to show licenses only for open libraries, not private libraries.