### PR TITLE
Remove uses of shell cd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Cache result of inhibit_warnings and include_in_build_config to speed up pod install.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5934](https://github.com/CocoaPods/CocoaPods/pull/5934)
-  
+
 * Improve performance of PathList.read_file_system 
   [Heath Borders](https://github.com/hborders)
   [#5890](https://github.com/CocoaPods/CocoaPods/issues/5890)
@@ -19,10 +19,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Cache result of uses_swift and should_build to speed up pod install.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5837](https://github.com/CocoaPods/CocoaPods/pull/5837)
-
-* GitHub issue inspection will now happen for any StandardError in a pod install  
-  [Orta Therox](https://github.com/orta)
-  [#5950](https://github.com/CocoaPods/CocoaPods/pull/5950)
 
 * Remove uses of `cd` in generated scripts  
   [Ben Asher](https://github.com/benasher44)
@@ -37,10 +33,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Ensure messages apps have an embed frameworks build phase  
   [Ben Asher](https://github.com/benasher44)
   [#5860](https://github.com/CocoaPods/CocoaPods/issues/5860)
-
-* Remove uses of shell `cd` to fix working directory issues  
-  [Ben Asher](https://github.com/benasher44)
-  [#5891](https://github.com/CocoaPods/CocoaPods/issues/5891)
 
 ## 1.1.0.rc.2 (2016-09-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Ben Asher](https://github.com/benasher44)
   [#5860](https://github.com/CocoaPods/CocoaPods/issues/5860)
 
+* Remove uses of shell `cd` to fix working directory issues  
+  [Ben Asher](https://github.com/benasher44)
+  [#5891](https://github.com/CocoaPods/CocoaPods/issues/5891)
+
 ## 1.1.0.rc.2 (2016-09-13)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5837](https://github.com/CocoaPods/CocoaPods/pull/5837)
 
+* GitHub issue inspection will now happen for any StandardError in a pod install  
+  [Orta Therox](https://github.com/orta)
+  [#5950](https://github.com/CocoaPods/CocoaPods/pull/5950)
+
+* Remove uses of `cd` in generated scripts  
+  [Ben Asher](https://github.com/benasher44)
+  [#5959](https://github.com/CocoaPods/CocoaPods/pull/5959)
+
 ##### Bug Fixes
 
 * Remove special handling for messages apps  

--- a/Rakefile
+++ b/Rakefile
@@ -178,7 +178,8 @@ begin
       task :rebuild => :check_for_pending_changes do
         tarballs.each do |tarball|
           basename = File.basename(tarball)
-          sh "cd #{File.dirname(tarball)} && rm #{basename} && env COPYFILE_DISABLE=1 tar -zcf #{basename} #{basename[0..-8]}"
+          untarred_path = File.join(File.dirname(tarball), basename[0..-8])
+          sh "rm #{tarball} && env COPYFILE_DISABLE=1 tar -zcf #{tarball} #{untarred_path}"
         end
       end
 

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -119,12 +119,6 @@ case "${TARGETED_DEVICE_FAMILY}" in
     ;;
 esac
 
-realpath() {
-  DIRECTORY="$(cd "${1%/*}" && pwd)"
-  FILENAME="${1##*/}"
-  echo "$DIRECTORY/$FILENAME"
-}
-
 install_resource()
 {
   if [[ "$1" = /* ]] ; then
@@ -166,7 +160,7 @@ EOM
       xcrun mapc "$RESOURCE_PATH" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/`basename "$RESOURCE_PATH" .xcmappingmodel`.cdm"
       ;;
     *.xcassets)
-      ABSOLUTE_XCASSET_FILE=$(realpath "$RESOURCE_PATH")
+      ABSOLUTE_XCASSET_FILE="$RESOURCE_PATH"
       XCASSET_FILES+=("$ABSOLUTE_XCASSET_FILE")
       ;;
     *)
@@ -195,7 +189,7 @@ then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
   OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)
   while read line; do
-    if [[ $line != "`realpath $PODS_ROOT`*" ]]; then
+    if [[ $line != "${PODS_ROOT}*" ]]; then
       XCASSET_FILES+=("$line")
     fi
   done <<<"$OTHER_XCASSETS"

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -241,9 +241,9 @@ module Pod
 
             build_phase = native_target.new_shell_script_build_phase('Create Symlinks to Header Folders')
             build_phase.shell_script = <<-eos.strip_heredoc
-          cd "$CONFIGURATION_BUILD_DIR/$WRAPPER_NAME"
-          ln -fs ${PUBLIC_HEADERS_FOLDER_PATH\#$WRAPPER_NAME/} ${PUBLIC_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
-          ln -fs ${PRIVATE_HEADERS_FOLDER_PATH\#\$WRAPPER_NAME/} ${PRIVATE_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
+          local base="$CONFIGURATION_BUILD_DIR/$WRAPPER_NAME"
+          ln -fs $base/${PUBLIC_HEADERS_FOLDER_PATH\#$WRAPPER_NAME/} $base/${PUBLIC_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
+          ln -fs $base/${PRIVATE_HEADERS_FOLDER_PATH\#\$WRAPPER_NAME/} $base/${PRIVATE_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
             eos
           end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -241,7 +241,7 @@ module Pod
 
             build_phase = native_target.new_shell_script_build_phase('Create Symlinks to Header Folders')
             build_phase.shell_script = <<-eos.strip_heredoc
-          local base="$CONFIGURATION_BUILD_DIR/$WRAPPER_NAME"
+          base="$CONFIGURATION_BUILD_DIR/$WRAPPER_NAME"
           ln -fs $base/${PUBLIC_HEADERS_FOLDER_PATH\#$WRAPPER_NAME/} $base/${PUBLIC_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
           ln -fs $base/${PRIVATE_HEADERS_FOLDER_PATH\#\$WRAPPER_NAME/} $base/${PRIVATE_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
             eos


### PR DESCRIPTION
In most cases, I just switched to passing full paths. For the `realpath` function, I'm 99% we don't need it. In its script, it's used for `PODS_ROOT`, which is always a full path, and `RESOURCE_PATH`, which is checked early on and also set to a full path (relative to `PODS_ROOT`) if it's not one. 