### PR TITLE
Allow passing --swift-version to pod spec/lib lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Danielle Tomlinson](https://github.com/dantoml)
   [#5984](https://github.com/CocoaPods/CocoaPods/pull/5984)
 
+* Allow setting the linting Swift version via `--swift-version=VERSION`  
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#5989](https://github.com/CocoaPods/CocoaPods/pull/5989)
+
 ##### Bug Fixes
 
 * Remove special handling for messages apps  

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -21,6 +21,7 @@ module Pod
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
             ['--private', 'Lint skips checks that apply only to public specs'],
+            ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec'],
           ].concat(super)
         end
 
@@ -34,6 +35,7 @@ module Pod
           @use_frameworks  = !argv.flag?('use-libraries')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
           @private         = argv.flag?('private', false)
+          @swift_version   = argv.option('swift-version', nil)
           @podspecs_paths  = argv.arguments!
           super
         end
@@ -55,6 +57,7 @@ module Pod
             validator.only_subspec   = @only_subspec
             validator.use_frameworks = @use_frameworks
             validator.ignore_public_only_results = @private
+            validator.swift_version = @swift_version
             validator.validate
 
             unless @clean

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -21,7 +21,8 @@ module Pod
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
             ['--private', 'Lint skips checks that apply only to public specs'],
-            ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec'],
+            ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec. ' \
+             'This takes precedence over a .swift-version file.'],
           ].concat(super)
         end
 

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -27,6 +27,7 @@ module Pod
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
             ['--private', 'Lint skips checks that apply only to public specs'],
+            ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec'],
           ].concat(super)
         end
 
@@ -40,6 +41,7 @@ module Pod
           @use_frameworks  = !argv.flag?('use-libraries')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
           @private         = argv.flag?('private', false)
+          @swift_version   = argv.option('swift-version', nil)
           @podspecs_paths  = argv.arguments!
           super
         end
@@ -57,6 +59,7 @@ module Pod
             validator.only_subspec   = @only_subspec
             validator.use_frameworks = @use_frameworks
             validator.ignore_public_only_results = @private
+            validator.swift_version = @swift_version
             validator.validate
             failure_reasons << validator.failure_reason
 

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -27,7 +27,8 @@ module Pod
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
             ['--private', 'Lint skips checks that apply only to public specs'],
-            ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec'],
+            ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec. ' \
+             'This takes precedence over a .swift-version file.'],
           ].concat(super)
         end
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -251,6 +251,10 @@ module Pod
       @swift_version ||= dot_swift_version || '2.3'
     end
 
+    # Set the SWIFT_VERSION that should be used to validate the pod.
+    #
+    attr_writer :swift_version
+
     # @return [String] the SWIFT_VERSION in the .swift-version file or nil.
     #
     def dot_swift_version

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -834,6 +834,13 @@ module Pod
           validator.swift_version.should == '2.3'
         end
 
+        it 'allows the user to set the version' do
+          validator = test_swiftpod
+          validator.stubs(:dot_swift_version).returns('3.0')
+          validator.swift_version = '4.0'
+          validator.swift_version.should == '4.0'
+        end
+
         it 'checks for dot_swift_version' do
           validator = test_swiftpod
           validator.expects(:dot_swift_version)


### PR DESCRIPTION
Default remains as `2.3`. `.swift-version` file is still supported to prevent users from needing to always pass the flag. The flag takes precedence over the file.

For future people viewing this PR:

## Linting a Swift 3.0 pod:

### Locally

`pod lib lint --swift-version=3.0`

or:

```
echo "3.0" > .swift-version
pod lib lint
```


### Online

`pod spec lint --swift-version=3.0`

or:

```
echo "3.0" > .swift-version
pod spec lint
```