### PR TITLE
[PodsProject] Set the `SWIFT_VERSION` flag

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -138,6 +138,7 @@ module Pod
               build_configuration.build_settings['TVOS_DEPLOYMENT_TARGET'] = tvos_deployment_target.to_s if tvos_deployment_target
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
+              build_configuration.build_settings['SWIFT_VERSION'] = '2.3'
             end
           end
         end


### PR DESCRIPTION
This commit adds the `SWIFT_VERSION` flag to pod build_configurations to
allow for Xcode 8 compatibility with existing pods. Until Swift 3.0 is
clearly defined and final, Swift 3.0 can be set with a post_install hook
in the Podfile such as:

```
post_install do |installer|
  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['SWIFT_VERSION'] = '3.0'
    end
  end
end
```

closes https://github.com/CocoaPods/CocoaPods/issues/5521