### PR TITLE
Output Swift targets when multiple versions of Swift are detected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Output Swift targets when multiple versions of Swift are detected.  
+  [Justin Martin](https://github.com/justinseanmartin) & [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6191](https://github.com/CocoaPods/CocoaPods/issues/6191)
+
 * [update] adding --sources to specify to only update pods from a repo  
   [Mark Schall](https://github.com/maschall)
   [#5809](https://github.com/CocoaPods/CocoaPods/pull/5809)


### PR DESCRIPTION
closes #6191 

/cc @justinseanmartin @benasher44 

Output looks like:

```
There may only be up to 1 unique SWIFT_VERSION per target. Found target(s) with multiple Swift versions:
Target: Swift 2.3
Target2: Swift 3.0
```