### PR TITLE
Avoid use of `activesupport` version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#5052](https://github.com/CocoaPods/CocoaPods/issues/5052)
 
+* Avoid use of `activesupport` version 5 to stay compatible with macOS system Ruby.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#5602](https://github.com/CocoaPods/CocoaPods/issues/5602)
+
 * Fix installing pods with `use_frameworks` when deduplication is disabled.  
   [Samuel Giddins](https://github.com/segiddins)
   [#5481](https://github.com/CocoaPods/CocoaPods/issues/5481)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ PATH
   remote: .
   specs:
     cocoapods (1.0.1)
-      activesupport (>= 4.0.2)
+      activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.0, < 2.0)
       cocoapods-core (= 1.0.1)
       cocoapods-deintegrate (>= 1.0.0, < 2.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -40,7 +40,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'molinillo',             '~> 0.5.0'
   s.add_runtime_dependency 'xcodeproj',             '>= 1.1.0', '< 2.0'
 
-  s.add_runtime_dependency 'activesupport', '>= 4.0.2'
+  ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
+  s.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'
   s.add_runtime_dependency 'colored',       '~> 1.2'
   s.add_runtime_dependency 'escape',        '~> 0.0.4'
   s.add_runtime_dependency 'fourflusher',   '~> 1.0.1'


### PR DESCRIPTION
Version 5 of `activesupport` requires Ruby version >= 2.2.2 which breaks fresh installations using system Ruby, which is still 2.0, even on macOS 10.12.

Supersedes CocoaPods/Xcodeproj#393

It makes more sense to do this in CP directly, because almost nobody will need to use it with `activesupport` 5 whereas other consumers of `xcodeproj` can still choose the newer version freely.