### PR TITLE
Set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES when appropriate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/tonymillion/Reachability.git
 [submodule "spec/cocoapods-integration-specs"]
 	path = spec/cocoapods-integration-specs
-	url = https://github.com/benasher44/cocoapods-integration-specs.git
+	url = https://github.com/CocoaPods/cocoapods-integration-specs.git
 [submodule "spec/fixtures/spec-repos/test_repo"]
 	path = spec/fixtures/spec-repos/test_repo
 	url = https://github.com/CocoaPods/cocoapods-test-specs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/tonymillion/Reachability.git
 [submodule "spec/cocoapods-integration-specs"]
 	path = spec/cocoapods-integration-specs
-	url = https://github.com/CocoaPods/cocoapods-integration-specs.git
+	url = https://github.com/benasher44/cocoapods-integration-specs.git
 [submodule "spec/fixtures/spec-repos/test_repo"]
 	path = spec/fixtures/spec-repos/test_repo
 	url = https://github.com/CocoaPods/cocoapods-test-specs.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   Improved support for framework-only projects.  
   [benasher44](https://github.com/benasher44)
   [#5733](https://github.com/CocoaPods/CocoaPods/pull/5733)
+* Set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES when appropriate.  
+  [benasher44](https://github.com/benasher44)
+  [#5732](https://github.com/CocoaPods/CocoaPods/pull/5732)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -70,6 +70,9 @@ module Pod
           # in embedded targets.
           if !target.requires_host_target? && pod_targets.any?(&:uses_swift?)
             config['EMBEDDED_CONTENT_CONTAINS_SWIFT'] = 'YES'
+            config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
+          else
+            config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
           end
           @xcconfig = Xcodeproj::Config.new(config)
 

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -256,6 +256,22 @@ module Pod
             @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
             @generator.generate.to_hash['EMBEDDED_CONTENT_CONTAINS_SWIFT'].should.be.nil
           end
+
+          it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to YES when there is swift' do
+            @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
+            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].should == 'YES'
+          end
+
+          it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO when there is no swift' do
+            @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(false)
+            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].should == 'NO'
+          end
+
+          it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO when there is swift, but the target is an extension' do
+            @target.stubs(:requires_host_target?).returns(true)
+            @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
+            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].should == 'NO'
+          end
         end
 
         #-----------------------------------------------------------------------#


### PR DESCRIPTION
It looks like we should be setting this new flag in Xcode 8:
- This new flag has made #4203 crop up again.
- According to research done in #5598, this deprecates the old `EMBEDDED_CONTENT_CONTAINS_SWIFT` flag.

This shouldn't be merged until the following is done:
- [x] Someone participating in #4203 has reported submitting to the App Store with this PR using Xcode 8 was successful