### PR TITLE
Added rake task to check submodules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,14 @@ begin
     title 'Building the gem'
   end
 
+  task :check_submodules do
+    title 'Ensuring submodules are initialized'
+    submodule_help_msg = 'Run git submodule update --init --recursive to ensure submodules are initialized'
+    raise submodule_help_msg if `git submodule status`.split("\n").any? do |line|
+      line.start_with? '-'
+    end
+  end
+
   require 'bundler/gem_tasks'
   require 'bundler/setup'
 
@@ -287,7 +295,7 @@ begin
   #-----------------------------------------------------------------------------#
 
   desc 'Run all specs'
-  task :spec => 'spec:all'
+  task :spec => [:check_submodules, 'spec:all']
 
   task :default => :spec
 


### PR DESCRIPTION
Fixes #5458:

- check_submodules task verifies submodules are initialized by checking the output of `git submodule status` (as far as I can tell, there aren't ways of doing this that rely on an exit code that aren't more complex)
- spec task depends on this task