### PR TITLE
[Gemfile] Add flag to skip unreleased versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
+SKIP_UNRELEASED_VERSIONS = false
+
 # Declares a dependency to the git repo of CocoaPods gem. This declaration is
 # compatible with the local git repos feature of Bundler.
 #
 def cp_gem(name, repo_name, branch = 'master', path: false)
+  return gem name if SKIP_UNRELEASED_VERSIONS
   opts = if path
            { :path => "../#{repo_name}" }
          else


### PR DESCRIPTION
This can be set to true on release branches, so that only versions of the gems which were released and pushed to RubyGems are considered.

/c @segiddins 