### PR TITLE
Expand the usage of the GH Inspector to all of pod install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5837](https://github.com/CocoaPods/CocoaPods/pull/5837)
 
+* GitHub issue inspection will now happen for any StandardError in a pod install  
+  [Orta Therox](https://github.com/orta)
+  [#5950](https://github.com/CocoaPods/CocoaPods/pull/5950)
 
 ##### Bug Fixes
 

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'colored',       '~> 1.2'
   s.add_runtime_dependency 'escape',        '~> 0.0.4'
   s.add_runtime_dependency 'fourflusher',   '~> 1.0.1'
-  s.add_runtime_dependency 'gh_inspector',   '~> 1.0'
+  s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
 
   s.add_development_dependency 'bacon', '~> 1.1'

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -1,3 +1,5 @@
+require 'gh_inspector'
+
 module Pod
   class Command
     class Install < Command
@@ -35,6 +37,15 @@ module Pod
         installer.repo_update = repo_update?(:default => false)
         installer.update = false
         installer.install!
+      rescue StandardError => e
+        search_for_exceptions(e)
+        raise e
+      end
+
+      def search_for_exceptions(exception)
+        inspector = GhInspector::Inspector.new 'cocoapods', 'cocoapods'
+        message_delegate = UserInterface::InspectorReporter.new
+        inspector.search_exception exception, message_delegate
       end
     end
   end

--- a/spec/functional/command/install_spec.rb
+++ b/spec/functional/command/install_spec.rb
@@ -27,5 +27,35 @@ module Pod
         run_command('install', '--repo-update')
       end
     end
+
+    describe 'Issue Inspection' do
+      before do
+        file = temporary_directory + 'Podfile'
+        File.open(file, 'w') do |f|
+          f.puts('platform :ios')
+          f.puts('pod "Reachability"')
+        end
+      end
+
+      it 'passes raised StandardError to the GH Inspector' do
+        error = StandardError
+        # Replace first method call with raising an error
+        Pod::Command.any_instance.expects(:installer_for_config).raises(error, 'message')
+
+        # Ensure that gh inspector is called
+        Command::Install.any_instance.expects(:search_for_exceptions).returns('')
+
+        lambda { run_command('install') }.should.raise error
+      end
+
+      it 'does not pass CP Informative errors to the GH Inspector' do
+        error = Pod::Informative
+        Pod::Command.any_instance.expects(:installer_for_config).raises(error, 'message')
+
+        # Ensure that gh inspector is not called
+        Command::Install.any_instance.expects(:search_for_exceptions).never
+        lambda { run_command('install') }.should.raise error
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously it would only look at the issues if the error occurred inside a Podfile, or as a part of an informational error that we've created. The problem is, most of our errors right now are occurring outside of that scope. 

So this expands the scope to all of `pod install`. Only when it comes from Ruby, so it should hit a lot of the `Errno::EEXIST - File exists` kind of issues for example. 

Also fixes a minor spacing issue in the gemspec.