### PR TITLE
Remove EMBEDDED_CONTENT_CONTAINS_SWIFT as it is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Ben Asher](https://github.com/benasher44)
   [#5732](https://github.com/CocoaPods/CocoaPods/pull/5732)
 
+* Update EMBEDDED_CONTENT_CONTAINS_SWIFT flag behaviour based on xcode version.
+  [codymoorhouse](https://github.com/codymoorhouse)
+  [#5732](https://github.com/CocoaPods/CocoaPods/issues/5732)
+
 * Verify that embedded target platform and swift version matches the host.  
   [Ben Asher](https://github.com/benasher44)
   [#5747](https://github.com/CocoaPods/CocoaPods/pull/5747)

--- a/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
+++ b/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
@@ -624,7 +624,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				IBSC_MODULE = watchOSsample_WatchKit_Extension;
 				INFOPLIST_FILE = "watchOSsample WatchKit/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = org.vu0.watchOSsample.watchkitapp;
@@ -641,7 +641,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+		    		ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				IBSC_MODULE = watchOSsample_WatchKit_Extension;
 				INFOPLIST_FILE = "watchOSsample WatchKit/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = org.vu0.watchOSsample.watchkitapp;

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -69,7 +69,6 @@ module Pod
           # cause an App Store rejection because frameworks cannot be embedded
           # in embedded targets.
           if !target.requires_host_target? && pod_targets.any?(&:uses_swift?)
-            config['EMBEDDED_CONTENT_CONTAINS_SWIFT'] = 'YES'
             config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
           else
             config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -68,11 +68,25 @@ module Pod
           # that use Swift. Setting this for the embedded target would
           # cause an App Store rejection because frameworks cannot be embedded
           # in embedded targets.
-          if !target.requires_host_target? && pod_targets.any?(&:uses_swift?)
-            config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
+
+	  # Extract xcodeversion number
+	  @xcodeversion = 'xcodebuild -version | cut -f 2 -d ' ' | head -n 1`
+
+	  # Check if xcodeversion is prior to v8.0
+	  if !target.requires_host_target? && pod_targets.any?(&:uses_swift?)
+	    if @xcodeversion < 8.0
+              config['EMBEDDED_CONTENT_CONTAINS_SWIFT'] = 'YES'          
+            else
+              config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
+            end
           else
-            config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
+	    if @xcodeversion < 8.0
+              config['EMBEDDED_CONTENT_CONTAINS_SWIFT'] = 'NO'
+            else
+              config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
+            end
           end
+
           @xcconfig = Xcodeproj::Config.new(config)
 
           @xcconfig.merge!(merged_user_target_xcconfigs)

--- a/spec/fixtures/Sample Extensions Project/Sample Extensions Project.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Sample Extensions Project/Sample Extensions Project.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				ALWAYS_EMBED_SWIFT_LIBRARIES = YES;
 				INFOPLIST_FILE = "Sample Extensions Project/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "cocoapods.Sample-Extensions-Project";
@@ -378,7 +378,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				ALWAYS_EMBED_SWIFT_LIBRARIES = YES;
 				INFOPLIST_FILE = "Sample Extensions Project/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "cocoapods.Sample-Extensions-Project";

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -241,20 +241,20 @@ module Pod
             @xcconfig.to_hash['OTHER_SWIFT_FLAGS'].should.include '$(inherited) "-D" "COCOAPODS"'
           end
 
-          it 'sets EMBEDDED_CONTENT_CONTAINS_SWIFT when there is swift' do
+          it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES when there is swift' do
             @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
-            @generator.generate.to_hash['EMBEDDED_CONTENT_CONTAINS_SWIFT'].should == 'YES'
+            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_LIBRARIES'].should == 'YES'
           end
 
-          it 'does not set EMBEDDED_CONTENT_CONTAINS_SWIFT when there is no swift' do
+          it 'does not set ALWAYS_EMBED_STANDARD_LIBRARIES when there is no swift' do
             @generator.send(:pod_targets).each { |pt| pt.stubs(:uses_swift?).returns(false) }
-            @generator.generate.to_hash['EMBEDDED_CONTENT_CONTAINS_SWIFT'].should.be.nil
+            @generator.generate.to_hash['ALWAYS_EMBED_STANDARD_LIBRARIES'].should.be.nil
           end
 
-          it 'does not set EMBEDDED_CONTENT_CONTAINS_SWIFT when there is swift, but the target is an extension' do
+          it 'does not set ALWAYS_EMBED_STANDARD_LIBRARIES when there is swift, but the target is an extension' do
             @target.stubs(:requires_host_target?).returns(true)
             @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
-            @generator.generate.to_hash['EMBEDDED_CONTENT_CONTAINS_SWIFT'].should.be.nil
+            @generator.generate.to_hash['ALWAYS_EMBED_STANDARD_LIBRARIES'].should.be.nil
           end
 
           it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to YES when there is swift' do


### PR DESCRIPTION
Previously was producing warnings when updating pods because of a deprecated flag.