### PR TITLE
Fix linting on Xcode 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Use the SWIFT_VERSION when linting pods.  
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#5841](https://github.com/CocoaPods/CocoaPods/issues/5841)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -388,8 +388,15 @@ module Pod
       source_file_ref = app_project.new_group('App', 'App').new_file(source_file)
       app_target = app_project.targets.first
       app_target.add_file_references([source_file_ref])
+      add_swift_version(app_target)
       add_xctest(app_target) if @installer.pod_targets.any? { |pt| pt.spec_consumers.any? { |c| c.frameworks.include?('XCTest') } }
       app_project.save
+    end
+
+    def add_swift_version(app_target)
+      app_target.build_configurations.each do |configuration|
+        configuration.build_settings['SWIFT_VERSION'] = '2.3'
+      end
     end
 
     def add_xctest(app_target)
@@ -445,6 +452,7 @@ module Pod
           next unless native_target = pod_target.native_target
           native_target.build_configuration_list.build_configurations.each do |build_configuration|
             (build_configuration.build_settings['OTHER_CFLAGS'] ||= '$(inherited)') << ' -Wincomplete-umbrella'
+            build_configuration.build_settings['SWIFT_VERSION'] = '2.3' if pod_target.uses_swift?
           end
         end
         if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -395,7 +395,7 @@ module Pod
 
     def add_swift_version(app_target)
       app_target.build_configurations.each do |configuration|
-        configuration.build_settings['SWIFT_VERSION'] = '2.3'
+        configuration.build_settings['SWIFT_VERSION'] = swift_version
       end
     end
 
@@ -452,7 +452,7 @@ module Pod
           next unless native_target = pod_target.native_target
           native_target.build_configuration_list.build_configurations.each do |build_configuration|
             (build_configuration.build_settings['OTHER_CFLAGS'] ||= '$(inherited)') << ' -Wincomplete-umbrella'
-            build_configuration.build_settings['SWIFT_VERSION'] = '2.3' if pod_target.uses_swift?
+            build_configuration.build_settings['SWIFT_VERSION'] = swift_version if pod_target.uses_swift?
           end
         end
         if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&
@@ -655,6 +655,19 @@ module Pod
     private
 
     # !@group Helpers
+
+    # @return [String] the SWIFT_VERSION to use for validation.
+    #
+    def swift_version
+      dot_swift_version || '2.3'
+    end
+
+    # @return [String] the SWIFT_VERSION in the .swift-version file or nil.
+    #
+    def dot_swift_version
+      swift_version_path = file.dirname + '.swift-version'
+      File.read(swift_version_path) if File.exists?(swift_version_path)
+    end
 
     # @return [Array<String>] an array of source URLs used to create the
     #         {Podfile} used in the linting process

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -237,6 +237,19 @@ module Pod
       Pathname(Dir.tmpdir) + 'CocoaPods/Lint'
     end
 
+    # @return [String] the SWIFT_VERSION to use for validation.
+    #
+    def swift_version
+      @swift_version ||= dot_swift_version || '2.3'
+    end
+
+    # @return [String] the SWIFT_VERSION in the .swift-version file or nil.
+    #
+    def dot_swift_version
+      swift_version_path = file.dirname + '.swift-version'
+      File.read(swift_version_path) if File.exist?(swift_version_path)
+    end
+
     #-------------------------------------------------------------------------#
 
     private
@@ -655,19 +668,6 @@ module Pod
     private
 
     # !@group Helpers
-
-    # @return [String] the SWIFT_VERSION to use for validation.
-    #
-    def swift_version
-      dot_swift_version || '2.3'
-    end
-
-    # @return [String] the SWIFT_VERSION in the .swift-version file or nil.
-    #
-    def dot_swift_version
-      swift_version_path = file.dirname + '.swift-version'
-      File.read(swift_version_path) if File.exists?(swift_version_path)
-    end
 
     # @return [Array<String>] an array of source URLs used to create the
     #         {Podfile} used in the linting process

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -247,7 +247,7 @@ module Pod
     #
     def dot_swift_version
       swift_version_path = file.dirname + '.swift-version'
