### PR TITLE
Re-escaped backslashes in embed_frameworks generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Re-escaped backslashes in embed_frameworks generator  
+  [Harlan Haskins](https://github.com/harlanhaskins)
+  [#6121](https://github.com/CocoaPods/CocoaPods/issues/6121)
 
 
 ## 1.2.0.beta.1 (2016-10-28)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -96,7 +96,7 @@ module Pod
             if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
-              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements \"$1\""
+              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements \\"$1\\""
 
               if [ "${COCOAPODS_PARALLEL_CODE_SIGN}" == "true" ]; then
                 code_sign_cmd="$code_sign_cmd &"


### PR DESCRIPTION
0d889c8 seems to have undone the escaped quotes, making them just regular bash quotes. This breaks app paths that have spaces in them.

This patch re-escapes the backslashes that escape the quotes in the generated bash (wow, that's a mouthful).

This tracks the fix for issue #6121 