### PR TITLE
Removed extension integration errors about mismatched Swift version / platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Ben Asher](https://github.com/benasher44)
   [#6123](https://github.com/CocoaPods/CocoaPods/issues/6123)
 
+* Remove errors that prevent host/extension target mismatches, which Xcode will warn about.
+  [Ben Asher](https://github.com/benasher44)
+  [#6173](https://github.com/CocoaPods/CocoaPods/issues/6173)
+
 
 ## 1.2.0.beta.1 (2016-10-28)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -324,19 +324,12 @@ module Pod
         end
 
         target_mismatches = []
-        check_prop = lambda do |target_definition1, target_definition2, attr, msg|
-          attr1 = target_definition1.send(attr)
-          attr2 = target_definition2.send(attr)
-          if attr1 != attr2
-            target_mismatches << "- #{target_definition1.name} (#{attr1}) and #{target_definition2.name} (#{attr2}) #{msg}."
-          end
-        end
         host_uuid_to_embedded_target_definitions.each do |uuid, target_definitions|
           host_target_definition = target_definitions_by_uuid[uuid]
           target_definitions.each do |target_definition|
-            check_prop.call(host_target_definition, target_definition, :platform, 'do not use the same platform')
-            check_prop.call(host_target_definition, target_definition, :uses_frameworks?, 'do not both set use_frameworks!')
-            check_prop.call(host_target_definition, target_definition, :swift_version, 'do not use the same Swift version')
+            unless host_target_definition.uses_frameworks? == target_definition.uses_frameworks?
+              target_mismatches << "- #{host_target_definition.name} (#{host_target_definition.uses_frameworks?}) and #{target_definition.name} (#{target_definition.uses_frameworks?}) do not both set use_frameworks!."
+            end
           end
         end
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -823,51 +823,6 @@ module Pod
             analyzer.analyze
           end.message.should.match /Sample Extensions Project \(false\) and Today Extension \(true\) do not both set use_frameworks!\./
         end
-
-        it 'raises when the extension and host target use different swift versions' do
-          podfile = Pod::Podfile.new do
-            source SpecHelper.test_repo_url
-            platform :ios, '8.0'
-            use_frameworks!
-            project 'Sample Extensions Project/Sample Extensions Project'
-
-            target 'Sample Extensions Project' do
-              pod 'JSONKit', '1.4'
-            end
-
-            target 'Today Extension' do
-              pod 'monkey'
-            end
-          end
-          podfile.target_definitions['Sample Extensions Project'].stubs(:swift_version).returns('2.3')
-          podfile.target_definitions['Today Extension'].stubs(:swift_version).returns('3.0')
-          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
-          should.raise Informative do
-            analyzer.analyze
-          end.message.should.match /Sample Extensions Project \(2\.3\) and Today Extension \(3\.0\) do not use the same Swift version\./
-        end
-
-        it 'raises when the extension and host target use different platforms' do
-          podfile = Pod::Podfile.new do
-            source SpecHelper.test_repo_url
-            platform :ios, '8.0'
-            use_frameworks!
-            project 'Sample Extensions Project/Sample Extensions Project'
-
-            target 'Sample Extensions Project' do
-              pod 'JSONKit', '1.4'
-            end
-
-            target 'Today Extension' do
-              pod 'monkey'
-            end
-          end
-          podfile.target_definitions['Sample Extensions Project'].stubs(:platform).returns(Platform.new(:osx, '10.6'))
-          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
-          should.raise Informative do
-            analyzer.analyze
-          end.message.should.match /Sample Extensions Project \(OS X 10\.6\) and Today Extension \(iOS 8\.0\) do not use the same platform\./
-        end
       end
 
       #-------------------------------------------------------------------------#


### PR DESCRIPTION
This fixes #6173. Xcode should warn you about these issues, so trying to maintain code that replicates this at `pod install` time seems like less of a great idea now. `use_frameworks!` issues are still ones that would be fixed with your CP setup though, so that error will stay.