### PR TITLE
Added support for message extensions embedded in messages applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [yanzhiwei147](https://github.com/yanzhiwei147)
   [#5510](https://github.com/CocoaPods/CocoaPods/pull/5510)
 
+* Add support for messages applications
+  [benasher44](https://github.com/benasher44)
+  [#5726](https://github.com/CocoaPods/CocoaPods/pull/5726)
+
 ##### Bug Fixes
 
 * Hash scope suffixes if they are over 50 characters to prevent file paths from being too long. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [yanzhiwei147](https://github.com/yanzhiwei147)
   [#5510](https://github.com/CocoaPods/CocoaPods/pull/5510)
 
-* Add support for messages applications
+* Add support for messages applications.  
   [benasher44](https://github.com/benasher44)
   [#5726](https://github.com/CocoaPods/CocoaPods/pull/5726)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -274,7 +274,7 @@ module Pod
           host_uuids = []
           aggregate_target_user_projects.product(target.user_targets).each do |user_project, user_target|
             host_targets = user_project.host_targets_for_embedded_target(user_target)
-            host_targets.map(&:product_type).each do |product_type|
+            host_targets.map(&:symbol_type).each do |product_type|
               target.add_host_target_product_type(product_type)
             end
             host_uuids += host_targets.map(&:uuid)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -21,9 +21,11 @@ module Pod
         # frameworks are embedded in the output directory / product bundle.
         #
         # @note This does not include :app_extension or :watch_extension because
-        # these types must have their frameworks embedded in their host targets
+        # these types must have their frameworks embedded in their host targets.
+        # For messages extensions, this only applies if it's embedded in a messages
+        # application.
         #
-        EMBED_FRAMEWORK_TARGET_TYPES = [:application, :unit_test_bundle, :ui_test_bundle, :watch2_extension].freeze
+        EMBED_FRAMEWORK_TARGET_TYPES = [:application, :unit_test_bundle, :ui_test_bundle, :watch2_extension, :messages_extension].freeze
 
         # @return [String] the name of the embed frameworks phase
         #
@@ -121,6 +123,7 @@ module Pod
         #       will have their frameworks embedded in their host targets.
         #
         def remove_embed_frameworks_script_phase_from_embedded_targets
+          return unless target.requires_host_target?
           native_targets.each do |native_target|
             if AggregateTarget::EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES.include? native_target.symbol_type
               remove_embed_frameworks_script_phase(native_target)
@@ -201,6 +204,7 @@ module Pod
         #         directory / product bundle.
         #
         def native_targets_to_embed_in
+          return [] if target.requires_host_target?
           native_targets.select do |target|
             EMBED_FRAMEWORK_TARGET_TYPES.include?(target.symbol_type)
           end

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -33,8 +33,8 @@ module Pod
     # Adds product type to the list of product types for the host
     # targets, in which this target will be embedded
     #
-    # @param [Symbol] Product type of a host, in which this target
-    #        will be embedded
+    # @param [Symbol] product_type Product type (symbol representation)
+    #        of a host, in which this target will be embedded
     #
     # @note This is important for messages extensions, since a messages
     #       extension has its frameworks embedded in its host when

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -8,6 +8,9 @@ module Pod
     attr_reader :target_definition
 
     # Product types where the product's frameworks must be embedded in a host target
+    #
+    # @note :messages_extension only applies when it is embedded in an app (as opposed to a messages app)
+    #
     EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :messages_extension, :watch_extension].freeze
 
     # Initialize a new instance
@@ -24,7 +27,7 @@ module Pod
       @search_paths_aggregate_targets = []
       @file_accessors = []
       @xcconfigs = {}
-      @host_target_types = [] # Product types of the host target, if this target is embedded
+      @host_target_types = Set.new # Product types of the host target, if this target is embedded
     end
 
     # Adds product type to the list of product types for the host

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -24,6 +24,21 @@ module Pod
       @search_paths_aggregate_targets = []
       @file_accessors = []
       @xcconfigs = {}
+      @host_target_types = [] # Product types of the host target, if this target is embedded
+    end
+
+    # Adds product type to the list of product types for the host
+    # targets, in which this target will be embedded
+    #
+    # @param [Symbol] Product type of a host, in which this target
+    #        will be embedded
+    #
+    # @note This is important for messages extensions, since a messages
+    #       extension has its frameworks embedded in its host when
+    #       its host is an app but not when it's a messages app
+    #
+    def add_host_target_product_type(product_type)
+      @host_target_types << product_type
     end
 
     # @return [Boolean] True if the user_target's pods are
@@ -39,7 +54,7 @@ module Pod
       return false if user_project.nil?
       symbol_types = user_targets.map(&:symbol_type).uniq
       raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}." unless symbol_types.count == 1
-      EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES.include? symbol_types[0]
+      EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES.include?(symbol_types[0]) && !@host_target_types.include?(:messages_application)
     end
 
     # @return [String] the label for the target.

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -172,6 +172,25 @@ module Pod
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
           phase.nil?.should == false
         end
+        
+        it 'does not add an embed frameworks build phase if the target to integrate is a messages extension for an iOS app' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          target = @target_integrator.send(:native_targets).first
+          target.stubs(:symbol_type).returns(:messages_extension)
+          @target_integrator.integrate!
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == true
+        end
+
+        it 'adds an embed frameworks build phase if the target to integrate is a messages extension for a messages application' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:requires_host_target? => false) # Messages extensions for messages applications do not require a host target
+          target = @target_integrator.send(:native_targets).first
+          target.stubs(:symbol_type).returns(:messages_extension)
+          @target_integrator.integrate!
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == false
+        end
 
         it 'adds an embed frameworks build phase if the target to integrate is a UI Test bundle' do
           @pod_bundle.stubs(:requires_frameworks? => true)
@@ -224,6 +243,31 @@ module Pod
           @target_integrator.integrate!
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
           phase.nil?.should == true
+        end
+
+        it 'removes embed frameworks build phases from messages extension targets that are used in an iOS app' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          @target_integrator.integrate!
+          target = @target_integrator.send(:native_targets).first
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == false
+          target.stubs(:symbol_type).returns(:messages_extension)
+          @target_integrator.integrate!
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == true
+        end
+
+        it 'does not remove embed frameworks build phases from messages extension targets that are used in a messages app' do
+          @pod_bundle.stubs(:requires_frameworks? => true)
+          @target_integrator.integrate!
+          target = @target_integrator.send(:native_targets).first
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == false
+          target.stubs(:symbol_type).returns(:messages_extension)
+          @pod_bundle.stubs(:requires_host_target? => false) # Messages extensions for messages applications do not require a host target
+          @target_integrator.integrate!
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == false
         end
 
         it 'removes embed frameworks build phases from framework targets' do

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -172,7 +172,7 @@ module Pod
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
           phase.nil?.should == false
         end
-        
+
         it 'does not add an embed frameworks build phase if the target to integrate is a messages extension for an iOS app' do
           @pod_bundle.stubs(:requires_frameworks? => true)
           target = @target_integrator.send(:native_targets).first

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -224,6 +224,12 @@ module Pod
             @target.requires_host_target?.should == true
           end
 
+          it 'does not require a host target for messages extension targets embedded in messages applications' do
+            @target.add_host_target_product_type(:messages_application)
+            @target.user_targets.first.stubs(:symbol_type).returns(:messages_extension)
+            @target.requires_host_target?.should == false
+          end
+
           it 'does not require a host target for watch 2 extension targets' do
             @target.user_targets.first.stubs(:symbol_type).returns(:watch2_extension)
             @target.requires_host_target?.should == false


### PR DESCRIPTION
Fixes #5594 

During analysis, we collect information on the product types of the host targets for the embedded targets. Then we use that to help determine if `requires_host_target?` is true or false. The addition here is that it's now false when the host target is a messages application because this type of target does not have a user-modifiable (in the Xcode 8 UI) target dependency list/build phase.