### PR TITLE
Wrap generated import headers using __OBJC__ for C only pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Wrap generated import headers with __OBJC__ to fix C only pods.   
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#5291](https://github.com/CocoaPods/CocoaPods/issues/5291)
+
 * Prevent crash when generating acknowledgements when license type is not specified.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [#5826](https://github.com/CocoaPods/CocoaPods/issues/5826)

--- a/lib/cocoapods/generator/header.rb
+++ b/lib/cocoapods/generator/header.rb
@@ -40,8 +40,9 @@ module Pod
       #
       def generate
         result = ''
+        result << "#ifdef __OBJC__\n"
         result << generate_platform_import_header
-
+        result << "#endif\n"
         result << "\n"
 
         imports.each do |import|

--- a/lib/cocoapods/generator/prefix_header.rb
+++ b/lib/cocoapods/generator/prefix_header.rb
@@ -55,18 +55,6 @@ module Pod
 
         result
       end
-
-      protected
-
-      # Generates the contents of the header according to the platform.
-      #
-      # @return [String]
-      #
-      def generate_platform_import_header
-        result =  "#ifdef __OBJC__\n"
-        result << super
-        result << "#endif\n"
-      end
     end
   end
 end

--- a/spec/unit/generator/header_spec.rb
+++ b/spec/unit/generator/header_spec.rb
@@ -9,7 +9,9 @@ module Pod
     it 'includes the imports' do
       @gen.imports << 'header.h'
       @gen.generate.should == <<-EOS.strip_heredoc
+      #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #endif
 
       #import "header.h"
       EOS
@@ -18,7 +20,9 @@ module Pod
     it 'includes the module imports' do
       @gen.module_imports << 'Module'
       @gen.generate.should == <<-EOS.strip_heredoc
+      #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #endif
 
 
       @import Module
@@ -49,7 +53,9 @@ module Pod
       path = temporary_directory + 'Test.h'
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
+      #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #endif
 
       EOS
     end


### PR DESCRIPTION
closes #5291 

This completes the pull request here (https://github.com/CocoaPods/CocoaPods/pull/5408) by fixing the tests.

Integration tests fail, though the DIFF looks correct. I am uncertain how to fix those but I think I've seen CocoaPods maintainers update these. Let me know!