### PR TITLE
Remove special casing for messages apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Remove special handling for messages apps  
+  [Ben Asher](https://github.com/benasher44)
+  [#5860](https://github.com/CocoaPods/CocoaPods/issues/5860)
 
 ## 1.1.0.rc.2 (2016-09-13)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -281,11 +281,7 @@ module Pod
         embedded_aggregate_targets.each do |target|
           host_uuids = []
           aggregate_target_user_projects.product(target.user_targets).each do |user_project, user_target|
-            host_targets = user_project.host_targets_for_embedded_target(user_target)
-            host_targets.map(&:symbol_type).each do |product_type|
-              target.add_host_target_product_type(product_type)
-            end
-            host_uuids += host_targets.map(&:uuid)
+            host_uuids += user_project.host_targets_for_embedded_target(user_target).map(&:uuid)
           end
           # For each host, keep track of its embedded target definitions
           # to later verify each embedded target's compatiblity with its host,

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -9,8 +9,6 @@ module Pod
 
     # Product types where the product's frameworks must be embedded in a host target
     #
-    # @note :messages_extension only applies when it is embedded in an app (as opposed to a messages app)
-    #
     EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :messages_extension, :watch_extension].freeze
 
     # Initialize a new instance

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -27,21 +27,6 @@ module Pod
       @search_paths_aggregate_targets = []
       @file_accessors = []
       @xcconfigs = {}
-      @host_target_types = Set.new # Product types of the host target, if this target is embedded
-    end
-
-    # Adds product type to the list of product types for the host
-    # targets, in which this target will be embedded
-    #
-    # @param [Symbol] product_type Product type (symbol representation)
-    #        of a host, in which this target will be embedded
-    #
-    # @note This is important for messages extensions, since a messages
-    #       extension has its frameworks embedded in its host when
-    #       its host is an app but not when it's a messages app
-    #
-    def add_host_target_product_type(product_type)
-      @host_target_types << product_type
     end
 
     # @return [Boolean] True if the user_target's pods are

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -57,7 +57,7 @@ module Pod
       return false if user_project.nil?
       symbol_types = user_targets.map(&:symbol_type).uniq
       raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}." unless symbol_types.count == 1
-      EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES.include?(symbol_types[0]) && !@host_target_types.include?(:messages_application)
+      EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES.include?(symbol_types[0])
     end
 
     # @return [String] the label for the target.

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -224,12 +224,6 @@ module Pod
             @target.requires_host_target?.should == true
           end
 
-          it 'does not require a host target for messages extension targets embedded in messages applications' do
-            @target.add_host_target_product_type(:messages_application)
-            @target.user_targets.first.stubs(:symbol_type).returns(:messages_extension)
-            @target.requires_host_target?.should == false
-          end
-
           it 'does not require a host target for watch 2 extension targets' do
             @target.user_targets.first.stubs(:symbol_type).returns(:watch2_extension)
             @target.requires_host_target?.should == false


### PR DESCRIPTION
This fixes #5860. It looks like I was wrong in assuming that messages applications can't have frameworks embedded in them. I'm not sure how a user would do this though, since last I checked you can't modify the messages app's Target Dependencies build phase via the Xcode 8 UI.

After this change, messages extensions will be treated like any other extension type.

Waiting to merge this, until I get further confirmation from @isair