### PR TITLE
Use the project-level swift version when not defined at the target-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Danielle Tomlinson](https://github.com/dantoml)
   [#5686](https://github.com/CocoaPods/CocoaPods/issues/5686)
 
+* Fix SWIFT_VERSION not being read when only defined at the project level.    
+  [Ben Asher](https://github.com/benasher44)
+  [#5700](https://github.com/CocoaPods/CocoaPods/issues/5700) and [#5737](https://github.com/CocoaPods/CocoaPods/issues/5737)
+
 
 ## 1.1.0.beta.1 (2016-07-11)
 

--- a/lib/cocoapods/installer/analyzer/target_inspector.rb
+++ b/lib/cocoapods/installer/analyzer/target_inspector.rb
@@ -216,10 +216,9 @@ module Pod
         # @return [String] the targets Swift version or nil
         #
         def compute_swift_version_from_targets(targets)
-          versions = targets.flat_map(&:build_configurations).
-            flat_map { |config| config.build_settings['SWIFT_VERSION'] }.
-            compact.
-            uniq
+          versions = targets.flat_map do |target|
+            target.resolved_build_setting('SWIFT_VERSION').values
+          end.flatten.compact.uniq
           case versions.count
           when 0
             nil

--- a/spec/unit/installer/analyzer/target_inspector_spec.rb
+++ b/spec/unit/installer/analyzer/target_inspector_spec.rb
@@ -326,6 +326,17 @@ module Pod
           target_inspector.send(:compute_swift_version_from_targets, user_targets)
         end.message.should.include 'There may only be up to 1 unique SWIFT_VERSION per target.'
       end
+
+      it 'returns the project-level SWIFT_VERSION if the target-level SWIFT_VERSION is not defined' do
+        user_project = Xcodeproj::Project.new('path')
+        user_project.build_configuration_list.set_setting('SWIFT_VERSION', '2.3')
+        target = user_project.new_target(:application, 'Target', :ios)
+        target_definition = Podfile::TargetDefinition.new(:default, nil)
+        user_targets = [target]
+
+        target_inspector = TargetInspector.new(target_definition, config.installation_root)
+        target_inspector.send(:compute_swift_version_from_targets, user_targets).should.equal '2.3'
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #5737 and #5700 

`PodVariant`s are unique by, among other things, their `TargetDefinition`'s swift version. Previously this would be `nil` if only defined at the project level. This would lead to multiple `PodVariant` instances for the same `PodTarget` incorrectly, and later on this leads to the `Errno::EEXIST` errors from incorrectly trying to create the same support files directories for the same `PodTarget`s.