### PR TITLE
Cache result of uses_swift and should_build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Cache result of uses_swift and should_build to speed up pod install.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#5837](https://github.com/CocoaPods/CocoaPods/pull/5837)
+
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -141,9 +141,12 @@ module Pod
     # A target should not be build if it has no source files.
     #
     def should_build?
-      source_files = file_accessors.flat_map(&:source_files)
-      source_files -= file_accessors.flat_map(&:headers)
-      !source_files.empty?
+      return @should_build if defined? @should_build
+      @should_build = begin
+        source_files = file_accessors.flat_map(&:source_files)
+        source_files -= file_accessors.flat_map(&:headers)
+        !source_files.empty?
+      end
     end
 
     # @return [Array<Specification::Consumer>] the specification consumers for
@@ -156,8 +159,11 @@ module Pod
     # @return [Boolean] Whether the target uses Swift code
     #
     def uses_swift?
-      file_accessors.any? do |file_accessor|
-        file_accessor.source_files.any? { |sf| sf.extname == '.swift' }
+      return @uses_swift if defined? @uses_swift
+      @uses_swift = begin
+        file_accessors.any? do |file_accessor|
+          file_accessor.source_files.any? { |sf| sf.extname == '.swift' }
+        end
       end
     end
 


### PR DESCRIPTION
We have a large project and our `pod install` time keeps increasing the more targets and pods we add.

Based on an old profile we did (http://danielribeiro.github.io/braintree_ios/ProfileForCallStackPrinter.html) it seems that during installation a lot of time is spent for checking if a target can be built or if it uses swift.

This small change speeds up our `pod install` by a lot (from 1m 40s to about 1m and 3s).

@segiddins the only concern is if that value should be invalidated at any point. For example, is there a chance the `prepare_command` of a pod generate sources that this change will miss?