### PR TITLE
[WIP] Correctly set direct and transitive dependency header search paths fo…

### DIFF
--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -40,14 +40,10 @@ module Pod
         # @return [Xcodeproj::Config]
         #
         def generate
-          target_search_paths = target.build_headers.search_paths(target.platform)
-          sandbox_search_paths = target.sandbox.public_headers.search_paths(target.platform)
-          search_paths = target_search_paths.concat(sandbox_search_paths).uniq
-
           config = {
             'FRAMEWORK_SEARCH_PATHS' => '$(inherited) ',
             'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1',
-            'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(search_paths),
+            'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(target.target_header_search_paths),
             'LIBRARY_SEARCH_PATHS' => '$(inherited) ',
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),
             'PODS_ROOT' => '${SRCROOT}',

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -24,6 +24,7 @@ module Pod
         @sandbox       = sandbox
         @relative_path = relative_path
         @search_paths  = []
+        @cache = {}
       end
 
       # @param  [Platform] platform
@@ -39,6 +40,21 @@ module Pod
 
         headers_dir = root.relative_path_from(sandbox.root).dirname
         ["${PODS_ROOT}/#{headers_dir}/#{@relative_path}"] + platform_search_paths.uniq.map { |entry| "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}" }
+      end
+
+      def search_paths_for_target(platform, target)
+        key = [platform, target.name]
+        if @cache.key?(key)
+          return @cache[key]
+        end
+        platform_search_paths = @search_paths.select do |entry|
+          entry[:platform] == platform.name and entry[:path].basename.to_s == target.name
+        end
+
+        headers_dir = root.relative_path_from(sandbox.root).dirname
+        result = platform_search_paths.uniq.map { |entry| "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}" }
+        @cache[key] = result
+        result
       end
 
       # Removes the directory as it is regenerated from scratch during each

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -281,6 +281,19 @@ module Pod
       "#{configuration_build_dir(dir)}/#{product_name}"
     end
 
+    def target_header_search_paths
+      do_target_header_search_paths
+    end
+
+    def do_target_header_search_paths(header_search_paths = [], include_private_headers = true)
+      header_search_paths.concat(build_headers.search_paths(platform)) if include_private_headers
+      header_search_paths.concat(sandbox.public_headers.search_paths_for_target(platform, self))
+      dependent_targets.each do |dependent_target|
+        dependent_target.do_target_header_search_paths(header_search_paths, false)
+      end
+      header_search_paths.uniq
+    end
+
     private
 
     # @param  [TargetDefinition] target_definition


### PR DESCRIPTION
…r pod targets

closes https://github.com/CocoaPods/CocoaPods/issues/5941

@orta the solution/code might be a bit too junior as I am very junior in Ruby. In a large project we have I can still compile all the Pod dependencies.

This does not force podspecs to include their transitive dependencies. Its still much better than the "catch-all" approach than before.

<img width="786" alt="screen shot 2016-09-24 at 8 36 39 am" src="https://cloud.githubusercontent.com/assets/310370/18809507/11e50e40-8232-11e6-9e29-c41b7021f97a.png">
