### PR TITLE
Require active_support in xcconfig_helper

### DIFF
--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/try'
+
 module Pod
   module Generator
     module XCConfig


### PR DESCRIPTION
Fixes a bug on master where active_support doesn't get loaded for `try` during pod install.
https://github.com/CocoaPods/CocoaPods/issues/5599#issuecomment-230892216

I don't think this needs a changelog entry because it's something that's only broken in master?
