### PR TITLE
Make analyzer skip the embedded target -> host compatibility check for hosts not defined in the Podfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Ben Asher](https://github.com/benasher44)
   [#5700](https://github.com/CocoaPods/CocoaPods/issues/5700) and [#5737](https://github.com/CocoaPods/CocoaPods/issues/5737)
 
+* Fix analyzer checking the compatibility of an embedded target with a host that has not been added the Podfile.  
+  [Ben Asher](https://github.com/benasher44)
+  [#5783](https://github.com/CocoaPods/CocoaPods/issues/5783)
 
 ## 1.1.0.beta.1 (2016-07-11)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -267,6 +267,8 @@ module Pod
       #
       def analyze_host_targets_in_podfile(aggregate_targets, embedded_aggregate_targets)
         target_definitions_by_uuid = {}
+        # Collect aggregate target definitions by uuid to later lookup host target
+        # definitions and verify their compatiblity with their embedded targets
         aggregate_targets.each do |target|
           target.user_targets.map(&:uuid).each do |uuid|
             target_definitions_by_uuid[uuid] = target.target_definition
@@ -275,6 +277,7 @@ module Pod
         aggregate_target_user_projects = aggregate_targets.map(&:user_project)
         embedded_targets_missing_hosts = []
         host_uuid_to_embedded_target_definitions = {}
+        # Search all of the known user projects for each embedded target's hosts
         embedded_aggregate_targets.each do |target|
           host_uuids = []
           aggregate_target_user_projects.product(target.user_targets).each do |user_project, user_target|
@@ -284,9 +287,15 @@ module Pod
             end
             host_uuids += host_targets.map(&:uuid)
           end
+          # For each host, keep track of its embedded target definitions
+          # to later verify each embedded target's compatiblity with its host,
+          # ignoring the hosts that aren't known to CocoaPods (no target
+          # definitions in the Podfile)
           host_uuids.each do |uuid|
             (host_uuid_to_embedded_target_definitions[uuid] ||= []) << target.target_definition if target_definitions_by_uuid.key? uuid
           end
+          # If none of the hosts are known to CocoaPods (no target definitions
+          # in the Podfile), add it to the list of targets missing hosts
           embedded_targets_missing_hosts << target unless host_uuids.any? do |uuid|
             target_definitions_by_uuid.key? uuid
           end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -269,6 +269,7 @@ module Pod
         target_definitions_by_uuid = {}
         aggregate_targets.each do |target|
           target.user_targets.map(&:uuid).each do |uuid|
+            raise Informative, "Missing target definition for target: #{target.name}" if target.target_definition.nil?
             target_definitions_by_uuid[uuid] = target.target_definition
           end
         end
@@ -325,6 +326,7 @@ module Pod
         end
         host_uuid_to_embedded_target_definitions.each do |uuid, target_definitions|
           host_target_definition = target_definitions_by_uuid[uuid]
+          raise Informative, "Missing target definition for host uuid: #{uuid}" if host_target_definition.nil?
           target_definitions.each do |target_definition|
             check_prop.call(host_target_definition, target_definition, :platform, 'do not use the same platform')
             check_prop.call(host_target_definition, target_definition, :uses_frameworks?, 'do not both set use_frameworks!')

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -269,7 +269,6 @@ module Pod
         target_definitions_by_uuid = {}
         aggregate_targets.each do |target|
           target.user_targets.map(&:uuid).each do |uuid|
-            raise Informative, "Missing target definition for target: #{target.name}" if target.target_definition.nil?
             target_definitions_by_uuid[uuid] = target.target_definition
           end
         end
@@ -286,7 +285,7 @@ module Pod
             host_uuids += host_targets.map(&:uuid)
           end
           host_uuids.each do |uuid|
-            (host_uuid_to_embedded_target_definitions[uuid] ||= []) << target.target_definition
+            (host_uuid_to_embedded_target_definitions[uuid] ||= []) << target.target_definition if target_definitions_by_uuid.key? uuid
           end
           embedded_targets_missing_hosts << target unless host_uuids.any? do |uuid|
             target_definitions_by_uuid.key? uuid
@@ -326,7 +325,6 @@ module Pod
         end
         host_uuid_to_embedded_target_definitions.each do |uuid, target_definitions|
           host_target_definition = target_definitions_by_uuid[uuid]
-          raise Informative, "Missing target definition for host uuid: #{uuid}" if host_target_definition.nil?
           target_definitions.each do |target_definition|
             check_prop.call(host_target_definition, target_definition, :platform, 'do not use the same platform')
             check_prop.call(host_target_definition, target_definition, :uses_frameworks?, 'do not both set use_frameworks!')

--- a/spec/fixtures/SampleProject/SampleProject.xcodeproj/project.pbxproj
+++ b/spec/fixtures/SampleProject/SampleProject.xcodeproj/project.pbxproj
@@ -38,6 +38,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		130F34EB1D73B132009D968D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 51E94E201644721F0035348C /* Sample Lib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 137F16121D3AFC2900029696;
+			remoteInfo = "Sample Framework";
+		};
 		137F16201D3AFC7B00029696 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 51E94E201644721F0035348C /* Sample Lib.xcodeproj */;
@@ -278,6 +285,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				130F34EC1D73B132009D968D /* PBXTargetDependency */,
 			);
 			name = TestRunner;
 			productName = TestRunner;
@@ -447,6 +455,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		130F34EC1D73B132009D968D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Sample Framework";
+			targetProxy = 130F34EB1D73B132009D968D /* PBXContainerItemProxy */;
+		};
 		13C623701D3B00F900EFB98B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Sample Framework";


### PR DESCRIPTION
This fixes #5783.

You could have your embedded target be embedded in multiple hosts, but only have CocoaPods help with integrating into one of those hosts. This fixes a bug I introduced in #5747, where the analyzer would assume it has the target definitions for all of an embedded target's hosts.

There is no new spec here, but updating the SampleProject fixture to embed a framework target in a 2nd target exposed the bug and failed the "copy a framework's pod target, when the framework is in a sub project" spec with a backtrace similar to that found in #5783. This PR fixes the spec.