### PR TITLE
Adds support in the validator for expressing what version of Swift was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Uku Loskit](https://github.com/UkuLoskit)
   [#6037](https://github.com/CocoaPods/CocoaPods/issues/6037)
 
+* The validator has an API for accessing which version of Swift was used.    
+  [Orta Therox](https://github.com/orta)
+  [#6049](https://github.com/CocoaPods/CocoaPods/pull/6049)
+
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -262,6 +262,13 @@ module Pod
       swift_version_path.read if swift_version_path.exist?
     end
 
+    # @return [String] A string representing the Swift version used during linting
+    #                  or nil, if Swift was not used.
+    #
+    def used_swift_version
+      swift_version if @installer.pod_targets.any?(&:uses_swift?)
+    end
+
     #-------------------------------------------------------------------------#
 
     private

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -868,7 +868,29 @@ module Pod
           validator.dot_swift_version.should == '1.0'
         end
       end
+
+      describe 'Getting the Swift value used by the validator' do
+        it 'passes nil when no targets have used Swift' do
+          validator = test_swiftpod
+          pod_target = stub(:uses_swift? => true)
+          installer = stub(:pod_targets => [pod_target])
+          validator.instance_variable_set(:@installer, installer)
+
+          validator.stubs(:dot_swift_version).returns('1.2.3')
+          validator.used_swift_version.should == '1.2.3'
+        end
+
+        it 'returns the swift_version when a target has used Swift' do
+          validator = test_swiftpod
+          pod_target = stub(:uses_swift? => false)
+          installer = stub(:pod_targets => [pod_target])
+          validator.instance_variable_set(:@installer, installer)
+
+          validator.used_swift_version.should.nil?
+        end
+      end
     end
+
     #-------------------------------------------------------------------------#
   end
 end


### PR DESCRIPTION
Allow our trunk plugin's uploader to correctly understand whether or not swift was used, and which version was chosen for https://github.com/CocoaPods/cocoapods-trunk/pull/77