### PR TITLE
Don't explicitly set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 [Konrad Feiler](https://github.com/Bersaelor)
 [#6052](https://github.com/CocoaPods/CocoaPods/issues/6052)
 
+* Don't explicitly set `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` to NO
+  [Ben Asher](https://github.com/benasher44)
+  [#6064](https://github.com/CocoaPods/CocoaPods/issues/6064)
+
 
 ## 1.1.1 (2016-10-20)
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -109,17 +109,14 @@ module Pod
 
           swift_version = Gem::Version.new(target_swift_version)
           should_embed = !target.requires_host_target? && pod_targets.any?(&:uses_swift?)
-          embed_value = should_embed ? 'YES' : 'NO'
-
-          config = {
-            'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => embed_value,
-            'EMBEDDED_CONTENT_CONTAINS_SWIFT' => embed_value,
-          }
-
-          if swift_version >= EMBED_STANDARD_LIBRARIES_MINIMUM_VERSION || !should_embed
-            config.delete('EMBEDDED_CONTENT_CONTAINS_SWIFT')
+          config = {}
+          if should_embed
+            if swift_version >= EMBED_STANDARD_LIBRARIES_MINIMUM_VERSION
+              config['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
+            else
+              config['EMBEDDED_CONTENT_CONTAINS_SWIFT'] = 'YES'
+            end
           end
-
           config
         end
 

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -272,17 +272,17 @@ module Pod
             @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].should == 'YES'
           end
 
-          it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO when there is no swift' do
+          it 'does not set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES when there is no swift' do
             @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(false)
             @generator.stubs(:target_swift_version).returns(nil)
-            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].should == 'NO'
+            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].nil?.should == true
           end
 
-          it 'sets ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO when there is swift, but the target is an extension' do
+          it 'does not set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES when there is swift, but the target is an extension' do
             @target.stubs(:requires_host_target?).returns(true)
             @generator.stubs(:target_swift_version).returns('2.3')
             @generator.send(:pod_targets).first.stubs(:uses_swift?).returns(true)
-            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].should == 'NO'
+            @generator.generate.to_hash['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'].nil?.should == true
           end
 
           it 'does not set EMBEDDED_CONTENT_CONTAINS_SWIFT when there is swift 2.3 or higher' do


### PR DESCRIPTION
This is the previous behavior for how we handled `EMBEDDED_CONTENT_CONTAINS_SWIFT`. I can't remember why I explicitly set the new one to NO. It's possible that it was related to an early Xcode beta issue, or I explicitly set it because that's what Xcode does when you apply the recommended build setting changes when updating to Xcode 8.

This fixes #6064.