### PR TITLE
[path_list.rb] Improve performance of read_file_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Improve performance of PathList.read_file_system 
+  [Heath Borders](https://github.com/hborders)
+  [#5890](https://github.com/CocoaPods/CocoaPods/issues/5890)
+
 * Cache result of uses_swift and should_build to speed up pod install.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5837](https://github.com/CocoaPods/CocoaPods/pull/5837)

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -57,7 +57,7 @@ module Pod
         dirs, files = dirs_and_files.partition { |path| File.directory?(path) }
 
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
-        relative_sorted = lambda do |paths|
+        sorted_relative_paths_from_full_paths = lambda do |paths|
           relative_paths = paths.lazy.map do |path|
             path_string = path.to_s
             path_string.slice(root_length, path_string.length - root_length)
@@ -65,8 +65,8 @@ module Pod
           relative_paths.sort_by(&:upcase)
         end
 
-        @dirs = relative_sorted.call(dirs)
-        @files = relative_sorted.call(files)
+        @dirs = sorted_relative_paths_from_full_paths.call(dirs)
+        @files = sorted_relative_paths_from_full_paths.call(files)
         @glob_cache = {}
       end
 

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -57,13 +57,13 @@ module Pod
         dirs, files = dirs_and_files.partition { |path| File.directory?(path) }
 
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
-        relative_sorted = lambda { |paths|
-          relative_paths = paths.lazy.map { |path| 
+        relative_sorted = lambda do |paths|
+          relative_paths = paths.lazy.map do |path|
             path_string = path.to_s
-            path_string.slice(root_length, path_string.length - root_length) 
-          }
+            path_string.slice(root_length, path_string.length - root_length)
+          end
           relative_paths.sort_by(&:upcase)
-        }
+        end
 
         @dirs = relative_sorted.call(dirs)
         @files = relative_sorted.call(files)

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -51,11 +51,22 @@ module Pod
           raise Informative, "Attempt to read non existent folder `#{root}`."
         end
         escaped_root = escape_path_for_glob(root)
-        absolute_paths = Pathname.glob(escaped_root + '**/*', File::FNM_DOTMATCH)
+
+        absolute_paths = Pathname.glob(escaped_root + '**/*', File::FNM_DOTMATCH).lazy
         dirs_and_files = absolute_paths.reject { |path| path.basename.to_s =~ /^\.\.?$/ }
-        relative_paths = dirs_and_files.map { |path| path.relative_path_from(root) }
-        sorted_paths = relative_paths.map(&:to_s).sort_by(&:upcase)
-        @dirs, @files = sorted_paths.partition { |path| File.directory?(root + path) }
+        dirs, files = dirs_and_files.partition { |path| File.directory?(path) }
+
+        root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
+        relative_sorted = lambda { |paths|
+          relative_paths = paths.lazy.map { |path| 
+            path_string = path.to_s
+            path_string.slice(root_length, path_string.length - root_length) 
+          }
+          relative_paths.sort_by(&:upcase)
+        }
+
+        @dirs = relative_sorted.call(dirs)
+        @files = relative_sorted.call(files)
         @glob_cache = {}
       end
 


### PR DESCRIPTION
* Used a simple `String.slice` to create relative paths instead of `path.relative_path_from(root)`. Since we already know that all files must exist under `root` (because we globbed `absolute_paths` from `root`), we can just remove the first `root.to_s.length + 1` characters from an `absolute_path` to get a `relative_path`.
* Partition `dirs` and `files` first since we already get an array of absolute paths back from `Pathname.glob`, removing unnecessary string concat: `File.directory?(root + path)`
* Used `lazy` arrays to reduce array iteration.

I [profiled my code before the change](https://github.com/CocoaPods/CocoaPods/files/477973/call-stack.zip).
I [profiled my new code again](https://github.com/CocoaPods/CocoaPods/files/478512/call-stack2.html.zip), and `read_file_system` practically disappears.

previous:

```
real     0m59.095s
user     0m46.133s
sys      0m2.360s
```

now:

```
real     0m23.712s
user     0m14.492s
sys      0m2.030s
```