### PR TITLE
use `pr_title` instead of `pr.title` in Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -22,7 +22,7 @@ if !modified_files.include?("CHANGELOG.md") && has_app_changes
 Here's an example of your CHANGELOG entry:
 
 ```markdown
-* #{pr.title}#{' '}
+* #{pr_title}#{' '}
   [#{pr_author}](https://github.com/#{pr_author})
   [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
 ```


### PR DESCRIPTION
Danger was crashing because `pr` was undefined, looks like this was a typo for `pr_title`