### PR TITLE
Fix "does not update non-git repo" test

### DIFF
--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -88,6 +88,7 @@ module Pod
         FileUtils.mkdir_p(tmp_directory)
         FileUtils.cp_r(ROOT + 'spec/fixtures/spec-repos/test_repo/', tmp_directory)
         non_git_repo = tmp_directory + 'test_repo'
+        FileUtils.rm(non_git_repo + '.git')
 
         podfile = Podfile.new do
           platform :ios, '8.0'


### PR DESCRIPTION
The test suggests that the fixture is a non-git repo when in reality it is not. Seemingly, the `.git` file in there references a relative path, but newer versions of git seem to make it absolute when cloning the
fixtures. This results in the copied repo being treated as a git repo and the test failing. The fix just removes `.git` after copying, making the fixture an actual non-git repo :)