### PR TITLE
Hash scope suffixes if they are over 50 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Hash scope suffixes if they are over 50 characters to prevent file paths from being too long. 
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#5491](https://github.com/CocoaPods/CocoaPods/issues/5491)
 
 
 ## 1.1.0.beta.1 (2016-07-11)

--- a/lib/cocoapods/installer/analyzer/pod_variant_set.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant_set.rb
@@ -23,7 +23,11 @@ module Pod
         #
         def scope_suffixes
           return { variants.first => nil } if variants.count == 1
-          scope_by_specs
+          Hash[scope_by_specs.map do |variant, scope|
+            require 'digest'
+            scope = Digest::MD5.hexdigest(scope)[0..7] if !scope.nil? && scope.length >= 50
+            [variant, scope]
+          end]
         end
 
         # Groups the collection by result of the block.

--- a/spec/unit/installer/analyzer/pod_variant_set_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_set_spec.rb
@@ -100,6 +100,22 @@ module Pod
         )
       end
 
+      it 'hashes scopes that are longer than 50 characters' do
+        @bar_subspec.name = 'matryoshka/ThisIsAReallyLongSubspecName'
+        variants = PodVariantSet.new([
+          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec, @bar_subspec], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.osx),
+        ])
+        variants.scope_suffixes.values.should == %w(
+          iOS
+          OSX
+          c4ca5113
+          .default-matryoshka_ThisIsAReallyLongSubspecName
+        )
+      end
+
       it 'returns scopes by versioned platform names and subspec names if they qualify' do
         variants = PodVariantSet.new([
           PodVariant.new([@root_spec, @default_subspec], Platform.new(:ios, '7.0')),


### PR DESCRIPTION
supersedes https://github.com/CocoaPods/Core/pull/344
actually closes https://github.com/CocoaPods/CocoaPods/issues/5491

