### PR TITLE
Generate a PODS_TARGET_SRCROOT build setting for every pod target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Generate `PODS_TARGET_SRCROOT` build setting for each pod target.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#5375](https://github.com/CocoaPods/CocoaPods/issues/5375)
+
 * Add support for running CocoaPods on Linux.  
   [Samuel Giddins](https://github.com/segiddins)
 

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -51,6 +51,7 @@ module Pod
             'LIBRARY_SEARCH_PATHS' => '$(inherited) ',
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target),
             'PODS_ROOT' => '${SRCROOT}',
+            'PODS_TARGET_SRCROOT' => target.pod_target_srcroot,
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
             'SKIP_INSTALL' => 'YES',
             # 'USE_HEADERMAP' => 'NO'

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -292,6 +292,12 @@ module Pod
       "#{configuration_build_dir(dir)}/#{product_name}"
     end
 
+    # @return [String] The source path of the root for this target relative to `$(PODS_ROOT)`
+    #
+    def pod_target_srcroot
+      "${PODS_ROOT}/#{sandbox.pod_dir(pod_name).relative_path_from(sandbox.root)}"
+    end
+
     private
 
     # @param  [TargetDefinition] target_definition

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -79,6 +79,16 @@ module Pod
             @xcconfig.to_hash['PODS_ROOT'].should.not.nil?
           end
 
+          it 'sets the PODS_TARGET_SRCROOT build variable for non local pod' do
+            @xcconfig.to_hash['PODS_TARGET_SRCROOT'].should == '${PODS_ROOT}/BananaLib'
+          end
+
+          it 'sets the PODS_TARGET_SRCROOT build variable for local pod' do
+            @pod_target.sandbox.store_local_path(@pod_target.pod_name, @spec.defined_in_file)
+            @xcconfig = @generator.generate
+            @xcconfig.to_hash['PODS_TARGET_SRCROOT'].should == '${PODS_ROOT}/../../spec/fixtures/banana-lib/BananaLib.podspec'
+          end
+
           it 'adds the library build headers and public headers search paths to the xcconfig, with quotes' do
             private_headers = "\"#{@pod_target.build_headers.search_paths(:ios).join('" "')}\""
             public_headers = "\"#{config.sandbox.public_headers.search_paths(:ios).join('" "')}\""


### PR DESCRIPTION
closes #5375, #5409

Podspecs can now safely depend on this build setting whether they are consumed locally or not to adjust various settings such as `HEADER_SEARCH_PATHS`.

/cc @mrackwitz @chrisballinger 

/cc @jcanizales this fixes your issue and hack in https://github.com/grpc/grpc/blob/master/src/objective-c/examples/Sample/Podfile#L30-L48 if you have time can you try this change and see if it works for you? It certainly works for us.

