### PR TITLE
[Create] Pass the Pod::version as a ENV var for the configure script to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [benasher44](https://github.com/benasher44)
   [#5747](https://github.com/CocoaPods/CocoaPods/pull/5747)
 
+* Pass the version of CocoaPods to `pod lib create`'s configure script.  
+  [orta](https://github.com/orta)
+  [#5787](https://github.com/CocoaPods/CocoaPods/pull/5787)
+
 ##### Bug Fixes
 
 * Hash scope suffixes if they are over 50 characters to prevent file paths from being too long. 

--- a/lib/cocoapods/command/lib/create.rb
+++ b/lib/cocoapods/command/lib/create.rb
@@ -75,7 +75,7 @@ module Pod
           UI.section("Configuring #{@name} template.") do
             Dir.chdir(@name) do
               if File.exist?('configure')
-                system('./configure', @name, *@additional_args)
+                system({ 'COCOAPODS_VERSION' => Pod::Version }, './configure', @name, *@additional_args)
               else
                 UI.warn 'Template does not have a configure file.'
               end

--- a/spec/functional/command/lib/create_spec.rb
+++ b/spec/functional/command/lib/create_spec.rb
@@ -34,7 +34,7 @@ module Pod
       dir = SpecHelper.temporary_directory + 'TestPod'
       dir.mkpath
       File.stubs(:exist?).with('configure').returns(true)
-      @sut.any_instance.expects(:system).with('./configure', 'TestPod', 'foo').once
+      @sut.any_instance.expects(:system).with({ 'COCOAPODS_VERSION' => Pod::Version }, './configure', 'TestPod', 'foo').once
       run_command('lib', 'create', 'TestPod', 'foo', '--verbose')
     end
 


### PR DESCRIPTION
The new pod-template isn't backwards compatible with older versions of CocoaPods due to linking to a framework, https://github.com/CocoaPods/pod-template/pull/187 - this gives it the ability to let people know that.