### PR TITLE
Read the correct SWIFT_VERSION when generating target XCConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Add target-device tvOS in copy_resources generator.    
-[Konrad Feiler](https://github.com/Bersaelor)
-[#6052](https://github.com/CocoaPods/CocoaPods/issues/6052)
+* Add target-device tvOS in copy_resources generator.  
+  [Konrad Feiler](https://github.com/Bersaelor)
+  [#6052](https://github.com/CocoaPods/CocoaPods/issues/6052)
+
+* Read the correct `SWIFT_VERSION` when generating target XCConfigs
+  [Ben Asher](https://github.com/benasher44)
+  [#6067](https://github.com/CocoaPods/CocoaPods/issues/6067)
 
 
 ## 1.1.1 (2016-10-20)

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -88,9 +88,10 @@ module Pod
 
         protected
 
+        # @return String the SWIFT_VERSION of the target being integrated
+        #
         def target_swift_version
-          settings = target.native_target.resolved_build_setting('SWIFT_VERSION') unless target.native_target.nil?
-          settings.values.compact.uniq.first unless settings.nil?
+          target.target_definition.swift_version unless target.target_definition.swift_version.blank?
         end
 
         EMBED_STANDARD_LIBRARIES_MINIMUM_VERSION = Gem::Version.new('2.3')

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -241,6 +241,11 @@ module Pod
             @xcconfig.to_hash['OTHER_SWIFT_FLAGS'].should.include '$(inherited) "-D" "COCOAPODS"'
           end
 
+          it 'uses the target definition swift version' do
+            @target_definition.stubs(:swift_version).returns('0.1')
+            @generator.send(:target_swift_version).should == '0.1'
+          end
+
           it 'sets EMBEDDED_CONTENT_CONTAINS_SWIFT when the target_swift_version is < 2.3' do
             @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
             @generator.stubs(:target_swift_version).returns('2.2')


### PR DESCRIPTION
We were trying to read the `SWIFT_VERSION` that we generate for pod targets by mistake.

This fixes #6067