### PR TITLE
[Installer] Set codesigning identity for watchos/tvos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Danielle Tomlinson](https://github.com/dantoml)
   [#5491](https://github.com/CocoaPods/CocoaPods/issues/5491)
 
+* Fix codesigning identity on watchOS and tvOS targets.    
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#5686](https://github.com/CocoaPods/CocoaPods/issues/5686)
+
 
 ## 1.1.0.beta.1 (2016-07-11)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -51,13 +51,15 @@ module Pod
           #
           def custom_build_settings
             settings = {
-              'CODE_SIGN_IDENTITY[sdk=iphoneos*]' => '',
-              'MACH_O_TYPE'                       => 'staticlib',
-              'OTHER_LDFLAGS'                     => '',
-              'OTHER_LIBTOOLFLAGS'                => '',
-              'PODS_ROOT'                         => '$(SRCROOT)',
-              'PRODUCT_BUNDLE_IDENTIFIER'         => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
-              'SKIP_INSTALL'                      => 'YES',
+              'CODE_SIGN_IDENTITY[sdk=iphoneos*]'  => '',
+              'CODE_SIGN_IDENTITY[sdk=watchos*]'   => '',
+              'CODE_SIGN_IDENTITY[sdk=appletvos*]' => '',
+              'MACH_O_TYPE'                        => 'staticlib',
+              'OTHER_LDFLAGS'                      => '',
+              'OTHER_LIBTOOLFLAGS'                 => '',
+              'PODS_ROOT'                          => '$(SRCROOT)',
+              'PRODUCT_BUNDLE_IDENTIFIER'          => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
+              'SKIP_INSTALL'                       => 'YES',
             }
             super.merge(settings)
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -51,9 +51,9 @@ module Pod
           #
           def custom_build_settings
             settings = {
+              'CODE_SIGN_IDENTITY[sdk=appletvos*]' => '',
               'CODE_SIGN_IDENTITY[sdk=iphoneos*]'  => '',
               'CODE_SIGN_IDENTITY[sdk=watchos*]'   => '',
-              'CODE_SIGN_IDENTITY[sdk=appletvos*]' => '',
               'MACH_O_TYPE'                        => 'staticlib',
               'OTHER_LDFLAGS'                      => '',
               'OTHER_LIBTOOLFLAGS'                 => '',

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -54,7 +54,11 @@ module Pod
               settings['PRIVATE_HEADERS_FOLDER_PATH'] = ''
               settings['PUBLIC_HEADERS_FOLDER_PATH'] = ''
             end
+
             settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = ''
+            settings['CODE_SIGN_IDENTITY[sdk=watchos*]'] = ''
+            settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'] = ''
+
             if target.swift_version
               settings['SWIFT_VERSION'] = target.swift_version
             end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -55,9 +55,9 @@ module Pod
               settings['PUBLIC_HEADERS_FOLDER_PATH'] = ''
             end
 
+            settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'] = ''
             settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = ''
             settings['CODE_SIGN_IDENTITY[sdk=watchos*]'] = ''
-            settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'] = ''
 
             if target.swift_version
               settings['SWIFT_VERSION'] = target.swift_version

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -90,6 +90,15 @@ module Pod
               end
             end
 
+            it 'sets an empty codesigning identity for iOS/tvOS/watchOS' do
+              @installer.install!
+              @project.targets.first.build_configurations.each do |config|
+                config.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'].should == ''
+                config.build_settings['CODE_SIGN_IDENTITY[sdk=watchos*]'].should == ''
+                config.build_settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'].should == ''
+              end
+            end
+
             #--------------------------------------#
 
             describe 'headers folder paths' do

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -93,9 +93,9 @@ module Pod
             it 'sets an empty codesigning identity for iOS/tvOS/watchOS' do
               @installer.install!
               @project.targets.first.build_configurations.each do |config|
+                config.build_settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'].should == ''
                 config.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'].should == ''
                 config.build_settings['CODE_SIGN_IDENTITY[sdk=watchos*]'].should == ''
-                config.build_settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'].should == ''
               end
             end
 


### PR DESCRIPTION
Set empty codesigning identifiers for the `appletvos` and `watchos` platforms so that they will correctly build with Xcode 8 betas.

closes https://github.com/CocoaPods/CocoaPods/issues/5686
depends on https://github.com/CocoaPods/cocoapods-integration-specs/pull/75