### PR TITLE
Fix for lint codesign failure on macOS projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Remove the `const_missing` hack for `Pod::SourcesManager`.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Fixed code signing issue causing lint failure on macOS.  
+  [Paul Cantrell](https://github.com/pcantrell)
+  [#5645](https://github.com/CocoaPods/CocoaPods/issues/5645)
 
 ## 1.2.0.beta.1 (2016-10-28)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -766,6 +766,8 @@ module Pod
       require 'fourflusher'
       command = ['clean', 'build', '-workspace', File.join(validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release']
       case consumer.platform_name
+      when :osx, :macos
+        command += %w(CODE_SIGN_IDENTITY=)
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)
         command += Fourflusher::SimControl.new.destination(:oldest, 'iOS', deployment_target)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -435,7 +435,8 @@ module Pod
         Executable.stubs(:capture_command).with('git', ['config', '--get', 'remote.origin.url'], :capture => :out).returns(['https://github.com/CocoaPods/Specs.git'])
         Executable.stubs(:which).with(:xcrun)
         command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release']
-        Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
+        args = %w(CODE_SIGN_IDENTITY=)
+        Executable.expects(:capture_command).with('xcodebuild', command + args, :capture => :merge).once.returns(['', stub(:success? => true)])
         args = %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator) + Fourflusher::SimControl.new.destination('Apple TV 1080p')
         Executable.expects(:capture_command).with('xcodebuild', command + args, :capture => :merge).once.returns(['', stub(:success? => true)])
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')


### PR DESCRIPTION
`pod spec lint` and `pod trunk push` are both failing for me with the following error:

```
CodeSign /tmp/xcode/DerivedData/App-ecacodmhenqbjqcvnllhxtofynly/Build/Products/Release/Siesta/Siesta.framework/Versions/A
    cd /var/folders/ct/_03srt6h8xj44m00r6bfmd400000gn/T/CocoaPods/Lint/Pods
    export CODESIGN_ALLOCATE=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate

Signing Identity:     "-"

    /usr/bin/codesign --force --sign - --timestamp=none /tmp/xcode/DerivedData/App-ecacodmhenqbjqcvnllhxtofynly/Build/Products/Release/Siesta/Siesta.framework/Versions/A
/tmp/xcode/DerivedData/App-ecacodmhenqbjqcvnllhxtofynly/Build/Products/Release/Siesta/Siesta.framework/Versions/A: code object is not signed at all
In subcomponent: /private/tmp/xcode/DerivedData/App-ecacodmhenqbjqcvnllhxtofynly/Build/Products/Release/Siesta/Siesta.framework/Versions/A/Siesta
Command /usr/bin/codesign failed with exit code 1

** BUILD FAILED **


The following build commands failed:
    CodeSign /tmp/xcode/DerivedData/App-ecacodmhenqbjqcvnllhxtofynly/Build/Products/Release/Siesta/Siesta.framework/Versions/A
(1 failure)
```

The culprit is that `"-"` signing identity. It appears to come not from Cocoapods or the pod being built, but from the empty macOS project generated by Xcode itself. (You can see this by generating a new, empty macOS … er, OS X app yourself from Xcode 7.3.1, without Cocoapods involved at all. The `CODE_SIGN_IDENTITY` of `"-"` shows up in the empty project. This may only be happening on machines that don't have a macOS dev certificate installed.)

While that’s an Apple problem, the Cocoapods validation process relies on Xcode-generated projects, making it impossible to push a pod that contains a macOS target.

This patch overrides the lint app’s broken config on macOS. I’ve verified that [it works](https://cocoapods.org/pods/Siesta/).
