### PR TITLE
[CopyResourcesScript] add empty enum case for tvOS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Orta Therox](https://github.com/orta)
   [#6049](https://github.com/CocoaPods/CocoaPods/pull/6049)
 
-
 ##### Bug Fixes
 
-* None.  
-
+* Add target-device tvOS in copy_resources generator.    
+[Konrad Feiler](https://github.com/Bersaelor)
+[#6052](https://github.com/CocoaPods/CocoaPods/issues/6052)
 
 ## 1.1.0.rc.3 (2016-10-11)
 

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -114,6 +114,9 @@ case "${TARGETED_DEVICE_FAMILY}" in
   2)
     TARGET_DEVICE_ARGS="--target-device ipad"
     ;;
+  3)
+    TARGET_DEVICE_ARGS="--target-device tv"
+    ;;
   *)
     TARGET_DEVICE_ARGS="--target-device mac"
     ;;

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -28,10 +28,10 @@
 #
 # - Have a way to track precisely the evolution of the artifacts (and of the
 #   UI) produced by CocoaPods (git diff of the after folders).
-# - Allow uses to submit pull requests with the environment necessary to
+# - Allow users to submit pull requests with the environment necessary to
 #   reproduce an issue.
 # - Have robust tests which don't depend on the programmatic interface of
-#   CocoaPods. These tests depend only the binary and its arguments an thus are
+#   CocoaPods. These tests depend only the binary and its arguments and thus are
 #   suitable for testing CP regardless of the implementation (they could even
 #   work for an Objective-C one)
 


### PR DESCRIPTION
[Fix for issue 6052](https://github.com/CocoaPods/CocoaPods/issues/6052)

TARGETED_DEVICE_FAMILY will be 3) for tvOS.
Without this line we get the following error when running the '[CP] Copy Pods Resources' build phase on a tvOS framework target:

```
***-tvOS.storyboard: error: tvOS storyboards do not support target device type "mac".
```

I first tried replacing the `target-device` with `appletv` or `tvos` but then realized that not setting this parameter works best.
<img width="974" alt="error ibtool" src="https://cloud.githubusercontent.com/assets/4517582/19446053/58145836-9497-11e6-8618-df30854907fa.png">

[Tested with Xcode 8]