### PR TITLE
Improved messages when missing host targets in the Podfile. Improved framework-only dev support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [benasher44](https://github.com/benasher44)
   [#5726](https://github.com/CocoaPods/CocoaPods/pull/5726)
 
+* Improved messaging when missing host targets for embedded targets.
+  Improved support for framework-only projects.  
+  [benasher44](https://github.com/benasher44)
+  [#5733](https://github.com/CocoaPods/CocoaPods/pull/5733)
+
 ##### Bug Fixes
 
 * Hash scope suffixes if they are over 50 characters to prevent file paths from being too long. 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -289,16 +289,16 @@ module Pod
           #  a project for doing framework development. In that case, just warn that
           #  the frameworks that these targets depend on won't be integrated anywhere
           if embedded_targets_missing_hosts_product_types == [:framework]
-            UI.warn 'The Podfile contains framework targets, for which the Podfile does not contain host targets (where these frameworks would be installed).' \
+            UI.warn 'The Podfile contains framework targets, for which the Podfile does not contain host targets (targets which embed the framework).' \
               "\n" \
-              'If this project is for doing framework development, you can ignore this message or add a test target that embeds these frameworks to make this message go away. Otherwise, please add the frameworks\' host targets to the Podfile.'
+              'If this project is for doing framework development, you can ignore this message. Otherwise, add a target to the Podfile that embeds these frameworks to make this message go away (e.g. a test target).'
           else
             target_names = embedded_targets_missing_hosts.map do |target|
               target.name.sub('Pods-', '') # Make the target names more recognizable to the user
             end.join ', '
             raise Informative, "Unable to find host target(s) for #{target_names}. Please add the host targets for the embedded targets to the Podfile." \
                                 "\n" \
-                                'Certain kinds of targets require a host target, in which to be embedded. These are example types of targets that need a host target:' \
+                                'Certain kinds of targets require a host target. A host target is a "parent" target which embeds a "child" target. These are example types of targets that need a host target:' \
                                 "\n- Framework" \
                                 "\n- App Extension" \
                                 "\n- Watch OS 1 Extension" \

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -747,7 +747,7 @@ module Pod
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           should.raise Informative do
             analyzer.analyze
-          end.message.should.match /Unable to find host target\(s\) for Today Extension. Please add the host targets for the embedded targets to the Podfile/
+          end.message.should.match /Unable to find host target\(s\) for Today Extension. Please add the host targets for the embedded targets to the Podfile\./
         end
 
         it 'warns when using a Podfile for framework-only projects' do
@@ -762,7 +762,7 @@ module Pod
           end
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           analyzer.analyze
-          UI.warnings.should.match /The Podfile contains framework targets, for which the Podfile does not contain host targets \(where these frameworks would be installed\)\./
+          UI.warnings.should.match /The Podfile contains framework targets, for which the Podfile does not contain host targets \(targets which embed the framework\)\./
         end
 
         it 'raises when the extension calls use_frameworks!, but the host target does not' do

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -747,7 +747,22 @@ module Pod
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           should.raise Informative do
             analyzer.analyze
-          end.message.should.match /Unable to find host target for Pods-Today Extension. Please add the host targets for the embedded targets to the Podfile/
+          end.message.should.match /Unable to find host target\(s\) for Today Extension. Please add the host targets for the embedded targets to the Podfile/
+        end
+
+        it 'warns when using a Podfile for framework-only projects' do
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            use_frameworks!
+            platform :ios, '8.0'
+            target 'Sample Framework' do
+              project 'SampleProject/Sample Lib/Sample Lib'
+              pod 'monkey'
+            end
+          end
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          analyzer.analyze
+          UI.warnings.should.match /The Podfile contains framework targets, for which the Podfile does not contain host targets \(where these frameworks would be installed\)\./
         end
 
         it 'raises when the extension calls use_frameworks!, but the host target does not' do


### PR DESCRIPTION
Fixes #5687

If all of the targets that require host targets in the Podfile are frameworks, you get a warning like this:
```
[!] The Podfile contains framework targets, for which the Podfile does not contain host targets (where these frameworks would be installed).
If this project is for doing framework development, you can ignore this message or add a test target that embeds these frameworks to make this message go away. Otherwise, please add the frameworks' host targets to the Podfile.
```

If there are more than just framework target types, the `Informative` has been updated like this:
```
[!] Unable to find host target(s) for MyAppExtension. Please add the host targets for the embedded targets to the Podfile.
Certain kinds of targets require a host target, in which to be embedded. These are example types of targets that need a host target:
- Framework
- App Extension
- Watch OS 1 Extension
- Messages Extension (except when used with a Messages Application)
```