-      File.read(swift_version_path) if File.exist?(swift_version_path)
+      swift_version_path.read if swift_version_path.exist?
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -835,18 +835,14 @@ module Pod
       describe '#dot_swift_version' do
         it 'looks for a .swift-version file' do
           validator = test_swiftpod
-          File.expects(:exist?).with do |arg|
-            arg.basename.to_s == '.swift-version'
-          end
+          Pathname.any_instance.expects(:exist?)
           validator.dot_swift_version
         end
 
         it 'uses the .swift-version file if present' do
           validator = test_swiftpod
-          File.stubs(:exist?).returns(true)
-          File.expects(:read).with do |arg|
-            arg.basename.to_s == '.swift-version'
-          end.returns('1.0')
+          Pathname.any_instance.stubs(:exist?).returns(true)
+          Pathname.any_instance.expects(:read).returns('1.0')
           validator.dot_swift_version.should == '1.0'
         end
       end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -784,13 +784,12 @@ module Pod
         validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.stubs(:build_pod)
         validator.stubs(:validate_url)
-        validator.stubs(:swift_version).returns('2.3')
-        validator.validate
         validator
       end
 
       it 'fails on deployment target < iOS 8 for Swift Pods' do
         validator = test_swiftpod
+        validator.validate
 
         validator.results.map(&:to_s).first.should.match /dynamic frameworks.*iOS > 8/
         validator.result_type.should == :error
@@ -800,6 +799,7 @@ module Pod
         Specification::Consumer.any_instance.stubs(:frameworks).returns(%w(XCTest))
 
         validator = test_swiftpod
+        validator.validate
         validator.results.count.should == 0
       end
 
@@ -807,12 +807,48 @@ module Pod
         Specification.any_instance.stubs(:deployment_target).returns('9.0')
 
         validator = test_swiftpod
+        validator.validate
 
         validator.results.count.should == 0
       end
 
-      it 'defaults to Swift 2.3' do
-        validator = test_swiftpod
+      describe '#swift_version' do
+        it 'defaults to Swift 2.3' do
+          validator = test_swiftpod
+          validator.stubs(:dot_swift_version).returns(nil)
+          validator.swift_version.should == '2.3'
+        end
+
+        it 'checks for dot_swift_version' do
+          validator = test_swiftpod
+          validator.expects(:dot_swift_version)
+          validator.swift_version
+        end
+
+        it 'uses the result of dot_swift_version if not nil' do
+          validator = test_swiftpod
+          validator.stubs(:dot_swift_version).returns('1.0')
+          validator.swift_version.should == '1.0'
+        end
+      end
+
+      describe '#dot_swift_version' do
+        it 'looks for a .swift-version file' do
+          validator = test_swiftpod
+          File.expects(:exist?).with do |arg|
+            arg.basename.to_s == '.swift-version'
+          end
+          validator.dot_swift_version
+        end
+
+        it 'uses the .swift-version file if present' do
+          validator = test_swiftpod
+          File.stubs(:exist?).returns(true)
+          File.expects(:read).with do |arg|
+            arg.basename.to_s == '.swift-version'
+          end.returns('1.0')
+          validator.dot_swift_version.should == '1.0'
+        end
       end
     end
     #-------------------------------------------------------------------------#

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -784,6 +784,7 @@ module Pod
         validator = Validator.new(file, config.sources_manager.master.map(&:url))
         validator.stubs(:build_pod)
         validator.stubs(:validate_url)
+        validator.stubs(:swift_version).returns('2.3')
         validator.validate
         validator
       end
@@ -808,6 +809,10 @@ module Pod
         validator = test_swiftpod
 
         validator.results.count.should == 0
+      end
+
+      it 'defaults to Swift 2.3' do
+        validator = test_swiftpod
       end
     end
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
Will default to SWIFT_VERSION = 2.3, but will check for a `.swift-version` file and use the version specified there if present.