### PR TITLE
Fixed pod repo push validation and push issues related to Dir.chdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Prevent crash when generating acknowledgements when license type is not specified.  
   [Marcelo Fabri](https://github.com/marcelofabri)
-  [#5826](https://github.com/CocoaPods/CocoaPods/issues/5826)  
+  [#5826](https://github.com/CocoaPods/CocoaPods/issues/5826)
+
+* Pass full path to App.xcworkspace for spec validation, and use `git -C` for `pod repo push` git ops.  
+  [Ben Asher](https://github.com/benasher44)
+  [#5805](https://github.com/CocoaPods/CocoaPods/issues/5805)
 
 
 ## 1.1.0.beta.2 (2016-09-03)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: da743f031f31ac2325c38a2db895f1b4c1faccc5
+  revision: 63da4db31cac3954ccdce9293267c17f028f53ae
   branch: master
   specs:
     cocoapods-core (1.1.0.beta.2)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -96,7 +96,7 @@ module Pod
         # specs to the master repo.
         #
         def check_if_master_repo
-          remotes = Dir.chdir(repo_dir) { `git remote -v 2>&1` }
+          remotes = `git -C #{repo_dir} remote -v 2>&1`
           master_repo_urls = [
             'git@github.com:CocoaPods/Specs.git',
             'https://github.com/CocoaPods/Specs.git',
@@ -145,7 +145,7 @@ module Pod
         # @return [void]
         #
         def check_repo_status
-          clean = Dir.chdir(repo_dir) { `git status --porcelain  2>&1` } == ''
+          clean = `git -C #{repo_dir} status --porcelain  2>&1` == ''
           raise Informative, "The repo `#{@repo}` at #{UI.path repo_dir} is not clean" unless clean
         end
 
@@ -155,7 +155,7 @@ module Pod
         #
         def update_repo
           UI.puts "Updating the `#{@repo}' repo\n".yellow
-          Dir.chdir(repo_dir) { UI.puts `git pull 2>&1` }
+          UI.puts `git -C #{repo_dir} pull 2>&1`
         end
 
         # Commits the podspecs to the source, which should be a git repo.
@@ -189,15 +189,13 @@ module Pod
               FileUtils.cp(spec_file, output_path)
             end
 
-            Dir.chdir(repo_dir) do
-              # only commit if modified
-              if git!('status', '--porcelain').include?(spec.name)
-                UI.puts " - #{message}"
-                git!('add', spec.name)
-                git!('commit', '--no-verify', '-m', message)
-              else
-                UI.puts " - [No change] #{spec}"
-              end
+            # only commit if modified
+            if repo_git('status', '--porcelain').include?(spec.name)
+              UI.puts " - #{message}"
+              repo_git('add', spec.name)
+              repo_git('commit', '--no-verify', '-m', message)
+            else
+              UI.puts " - [No change] #{spec}"
             end
           end
         end
@@ -208,7 +206,7 @@ module Pod
         #
         def push_repo
           UI.puts "\nPushing the `#{@repo}' repo\n".yellow
-          Dir.chdir(repo_dir) { UI.puts `git push origin master 2>&1` }
+          UI.puts `git -C #{repo_dir} push origin master 2>&1`
         end
 
         #---------------------------------------------------------------------#
@@ -216,6 +214,12 @@ module Pod
         private
 
         # @!group Private helpers
+
+        # @return result of calling the git! with args in repo_dir
+        #
+        def repo_git(*args)
+          git!(["-C", repo_dir] + args)
+        end
 
         # @return [Pathname] The directory of the repository.
         #

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -96,7 +96,7 @@ module Pod
         # specs to the master repo.
         #
         def check_if_master_repo
-          remotes = `git -C #{repo_dir} remote -v 2>&1`
+          remotes = `git -C "#{repo_dir}" remote -v 2>&1`
           master_repo_urls = [
             'git@github.com:CocoaPods/Specs.git',
             'https://github.com/CocoaPods/Specs.git',
@@ -145,7 +145,7 @@ module Pod
         # @return [void]
         #
         def check_repo_status
-          clean = `git -C #{repo_dir} status --porcelain  2>&1` == ''
+          clean = `git -C "#{repo_dir}" status --porcelain  2>&1` == ''
           raise Informative, "The repo `#{@repo}` at #{UI.path repo_dir} is not clean" unless clean
         end
 
@@ -155,7 +155,7 @@ module Pod
         #
         def update_repo
           UI.puts "Updating the `#{@repo}' repo\n".yellow
-          UI.puts `git -C #{repo_dir} pull 2>&1`
+          UI.puts `git -C "#{repo_dir}" pull 2>&1`
         end
 
         # Commits the podspecs to the source, which should be a git repo.
@@ -206,7 +206,7 @@ module Pod
         #
         def push_repo
           UI.puts "\nPushing the `#{@repo}' repo\n".yellow
-          UI.puts `git -C #{repo_dir} push origin master 2>&1`
+          UI.puts `git -C "#{repo_dir}" push origin master 2>&1`
         end
 
         #---------------------------------------------------------------------#

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -218,7 +218,7 @@ module Pod
         # @return result of calling the git! with args in repo_dir
         #
         def repo_git(*args)
-          git!(["-C", repo_dir] + args)
+          git!(['-C', repo_dir] + args)
         end
 
         # @return [Pathname] The directory of the repository.

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -103,9 +103,8 @@ module Pod
     end
 
     def update_git_repo(show_output = false)
-      ensure_in_repo!
       Config.instance.with_changes(:verbose => show_output) do
-        git!(%w(pull --ff-only))
+        git!(['-C', repo, 'pull', '--ff-only'])
       end
     rescue
       UI.warn 'CocoaPods was not able to update the ' \
@@ -117,10 +116,9 @@ module Pod
 
   class MasterSource
     def update_git_repo(show_output = false)
-      ensure_in_repo!
       if repo.join('.git', 'shallow').file?
         UI.info "Performing a deep fetch of the `#{name}` specs repo to improve future performance" do
-          git!(%w(fetch --unshallow))
+          git!(['-C', repo, 'pull', 'fetch', '--unshallow'])
         end
       end
       super

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -118,7 +118,7 @@ module Pod
     def update_git_repo(show_output = false)
       if repo.join('.git', 'shallow').file?
         UI.info "Performing a deep fetch of the `#{name}` specs repo to improve future performance" do
-          git!(['-C', repo, 'pull', 'fetch', '--unshallow'])
+          git!(['-C', repo, 'fetch', '--unshallow'])
         end
       end
       super

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -718,7 +718,7 @@ module Pod
     #
     def xcodebuild
       require 'fourflusher'
-      command = %W(clean build -workspace #{validation_dir}/App.xcworkspace -scheme App -configuration Release)
+      command = ['clean', 'build', '-workspace', File.join(validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release']
       case consumer.platform_name
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -718,7 +718,7 @@ module Pod
     #
     def xcodebuild
       require 'fourflusher'
-      command = %w(clean build -workspace App.xcworkspace -scheme App -configuration Release)
+      command = %W(clean build -workspace #{validation_dir}/App.xcworkspace -scheme App -configuration Release)
       case consumer.platform_name
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)
@@ -731,7 +731,7 @@ module Pod
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)
       end
 
-      output, status = Dir.chdir(validation_dir) { _xcodebuild(command) }
+      output, status = _xcodebuild(command)
 
       unless status.success?
         message = 'Returned an unsuccessful exit code.'

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -120,9 +120,15 @@ module Pod
 
       it 'prints a warning if the update failed' do
         set_up_test_repo_for_update
-        Source.any_instance.stubs(:git).with(%w(rev-parse HEAD)).returns('aabbccd')
-        Source.any_instance.stubs(:git).with(%w(diff --name-only aabbccd..HEAD)).returns('')
-        MasterSource.any_instance.expects(:git!).with(%w(pull --ff-only)).raises(<<-EOS)
+        Source.any_instance.stubs(:git).with do |options|
+          options.join(' ').should.equal %W(-C #{test_repo_path} rev-parse HEAD).join(' ')
+        end.returns('aabbccd')
+        Source.any_instance.stubs(:git).with do |options|
+          options.join(' ').should.equal %W(-C #{test_repo_path} diff --name-only aabbccd..HEAD).join(' ')
+        end.returns('')
+        MasterSource.any_instance.expects(:git!).with do |options|
+          options.join(' ').should.equal %W(-C #{test_repo_path} pull --ff-only).join(' ')
+        end.raises(<<-EOS)
 fatal: '/dev/null' does not appear to be a git repository
 fatal: Could not read from remote repository.
 

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -90,7 +90,9 @@ module Pod
       it 'updates source backed by a git repository' do
         set_up_test_repo_for_update
         @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
-        MasterSource.any_instance.expects(:git!).with(%w(pull --ff-only))
+        MasterSource.any_instance.expects(:git!).with do |options|
+          options.join(' ').should.equal %W(-C #{test_repo_path} pull --ff-only).join(' ')
+        end
         @sources_manager.update(test_repo_path.basename.to_s, true)
       end
 
@@ -105,8 +107,12 @@ module Pod
         set_up_test_repo_for_update
         test_repo_path.join('.git', 'shallow').open('w') { |f| f << 'a' * 40 }
         @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
-        MasterSource.any_instance.expects(:git!).with(%w(fetch --unshallow))
-        MasterSource.any_instance.expects(:git!).with(%w(pull --ff-only))
+        MasterSource.any_instance.expects(:git!).with do |options|
+          options.join(' ').should.equal %W(-C #{test_repo_path} fetch --unshallow).join(' ')
+        end
+        MasterSource.any_instance.expects(:git!).with do |options|
+          options.join(' ').should.equal %W(-C #{test_repo_path} pull --ff-only).join(' ')
+        end
         @sources_manager.update(test_repo_path.basename.to_s, true)
 
         UI.output.should.match /deep fetch.+`master`.+improve future performance/

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -91,7 +91,7 @@ module Pod
         set_up_test_repo_for_update
         @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
         MasterSource.any_instance.expects(:git!).with do |options|
-          options.join(' ').should.equal %W(-C #{test_repo_path} pull --ff-only).join(' ')
+          options.join(' ') == %W(-C #{test_repo_path} pull --ff-only).join(' ')
         end
         @sources_manager.update(test_repo_path.basename.to_s, true)
       end
@@ -108,10 +108,10 @@ module Pod
         test_repo_path.join('.git', 'shallow').open('w') { |f| f << 'a' * 40 }
         @sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
         MasterSource.any_instance.expects(:git!).with do |options|
-          options.join(' ').should.equal %W(-C #{test_repo_path} fetch --unshallow).join(' ')
+          options.join(' ') == %W(-C #{test_repo_path} fetch --unshallow).join(' ')
         end
         MasterSource.any_instance.expects(:git!).with do |options|
-          options.join(' ').should.equal %W(-C #{test_repo_path} pull --ff-only).join(' ')
+          options.join(' ') == %W(-C #{test_repo_path} pull --ff-only).join(' ')
         end
         @sources_manager.update(test_repo_path.basename.to_s, true)
 
@@ -121,13 +121,13 @@ module Pod
       it 'prints a warning if the update failed' do
         set_up_test_repo_for_update
         Source.any_instance.stubs(:git).with do |options|
-          options.join(' ').should.equal %W(-C #{test_repo_path} rev-parse HEAD).join(' ')
+          options.join(' ') == %W(-C #{test_repo_path} rev-parse HEAD).join(' ')
         end.returns('aabbccd')
         Source.any_instance.stubs(:git).with do |options|
-          options.join(' ').should.equal %W(-C #{test_repo_path} diff --name-only aabbccd..HEAD).join(' ')
+          options.join(' ') == %W(-C #{test_repo_path} diff --name-only aabbccd..HEAD).join(' ')
         end.returns('')
         MasterSource.any_instance.expects(:git!).with do |options|
-          options.join(' ').should.equal %W(-C #{test_repo_path} pull --ff-only).join(' ')
+          options.join(' ') == %W(-C #{test_repo_path} pull --ff-only).join(' ')
         end.raises(<<-EOS)
 fatal: '/dev/null' does not appear to be a git repository
 fatal: Could not read from remote repository.

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -435,7 +435,7 @@ module Pod
         Executable.stubs(:capture_command).with('git', ['config', '--get', 'remote.origin.url'], :capture => :out).returns(['https://github.com/CocoaPods/Specs.git'])
         Executable.stubs(:which).with(:xcrun)
         Executable.expects(:which).with('xcodebuild').times(4).returns('/usr/bin/xcodebuild')
-        command = %w(clean build -workspace App.xcworkspace -scheme App -configuration Release)
+        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release']
         Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
         args = %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator) + Fourflusher::SimControl.new.destination('Apple TV 1080p')
         Executable.expects(:capture_command).with('xcodebuild', command + args, :capture => :merge).once.returns(['', stub(:success? => true)])


### PR DESCRIPTION
Removes uses of `Dir.chdir` for this flow. It prefers using `git -C` and passing the full path to App.xcworkspace for validation. This fixes #5805 