### PR TITLE
Error if project targets have mismatched Swift versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Remove uses of `cd` in generated scripts  
   [Ben Asher](https://github.com/benasher44)
   [#5959](https://github.com/CocoaPods/CocoaPods/pull/5959)
+* GitHub issue inspection will now happen for any StandardError in a pod install  
+  [Orta Therox](https://github.com/orta)
+  [#5950](https://github.com/CocoaPods/CocoaPods/pull/5950)
+* Error with helpful message when integrating a pod into targets that have mismatched Swift versions.  
+  [Ben Asher](https://github.com/benasher44)
+  [#5917](https://github.com/CocoaPods/CocoaPods/pull/5917)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Remove uses of `cd` in generated scripts  
   [Ben Asher](https://github.com/benasher44)
   [#5959](https://github.com/CocoaPods/CocoaPods/pull/5959)
-* GitHub issue inspection will now happen for any StandardError in a pod install  
-  [Orta Therox](https://github.com/orta)
-  [#5950](https://github.com/CocoaPods/CocoaPods/pull/5950)
+
 * Error with helpful message when integrating a pod into targets that have mismatched Swift versions.  
   [Ben Asher](https://github.com/benasher44)
   [#5917](https://github.com/CocoaPods/CocoaPods/pull/5917)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -433,7 +433,7 @@ module Pod
 
         error_messages = []
         targets_by_spec.each do |spec, targets|
-          error_messages << "#{spec.name} required by #{targets.map(&target_msg).join(', ')}" unless targets.uniq(&:swift_version).count == 1
+          error_messages << "- #{spec.name} required by #{targets.map(&target_msg).join(', ')}" unless targets.uniq(&:swift_version).count == 1
         end
         raise Informative, "The following pods are integrated into targets that do not have the same Swift version:\n\n#{error_messages.join("\n")}" unless error_messages.empty?
       end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -435,7 +435,7 @@ module Pod
         targets_by_spec.each do |spec, targets|
           error_messages << "#{spec.name} required by #{targets.map(&target_msg).join(', ')}" unless targets.uniq(&:swift_version).count == 1
         end
-        raise Informative, "The following pods are integrated into targets that do not have the same Swift version:\n\n#{error_messages.join("\n")}"
+        raise Informative, "The following pods are integrated into targets that do not have the same Swift version:\n\n#{error_messages.join("\n")}" unless error_messages.empty?
       end
 
       # Setup the pod targets for an aggregate target. Deduplicates resulting

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -424,7 +424,7 @@ module Pod
         end
 
         target_msg = lambda do |target|
-          if target.swift_version.nil?
+          if target.swift_version.nil? or target.swift_version.empty?
             "#{target.name} (Swift version missing)"
           else
             "#{target.name} (Swift #{target.swift_version})"

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -424,7 +424,7 @@ module Pod
         end
 
         target_msg = lambda do |target|
-          if target.swift_version.nil? or target.swift_version.empty?
+          if target.swift_version.nil? || target.swift_version.empty?
             "#{target.name} (Swift version missing)"
           else
             "#{target.name} (Swift #{target.swift_version})"

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -662,12 +662,12 @@ module Pod
         should.raise(Informative) { analyzer.analyze }
       end
 
-      it 'raises when targets integrate the same pod but have different swift versions' do
+      it 'raises when targets integrate the same swift pod but have different swift versions' do
         podfile = Podfile.new do
-          source 'https://github.com/CocoaPods/Specs.git'
+          source SpecHelper.test_repo_url
           project 'SampleProject/SampleProject'
           platform :ios, '8.0'
-          pod 'RestKit', '~> 0.23.0'
+          pod 'OrangeFramework'
           target 'SampleProject'
           target 'TestRunner'
         end
@@ -676,15 +676,15 @@ module Pod
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
         should.raise Informative do
           analyzer.analyze
-        end.message.should.match /The following pods are integrated into targets that do not have the same Swift version:/
+        end.message.should.match /The following pods are integrated into Swift targets that do not have the same Swift version:/
       end
 
-      it 'raises when targets integrate the same pod but have different swift versions (swift version unset at the project level, but set in one target)' do
+      it 'does not raise when targets integrate the same pod but only one of the targets is a swift target' do
         podfile = Podfile.new do
-          source 'https://github.com/CocoaPods/Specs.git'
+          source SpecHelper.test_repo_url
           project 'SampleProject/SampleProject'
           platform :ios, '8.0'
-          pod 'RestKit', '~> 0.23.0'
+          pod 'OrangeFramework'
           target 'SampleProject'
           target 'TestRunner'
         end
@@ -692,17 +692,15 @@ module Pod
         # when the swift version is unset at the project level, but set in one target, swift_version is nil
         podfile.target_definitions['TestRunner'].stubs(:swift_version).returns(nil)
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
-        should.raise Informative do
-          analyzer.analyze
-        end.message.should.match /The following pods are integrated into targets that do not have the same Swift version:/
+        lambda { analyzer.analyze }.should.not.raise
       end
 
-      it 'raises when targets integrate the same pod but have different swift versions (swift version set at the project level, but unset in one target)' do
+      it 'does not raise when swift targets with different swift versions integrate a non-swift pod' do
         podfile = Podfile.new do
-          source 'https://github.com/CocoaPods/Specs.git'
+          source SpecHelper.test_repo_url
           project 'SampleProject/SampleProject'
           platform :ios, '8.0'
-          pod 'RestKit', '~> 0.23.0'
+          pod 'JSONKit'
           target 'SampleProject'
           target 'TestRunner'
         end
@@ -710,9 +708,7 @@ module Pod
         # when the swift version is set at the project level, but unset in one target, swift_version is empty
         podfile.target_definitions['TestRunner'].stubs(:swift_version).returns('')
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
-        should.raise Informative do
-          analyzer.analyze
-        end.message.should.match /The following pods are integrated into targets that do not have the same Swift version:/
+        lambda { analyzer.analyze }.should.not.raise
       end
 
       #--------------------------------------#


### PR DESCRIPTION
With this change, having a project that has one target that has a Swift version set and another that has it unset or set to something different, the user will get an error with a message like this during `pod install`

```
[!] The following pods are integrated into Swift targets that do not have the same Swift version:

- SomePod required by MyAppTarget1 (Swift 2.3), MyAppTarget2 (Swift 3.0)
```

This should help folks resolve issues related to #5864 and #5834.