### PR TITLE
Escape spaces in CONFIGURATION_BUILD_DIR when creating header folders symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Harlan Haskins](https://github.com/harlanhaskins)
   [#6121](https://github.com/CocoaPods/CocoaPods/issues/6121)
 
+* Escape spaces in CONFIGURATION_BUILD_DIR when creating header folders symlink  
+  [Dmitry Obukhov](https://github.com/stel)
+  [#6146](https://github.com/CocoaPods/CocoaPods/pull/6146)
 
 ## 1.2.0.beta.1 (2016-10-28)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -242,8 +242,8 @@ module Pod
             build_phase = native_target.new_shell_script_build_phase('Create Symlinks to Header Folders')
             build_phase.shell_script = <<-eos.strip_heredoc
           base="$CONFIGURATION_BUILD_DIR/$WRAPPER_NAME"
-          ln -fs $base/${PUBLIC_HEADERS_FOLDER_PATH\#$WRAPPER_NAME/} $base/${PUBLIC_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
-          ln -fs $base/${PRIVATE_HEADERS_FOLDER_PATH\#\$WRAPPER_NAME/} $base/${PRIVATE_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}
+          ln -fs "$base/${PUBLIC_HEADERS_FOLDER_PATH\#$WRAPPER_NAME/}" "$base/${PUBLIC_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}"
+          ln -fs "$base/${PRIVATE_HEADERS_FOLDER_PATH\#\$WRAPPER_NAME/}" "$base/${PRIVATE_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}"
             eos
           end
 


### PR DESCRIPTION
If Xcode target name contains whitespaces Create Symlinks to Header Folders build phase fails on Archiving macOS app.

Podfile to reproduce:
```ruby
target 'Test Project Name' do
    use_frameworks!
    pod 'Realm'
end
```

Error message on Archiving:
```
ln: Name/BuildProductsPath/Release/Realm/Realm.framework/Headers: No such file or directory
ln: Name/BuildProductsPath/Release/Realm/Realm.framework/PrivateHeaders: No such file or directory
```

Where
```
CONFIGURATION_BUILD_DIR="/Users/do/Library/Developer/Xcode/DerivedData/Test_Project_Name-fqaocpznfgakqffqdcohsxgjtdhz/Build/Intermediates/ArchiveIntermediates/Test Project Name/BuildProductsPath/Release/Realm"
```