### PR TITLE
Redefine FOUNDATION_EXPORT for C-only pods in umbrella header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Ben Asher](https://github.com/benasher44)
   [#6064](https://github.com/CocoaPods/CocoaPods/issues/6064)
 
+* Redefine FOUNDATION_EXPORT for C-only pods in umbrella header 
+  [Chris Ballinger](https://github.com/chrisballinger)
+  [#6024](https://github.com/CocoaPods/CocoaPods/issues/6024)
+
 
 ## 1.1.1 (2016-10-20)
 
@@ -67,6 +71,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * None.  
 
+* Redefine FOUNDATION_EXPORT for C-only pods in umbrella header 
+  [Chris Ballinger](https://github.com/chrisballinger)
+  [#6024](https://github.com/CocoaPods/CocoaPods/issues/6024)
 
 ## 1.1.0.rc.3 (2016-10-11)
 

--- a/lib/cocoapods/generator/header.rb
+++ b/lib/cocoapods/generator/header.rb
@@ -42,6 +42,14 @@ module Pod
         result = ''
         result << "#ifdef __OBJC__\n"
         result << generate_platform_import_header
+        result << "#else\n"
+        result << "#ifndef FOUNDATION_EXPORT\n"
+        result << "#if defined(__cplusplus)\n"
+        result << "#define FOUNDATION_EXPORT extern \"C\"\n"
+        result << "#else\n"
+        result << "#define FOUNDATION_EXPORT extern\n"
+        result << "#endif\n"
+        result << "#endif\n"
         result << "#endif\n"
         result << "\n"
 

--- a/spec/unit/generator/header_spec.rb
+++ b/spec/unit/generator/header_spec.rb
@@ -11,6 +11,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import "header.h"
@@ -22,6 +30,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
 
@@ -55,6 +71,14 @@ module Pod
       path.read.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       EOS

--- a/spec/unit/generator/prefix_header_spec.rb
+++ b/spec/unit/generator/prefix_header_spec.rb
@@ -14,6 +14,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import "BlocksKit.h"
@@ -30,6 +38,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import "BlocksKit.h"
@@ -51,6 +67,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import "BlocksKit.h"
@@ -61,6 +85,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import <BananaTree/BananaTree.h>
@@ -80,6 +112,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import <BananaTree/BananaTree.h>
@@ -91,6 +131,14 @@ module Pod
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import "header.h"
@@ -104,6 +152,14 @@ module Pod
       path.read.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
       #import <UIKit/UIKit.h>
+      #else
+      #ifndef FOUNDATION_EXPORT
+      #if defined(__cplusplus)
+      #define FOUNDATION_EXPORT extern "C"
+      #else
+      #define FOUNDATION_EXPORT extern
+      #endif
+      #endif
       #endif
 
       #import <BananaTree/BananaTree.h>

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -291,6 +291,14 @@ module Pod
               expected = <<-EOS.strip_heredoc
           #ifdef __OBJC__
           #import <UIKit/UIKit.h>
+          #else
+          #ifndef FOUNDATION_EXPORT
+          #if defined(__cplusplus)
+          #define FOUNDATION_EXPORT extern "C"
+          #else
+          #define FOUNDATION_EXPORT extern
+          #endif
+          #endif
           #endif
 
           #import "BlocksKit.h"


### PR DESCRIPTION
Fixes #6024 

e.g.

```objc
#ifdef __OBJC__
#import <UIKit/UIKit.h>
#else
#ifndef FOUNDATION_EXPORT
#if defined(__cplusplus)
#define FOUNDATION_EXPORT extern "C"
#else
#define FOUNDATION_EXPORT extern
#endif
#endif
#endif
```