### PR TITLE
Fix cross-project framework dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Danielle Tomlinson](https://github.com/dantoml)
   [#6078](https://github.com/CocoaPods/CocoaPods/issues/6078)
 
+* Fix framework support for frameworks in sub-projects.  
+  [Ben Asher](https://github.com/benasher44)
+  [#6123](https://github.com/CocoaPods/CocoaPods/issues/6123)
+
 
 ## 1.2.0.beta.1 (2016-10-28)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -238,17 +238,18 @@ module Pod
       #
       def copy_embedded_target_pod_targets_to_host(aggregate_target, embedded_aggregate_targets)
         return if aggregate_target.requires_host_target?
-        pod_target_names = Set.new aggregate_target.pod_targets.map(&:name)
-        aggregate_user_target_uuids = Set.new aggregate_target.user_targets.map(&:uuid)
+        pod_target_names = Set.new(aggregate_target.pod_targets.map(&:name))
+        aggregate_user_target_uuids = Set.new(aggregate_target.user_targets.map(&:uuid))
         embedded_aggregate_targets.each do |embedded_aggregate_target|
           next unless embedded_aggregate_target.user_targets.any? do |embedded_user_target|
             # You have to ask the host target's project for the host targets of
             # the embedded target, as opposed to asking user_project for the
             # embedded targets of the host target. The latter doesn't work when
-            # the embedded target lives in a sub-project. The line below gets
+            # the embedded target lives in a sub-project. The lines below get
             # the host target uuids for the embedded target and checks to see if
             # those match to any of the user_target uuids in the aggregate_target.
-            !aggregate_user_target_uuids.intersection(Set.new(aggregate_target.user_project.host_targets_for_embedded_target(embedded_user_target).map(&:uuid))).empty?
+            host_target_uuids = Set.new(aggregate_target.user_project.host_targets_for_embedded_target(embedded_user_target).map(&:uuid))
+            !aggregate_user_target_uuids.intersection(host_target_uuids).empty?
           end
           # This embedded target is hosted by the aggregate target's user_target; copy over the non-duplicate pod_targets
           aggregate_target.pod_targets = aggregate_target.pod_targets + embedded_aggregate_target.pod_targets.select do |pod_target|

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -242,6 +242,12 @@ module Pod
         aggregate_user_target_uuids = Set.new aggregate_target.user_targets.map(&:uuid)
         embedded_aggregate_targets.each do |embedded_aggregate_target|
           next unless embedded_aggregate_target.user_targets.any? do |embedded_user_target|
+            # You have to ask the host target's project for the host targets of
+            # the embedded target, as opposed to asking user_project for the
+            # embedded targets of the host target. The latter doesn't work when
+            # the embedded target lives in a sub-project. The line below gets
+            # the host target uuids for the embedded target and checks to see if
+            # those match to any of the user_target uuids in the aggregate_target.
             !aggregate_user_target_uuids.intersection(Set.new(aggregate_target.user_project.host_targets_for_embedded_target(embedded_user_target).map(&:uuid))).empty?
           end
           # This embedded target is hosted by the aggregate target's user_target; copy over the non-duplicate pod_targets

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -238,18 +238,14 @@ module Pod
       #
       def copy_embedded_target_pod_targets_to_host(aggregate_target, embedded_aggregate_targets)
         return if aggregate_target.requires_host_target?
-        # Get the uuids of the aggregate_target's user_targets' embedded targets if any
-        embedded_uuids = Set.new(aggregate_target.user_targets.map do |target|
-          aggregate_target.user_project.embedded_targets_in_native_target(target).map(&:uuid)
-        end.flatten)
-        return if embedded_uuids.empty?
-        embedded_aggregate_targets.each do |embedded_target|
-          next unless embedded_target.user_targets.map(&:uuid).any? do |embedded_uuid|
-            embedded_uuids.include? embedded_uuid
+        pod_target_names = aggregate_target.pod_targets.map(&:name)
+        aggregate_user_target_uuids = Set.new aggregate_target.user_targets.map(&:uuid)
+        embedded_aggregate_targets.each do |embedded_aggregate_target|
+          next unless embedded_aggregate_target.user_targets.any? do |embedded_user_target|
+            !aggregate_user_target_uuids.intersection(Set.new(aggregate_target.user_project.host_targets_for_embedded_target(embedded_user_target).map(&:uuid))).empty?
           end
-          pod_target_names = aggregate_target.pod_targets.map(&:name)
           # This embedded target is hosted by the aggregate target's user_target; copy over the non-duplicate pod_targets
-          aggregate_target.pod_targets = aggregate_target.pod_targets + embedded_target.pod_targets.select do |pod_target|
+          aggregate_target.pod_targets = aggregate_target.pod_targets + embedded_aggregate_target.pod_targets.select do |pod_target|
             !pod_target_names.include? pod_target.name
           end
         end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -238,7 +238,7 @@ module Pod
       #
       def copy_embedded_target_pod_targets_to_host(aggregate_target, embedded_aggregate_targets)
         return if aggregate_target.requires_host_target?
-        pod_target_names = aggregate_target.pod_targets.map(&:name)
+        pod_target_names = Set.new aggregate_target.pod_targets.map(&:name)
         aggregate_user_target_uuids = Set.new aggregate_target.user_targets.map(&:uuid)
         embedded_aggregate_targets.each do |embedded_aggregate_target|
           next unless embedded_aggregate_target.user_targets.any? do |embedded_user_target|

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -765,10 +765,10 @@ module Pod
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           result = analyzer.analyze
 
-          result.targets.select { |at| at.name == 'Pods-SampleProject' }.flat_map(&:pod_targets).map { |pt| "#{pt.name}" }.sort.uniq.should == [
-            'JSONKit',
-            'monkey',
-          ].sort
+          result.targets.select { |at| at.name == 'Pods-SampleProject' }.flat_map(&:pod_targets).map(&:name).sort.uniq.should == %w(
+            JSONKit
+            monkey
+          ).sort
         end
 
         it "raises when unable to find an extension's host target" do

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -753,7 +753,9 @@ module Pod
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
 
-            target 'SampleProject'
+            target 'SampleProject' do
+              pod 'JSONKit'
+            end
 
             target 'Sample Framework' do
               project 'SampleProject/Sample Lib/Sample Lib'
@@ -763,8 +765,9 @@ module Pod
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           result = analyzer.analyze
 
-          result.targets.flat_map { |at| at.pod_targets.map { |pt| "#{at.name}/#{pt.name}" } }.sort.should == [
-            'Pods-Sample Framework/monkey',
+          result.targets.select { |at| at.name == 'Pods-SampleProject' }.flat_map(&:pod_targets).map { |pt| "#{pt.name}" }.sort.uniq.should == [
+            'JSONKit',
+            'monkey',
           ].sort
         end
 


### PR DESCRIPTION
Fixes #6123 

I fixed `copy_embedded_target_pod_targets_to_host` to properly handle embedded targets that live in another project. I don't think this has worked properly on master. From what I can gather, the way that I originally wrote the test convinced me that this was working. My best guess is that the version of this that I had people asking about this test (and worked) changed during the PR and didn't end up being exactly what made it into master. This fixes the test (verified it failed before), and then it fixes `copy_embedded_target_pod_targets_to_host`.