### PR TITLE
WIP: Set Swift version when linting Pods

### DIFF
--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -388,8 +388,15 @@ module Pod
       source_file_ref = app_project.new_group('App', 'App').new_file(source_file)
       app_target = app_project.targets.first
       app_target.add_file_references([source_file_ref])
+      add_swift_version(app_target)
       add_xctest(app_target) if @installer.pod_targets.any? { |pt| pt.spec_consumers.any? { |c| c.frameworks.include?('XCTest') } }
       app_project.save
+    end
+
+    def add_swift_version(app_target)
+      app_target.build_configurations.each do |configuration|
+        configuration.build_settings['SWIFT_VERSION'] = '2.3'
+      end
     end
 
     def add_xctest(app_target)
@@ -445,6 +452,7 @@ module Pod
           next unless native_target = pod_target.native_target
           native_target.build_configuration_list.build_configurations.each do |build_configuration|
             (build_configuration.build_settings['OTHER_CFLAGS'] ||= '$(inherited)') << ' -Wincomplete-umbrella'
+            build_configuration.build_settings['SWIFT_VERSION'] = '2.3' if pod_target.uses_swift?
           end
         end
         if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&


### PR DESCRIPTION
Linting Pods written in Swift is currently not working with Xcode 8 beta 3, because Swift targets without the `SWIFT_VERSION` setting do not even build anymore. Our current strategy of looking at the user project for input also does not work at all for the linter case, because we generate the user project here and also the Pods project is manually generated before the user project.

This PR currently just sets `SWIFT_VERSION` to 2.3 unconditionally, which probably would work for most existing Pods targeting stable versions of Swift, but isn't really a feasible solution.

I see a few potential solutions for this:

1) Default to 2.3 and add a CLI flag `--swift-version` to let users specify a different version for their Pod being used for linting. A variant of this which would make the flag more discoverable would be having no default and instead failing when linting a Swift Pod and forcing the user to always specify the version explicitly.

2) Adding a `swift_version` attribute to the podspec DSL. We have discussed this quite a few times and dismissed it for many good reasons, but I'm still including it here for completeness sake.

3) Try to infer the Swift version, using `swift-update` or compiling the Pod with all the different available toolchains. This seems pretty brittle, because even version 2.2 vs. 2.3 aren't fully source-compatible.

4) Use `.swift-version` files as a way to determine the Swift language version of a Pod.

Personally, I think the first solution is the most feasible one and defaulting to 2.3 should be good enough — we can update the default in due time when Swift 3 becomes the more prevalent version.

cc @mrackwitz @segiddins @DanToml 