### PR TITLE
[repo/push] allow URLs for pushing to private repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Boris Bügling](https://github.com/neonichu)
   [#5558](https://github.com/CocoaPods/CocoaPods/issues/5558)
 
+* Accept `pod repo push` with URL instead of only repo name  
+  [Mark Schall](https://github.com/maschall)
+  [#5572](https://github.com/CocoaPods/CocoaPods/pull/5572)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -39,7 +39,10 @@ module Pod
           @allow_warnings = argv.flag?('allow-warnings')
           @local_only = argv.flag?('local-only')
           @repo = argv.shift_argument
-          @source = config.sources_manager.sources([@repo]).first unless @repo.nil?
+          begin
+            @source = config.sources_manager.source_with_name_or_url(@repo) unless @repo.nil?
+          rescue
+          end
           @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).join(',')).split(',')
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
@@ -52,8 +55,8 @@ module Pod
 
         def validate!
           super
-          help! 'A spec-repo name is required.' unless @repo
-          unless @source.repo.directory?
+          help! 'A spec-repo name or url is required.' unless @repo
+          unless @source && @source.repo.directory?
             raise Informative,
                   "Unable to find the `#{@repo}` repo. " \
                   'If it has not yet been cloned, add it via `pod repo add`.'

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -39,10 +39,7 @@ module Pod
           @allow_warnings = argv.flag?('allow-warnings')
           @local_only = argv.flag?('local-only')
           @repo = argv.shift_argument
-          begin
-            @source = config.sources_manager.source_with_name_or_url(@repo) unless @repo.nil?
-          rescue
-          end
+          @source = source_for_repo
           @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).join(',')).split(',')
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
@@ -244,6 +241,18 @@ module Pod
         #
         def count
           podspec_files.count
+        end
+
+        # Returns source for @repo
+        #
+        # @note If URL is invalid or repo doesn't exist, validate! will throw the error
+        #
+        # @return [Source]
+        #
+        def source_for_repo
+          config.sources_manager.source_with_name_or_url(@repo) unless @repo.nil?
+        rescue
+          nil
         end
 
         #---------------------------------------------------------------------#

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -16,7 +16,7 @@ module Pod
         e.message.should.match(/Unable to find the `missing_repo` repo/)
       end
     end
-    
+
     it "complains if it can't get repo url" do
       Dir.chdir(fixture('banana-lib')) do
         Command::Repo::Add.any_instance.stubs(:clone_repo)
@@ -126,7 +126,7 @@ module Pod
       Dir.chdir(@upstream) { `git checkout master -q` }
       (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
     end
-    
+
     it 'successfully pushes a spec to URL' do
       cmd = command('repo', 'push', @upstream)
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }


### PR DESCRIPTION
🌈

This should be useful to developers using CI environments to publish to private repositories.  

Currently you have to have a repo added locally in order to push to it using `pod repo add PrivateRepo http://private.com/repo.git`, however executing this more than once will cause an error that would need to be ignored or more complicated setup.

You still need the machine to have access rights to push to that private repositories, but this alleviates a struggle for deploying.

(also I know this will likely conflict with https://github.com/CocoaPods/CocoaPods/pull/5568 when merged, but should be minor updates to fix.)