### PR TITLE
Verify embedded target platform/swift matches its host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Remove references to the pre-1.0 Migrator.  
   [Danielle Tomlinson](https://github.com/dantoml)
   [#5635](https://github.com/CocoaPods/CocoaPods/pull/5635)  
-  
+
 * Improve performance of dependency resolution.
   [yanzhiwei147](https://github.com/yanzhiwei147)
   [#5510](https://github.com/CocoaPods/CocoaPods/pull/5510)
@@ -24,9 +24,14 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   Improved support for framework-only projects.  
   [benasher44](https://github.com/benasher44)
   [#5733](https://github.com/CocoaPods/CocoaPods/pull/5733)
+
 * Set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES when appropriate.  
   [benasher44](https://github.com/benasher44)
   [#5732](https://github.com/CocoaPods/CocoaPods/pull/5732)
+
+* Verify that embedded target platform and swift version matches the host.  
+  [benasher44](https://github.com/benasher44)
+  [#5747](https://github.com/CocoaPods/CocoaPods/pull/5747)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -328,7 +328,7 @@ module Pod
           target_definitions.each do |target_definition|
             check_prop.call(host_target_definition, target_definition, :platform, 'do not use the same platform')
             check_prop.call(host_target_definition, target_definition, :uses_frameworks?, 'do not both set use_frameworks!')
-            check_prop.call(host_target_definition, target_definition, :swift_version, 'do not both use the same Swift version')
+            check_prop.call(host_target_definition, target_definition, :swift_version, 'do not use the same Swift version')
           end
         end
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -783,7 +783,7 @@ module Pod
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           should.raise Informative do
             analyzer.analyze
-          end.message.should.match /Pods-Sample Extensions Project must call use_frameworks! because it is hosting an embedded target that calls use_frameworks!/
+          end.message.should.match /Sample Extensions Project \(false\) and Today Extension \(true\) do not both set use_frameworks!\./
         end
       end
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -785,6 +785,51 @@ module Pod
             analyzer.analyze
           end.message.should.match /Sample Extensions Project \(false\) and Today Extension \(true\) do not both set use_frameworks!\./
         end
+
+        it 'raises when the extension and host target use different swift versions' do
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            platform :ios, '8.0'
+            use_frameworks!
+            project 'Sample Extensions Project/Sample Extensions Project'
+
+            target 'Sample Extensions Project' do
+              pod 'JSONKit', '1.4'
+            end
+
+            target 'Today Extension' do
+              pod 'monkey'
+            end
+          end
+          podfile.target_definitions['Sample Extensions Project'].stubs(:swift_version).returns('2.3')
+          podfile.target_definitions['Today Extension'].stubs(:swift_version).returns('3.0')
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          should.raise Informative do
+            analyzer.analyze
+          end.message.should.match /Sample Extensions Project \(2\.3\) and Today Extension \(3\.0\) do not use the same Swift version\./
+        end
+
+        it 'raises when the extension and host target use different platforms' do
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            platform :ios, '8.0'
+            use_frameworks!
+            project 'Sample Extensions Project/Sample Extensions Project'
+
+            target 'Sample Extensions Project' do
+              pod 'JSONKit', '1.4'
+            end
+
+            target 'Today Extension' do
+              pod 'monkey'
+            end
+          end
+          podfile.target_definitions['Sample Extensions Project'].stubs(:platform).returns(Platform.new(:osx, '10.6'))
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          should.raise Informative do
+            analyzer.analyze
+          end.message.should.match /Sample Extensions Project \(OS X 10\.6\) and Today Extension \(iOS 8\.0\) do not use the same platform\./
+        end
       end
 
       #-------------------------------------------------------------------------#


### PR DESCRIPTION
The new swift build settings are a bit confusing, and my coworkers and I were able to reproduce what we initially thought was the same issues as #5700 and #5737. It turned out to be slightly different. We don't validate that the swift version of the embedded target matches that of its host. This change adds that validation.