### PR TITLE
[repo/push] --use-json to convert podspecs to JSON format when pushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Use `git ls-remote` to skip full clones for branch dependencies.  
   [Juan Civile](https://github.com/champo)
   [#5376](https://github.com/CocoaPods/CocoaPods/issues/5376)
-
+  
+* [repo/push] --use-json to convert podspecs to JSON format when pushing  
+  [Mark Schall](https://github.com/maschall)
+  [#5568](https://github.com/CocoaPods/CocoaPods/pull/5568)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -31,6 +31,7 @@ module Pod
             ['--no-private', 'Lint includes checks that apply only to public repos'],
             ['--commit-message="Fix bug in pod"', 'Add custom commit message. ' \
             'Opens default editor if no commit message is specified.'],
+            ['--use-json', 'Push JSON spec to repo'],
           ].concat(super)
         end
 
@@ -45,6 +46,7 @@ module Pod
           @private = argv.flag?('private', true)
           @message = argv.option('commit-message')
           @commit_message = argv.flag?('commit-message', false)
+          @use_json = argv.flag?('use-json')
           super
         end
 
@@ -177,9 +179,16 @@ module Pod
             else
               message = "[Add] #{spec}"
             end
-
             FileUtils.mkdir_p(output_path)
-            FileUtils.cp(spec_file, output_path)
+            
+            if @use_json
+              json_file_name = "#{spec.name}.podspec.json"
+              json_file = File.join(output_path, json_file_name)
+              File.open(json_file, 'w') { |file| file.write(spec.to_pretty_json) }
+            else
+              FileUtils.cp(spec_file, output_path)
+            end
+            
             Dir.chdir(repo_dir) do
               # only commit if modified
               if git!('status', '--porcelain').include?(spec.name)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -180,7 +180,7 @@ module Pod
               message = "[Add] #{spec}"
             end
             FileUtils.mkdir_p(output_path)
-            
+
             if @use_json
               json_file_name = "#{spec.name}.podspec.json"
               json_file = File.join(output_path, json_file_name)
@@ -188,7 +188,7 @@ module Pod
             else
               FileUtils.cp(spec_file, output_path)
             end
-            
+
             Dir.chdir(repo_dir) do
               # only commit if modified
               if git!('status', '--porcelain').include?(spec.name)

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -98,8 +98,8 @@ module Pod
       e.message.should.match(/repo.*not clean/)
       (@upstream + 'PushTest/1.4/PushTest.podspec').should.not.exist?
     end
-
-    it 'successfully pushes a spec' do
+    
+    it 'generate a message for commit' do
       cmd = command('repo', 'push', 'master')
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
       cmd.expects(:validate_podspec_files).returns(true)
@@ -107,8 +107,24 @@ module Pod
       Pod::UI.output.should.include('[Add] PushTest (1.4)')
       Pod::UI.output.should.include('[Fix] JSONKit (1.4)')
       Pod::UI.output.should.include('[No change] BananaLib (1.0)')
+    end
+
+    it 'successfully pushes a spec' do
+      cmd = command('repo', 'push', 'master')
+      Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
+      cmd.expects(:validate_podspec_files).returns(true)
+      Dir.chdir(temporary_directory) { cmd.run }
       Dir.chdir(@upstream) { `git checkout master -q` }
       (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
+    end
+    
+    it 'successfully pushes converted JSON podspec' do
+      cmd = command('repo', 'push', 'master', '--use-json')
+      Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
+      cmd.expects(:validate_podspec_files).returns(true)
+      Dir.chdir(temporary_directory) { cmd.run }
+      Dir.chdir(@upstream) { `git checkout master -q` }
+      (@upstream + 'PushTest/1.4/PushTest.podspec.json').read.should.include('PushTest')
     end
 
     it 'initializes with default sources if no custom sources specified' do

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -98,7 +98,7 @@ module Pod
       e.message.should.match(/repo.*not clean/)
       (@upstream + 'PushTest/1.4/PushTest.podspec').should.not.exist?
     end
-    
+
     it 'generate a message for commit' do
       cmd = command('repo', 'push', 'master')
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
@@ -117,7 +117,7 @@ module Pod
       Dir.chdir(@upstream) { `git checkout master -q` }
       (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
     end
-    
+
     it 'successfully pushes converted JSON podspec' do
       cmd = command('repo', 'push', 'master', '--use-json')
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }


### PR DESCRIPTION
🌈

We use a private repository for podspecs and found that when we changed to 1.0.1 cocoapods we had issues with Ruby DSLs that were old.

Following the trunk, we decided to convert our DSL to JSON format when pushing to our repository.

We thought that others could use the same thing.