### PR TITLE
Set 'Allow app extension API only' for Messages extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Mark Schall](https://github.com/maschall)
   [#5568](https://github.com/CocoaPods/CocoaPods/pull/5568)
 
+* Set 'Allow app extension API only' for Messages extensions.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#5558](https://github.com/CocoaPods/CocoaPods/issues/5558)
+
+
 ##### Bug Fixes
 
 * Fix local pod platform conflict error message.  

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -185,7 +185,7 @@ module Pod
           frameworks_group = project.frameworks_group
           aggregate_targets.each do |aggregate_target|
             is_app_extension = !(aggregate_target.user_targets.map(&:symbol_type) &
-                                 [:app_extension, :watch_extension, :watch2_extension, :tv_extension]).empty?
+                                 [:app_extension, :watch_extension, :watch2_extension, :tv_extension, :messages_extension]).empty?
             is_app_extension ||= aggregate_target.user_targets.any? { |ut| ut.common_resolved_build_setting('APPLICATION_EXTENSION_API_ONLY') == 'YES' }
 
             aggregate_target.pod_targets.each do |pod_target|

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -209,6 +209,10 @@ module Pod
               test_extension_target(:tv_extension)
             end
 
+            it 'configures APPLICATION_EXTENSION_API_ONLY for Messages extension targets' do
+              test_extension_target(:messages_extension)
+            end
+
             it 'configures APPLICATION_EXTENSION_API_ONLY for targets where the user target has it set' do
               mock_user_target = mock('UserTarget', :symbol_type => :application)
               mock_user_target.expects(:common_resolved_build_setting).with('APPLICATION_EXTENSION_API_ONLY').returns('YES')


### PR DESCRIPTION
Fixes #5558 

Depends on CocoaPods/Xcodeproj#390 to actually work in practice.