### PR TITLE
Improved clarity of title for #5726 summary entry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [yanzhiwei147](https://github.com/yanzhiwei147)
   [#5510](https://github.com/CocoaPods/CocoaPods/pull/5510)
 
-* Add support for messages applications.  
+* Add support for building Messages applications.  
   [benasher44](https://github.com/benasher44)
   [#5726](https://github.com/CocoaPods/CocoaPods/pull/5726)
 


### PR DESCRIPTION
Capitalized “Messages” to make clear that it is a product name reference (Mac/iOS Messages.app), and added a verb to clarify that the fix pertains to the end use of CocoaPods as opposed to its integration with something else.