### PR TITLE
Use host target for frameworks of XPC services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Use host target for frameworks of XPC services.
+  [Ingmar Stein](https://github.com/IngmarStein)
+  [#6029](https://github.com/CocoaPods/CocoaPods/pull/6029)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* Use host target for frameworks of XPC services.
+* Use host target for frameworks of XPC services.  
   [Ingmar Stein](https://github.com/IngmarStein)
   [#6029](https://github.com/CocoaPods/CocoaPods/pull/6029)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: a517d2371f5156e6b4db0948418189a7066d8607
+  revision: 8d21748dd4f47e9272501d938398e9d50c49fefe
   branch: master
   specs:
     xcodeproj (1.3.2)
@@ -277,4 +277,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.12.5
+   1.13.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,4 +277,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.13.3
+   1.12.5

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -9,7 +9,7 @@ module Pod
 
     # Product types where the product's frameworks must be embedded in a host target
     #
-    EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :messages_extension, :watch_extension].freeze
+    EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :messages_extension, :watch_extension, :xpc_service].freeze
 
     # Initialize a new instance
     #

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -224,6 +224,11 @@ module Pod
             @target.requires_host_target?.should == true
           end
 
+          it 'requires a host target for XPC service targets' do
+            @target.user_targets.first.stubs(:symbol_type).returns(:xpc_service)
+            @target.requires_host_target?.should == true
+          end
+
           it 'does not require a host target for watch 2 extension targets' do
             @target.user_targets.first.stubs(:symbol_type).returns(:watch2_extension)
             @target.requires_host_target?.should == false


### PR DESCRIPTION
This PR adds XPC services to the list of project types where frameworks must be embedded in a host target.

References https://github.com/CocoaPods/Xcodeproj/pull/428