### PR TITLE
Cache result of include_in_build_config and inhibit_warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Cache result of inhibit_warnings and include_in_build_config to speed up pod install.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#5934](https://github.com/CocoaPods/CocoaPods/pull/5934)
+  
 * Improve performance of PathList.read_file_system 
   [Heath Borders](https://github.com/hborders)
   [#5890](https://github.com/CocoaPods/CocoaPods/issues/5890)


### PR DESCRIPTION
We re-run the profiler against our project and noticed two more big improvements in `pod install` times.

If you wanted to see how long a project with 10+ targets and 130 pods takes to integrate I've attached the generated log here. You might be able to pick other areas of improvements but we noticed again that `pod_target` could be caching some of its results again. 

I do not believe caching these could cause any harm or throw a `pod_target` out of sync.

[profile.zip](https://github.com/CocoaPods/CocoaPods/files/488807/profile.zip) (it might take a bit of time to render in Chrome :))

This dropped our `pod install` time from 1m 8s to about 48seconds.