### PR TITLE
[Embed] Fix codesigning issues when targets have spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * None.  
 
 ##### Bug Fixes
+
 * Fix codesigning issues when targets have spaces.   
   [Sam Gammon](https://github.com/sgammon)
   [#6153](https://github.com/CocoaPods/CocoaPods/issues/6153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * None.  
 
 ##### Bug Fixes
+* Fix codesigning issues when targets have spaces.   
+  [Sam Gammon](https://github.com/sgammon)
+  [#6153](https://github.com/CocoaPods/CocoaPods/issues/6153)
 
 * Raise an exception if unable to find a reference for a path and handle symlink references.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -77,7 +77,7 @@ module Pod
             fi
 
             # Resign the code if required by the build settings to avoid unstable apps
-            code_sign_if_enabled "\"${destination}/$(basename "$1")\""
+            code_sign_if_enabled "${destination}/$(basename "$1")"
 
             # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
             if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then
@@ -96,7 +96,7 @@ module Pod
             if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
-              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements \\"$1\\""
+              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements '$1'"
 
               if [ "${COCOAPODS_PARALLEL_CODE_SIGN}" == "true" ]; then
                 code_sign_cmd="$code_sign_cmd &"

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -77,7 +77,7 @@ module Pod
             fi
 
             # Resign the code if required by the build settings to avoid unstable apps
-            code_sign_if_enabled "${destination}/$(basename "$1")"
+            code_sign_if_enabled "\"${destination}/$(basename "$1")\""
 
             # Embed linked Swift runtime libraries. No longer necessary as of Xcode 7.
             if [ "${XCODE_VERSION_MAJOR}" -lt 7 ]; then


### PR DESCRIPTION
🌈

This small change fixes an issue with `{target}-frameworks.sh`, wherein spaces in the target cause a `No such file or directory` error. The fix is simple: wrap `code_sign_if_enabled` in quotes. Works in my local env and hope it works in yours too :+1:

Fixes and closes CocoaPods/CocoaPods#6153.