### PR TITLE
add more HEADER_EXTENSIONS

### DIFF
--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -9,7 +9,7 @@ module Pod
     # @note The FileAccessor always returns absolute paths.
     #
     class FileAccessor
-      HEADER_EXTENSIONS = Xcodeproj::Constants::HEADER_FILES_EXTENSIONS
+      HEADER_EXTENSIONS = (%w(.inl .msg) + Xcodeproj::Constants::HEADER_FILES_EXTENSIONS)
       SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift) + HEADER_EXTENSIONS).uniq.freeze
 
       GLOB_PATTERNS = {


### PR DESCRIPTION
I'm working with cocos2dx. Headers with .inl extension will not be symlinked in Pod Headers. [Like this one](https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/math/MathUtilSSE.inl) .
There're far more header extensions that should be supported regarding that cpp has no limit in header extensions.
OR Should we provide such a config option ?