### PR TITLE
Remove the superfluous call to gh inspector introduced in #5950

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5837](https://github.com/CocoaPods/CocoaPods/pull/5837)
 
-* GitHub issue inspection will now happen for any StandardError in a pod install  
-  [Orta Therox](https://github.com/orta)
-  [#5950](https://github.com/CocoaPods/CocoaPods/pull/5950)
-
 ##### Bug Fixes
 
 * Remove special handling for messages apps  

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -1,5 +1,3 @@
-require 'gh_inspector'
-
 module Pod
   class Command
     class Install < Command
@@ -37,15 +35,6 @@ module Pod
         installer.repo_update = repo_update?(:default => false)
         installer.update = false
         installer.install!
-      rescue StandardError => e
-        search_for_exceptions(e)
-        raise e
-      end
-
-      def search_for_exceptions(exception)
-        inspector = GhInspector::Inspector.new 'cocoapods', 'cocoapods'
-        message_delegate = UserInterface::InspectorReporter.new
-        inspector.search_exception exception, message_delegate
       end
     end
   end

--- a/spec/functional/command/install_spec.rb
+++ b/spec/functional/command/install_spec.rb
@@ -27,35 +27,5 @@ module Pod
         run_command('install', '--repo-update')
       end
     end
-
-    describe 'Issue Inspection' do
-      before do
-        file = temporary_directory + 'Podfile'
-        File.open(file, 'w') do |f|
-          f.puts('platform :ios')
-          f.puts('pod "Reachability"')
-        end
-      end
-
-      it 'passes raised StandardError to the GH Inspector' do
-        error = StandardError
-        # Replace first method call with raising an error
-        Pod::Command.any_instance.expects(:installer_for_config).raises(error, 'message')
-
-        # Ensure that gh inspector is called
-        Command::Install.any_instance.expects(:search_for_exceptions).returns('')
-
-        lambda { run_command('install') }.should.raise error
-      end
-
-      it 'does not pass CP Informative errors to the GH Inspector' do
-        error = Pod::Informative
-        Pod::Command.any_instance.expects(:installer_for_config).raises(error, 'message')
-
-        # Ensure that gh inspector is not called
-        Command::Install.any_instance.expects(:search_for_exceptions).never
-        lambda { run_command('install') }.should.raise error
-      end
-    end
   end
 end


### PR DESCRIPTION
Undoes #5950 - as it was running the inspector twice.