### PR TITLE
[Repo::Add] Add --progress option to show git progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Show git progress when downloading the CocoaPods Specs repo.  
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#5937](https://github.com/CocoaPods/CocoaPods/issues/5937)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -17,7 +17,7 @@ module Pod
 
         def self.options
           [
-            ['--progress', 'Show the progress of cloning the spec repository']
+            ['--progress', 'Show the progress of cloning the spec repository'],
           ].concat(super)
         end
 
@@ -74,9 +74,9 @@ module Pod
         #
         def clone_repo
           changes = if @progress
-            { verbose: true }
-          else
-            {}
+                      { :verbose => true }
+                    else
+                      {}
           end
 
           config.with_changes(changes) do

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -15,10 +15,17 @@ module Pod
           CLAide::Argument.new('BRANCH', false),
         ]
 
+        def self.options
+          [
+            ['--progress', 'Show the progress of cloning the spec repository']
+          ].concat(super)
+        end
+
         def initialize(argv)
           @name = argv.shift_argument
           @url = argv.shift_argument
           @branch = argv.shift_argument
+          @progress = argv.flag?('progress')
           super
         end
 
@@ -66,9 +73,20 @@ module Pod
         # @return [void]
         #
         def clone_repo
-          Dir.chdir(config.repos_dir) do
-            command = ['clone', @url, @name]
-            git!(command)
+          changes = if @progress
+            { verbose: true }
+          else
+            {}
+          end
+
+          config.with_changes(changes) do
+            Dir.chdir(config.repos_dir) do
+              command = ['clone', @url, @name]
+              if @progress
+                command << '--progress'
+              end
+              git!(command)
+            end
           end
         end
 

--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -50,7 +50,7 @@ module Pod
       # @return [void]
       #
       def add_master_repo
-        cmd = ['master', url, 'master']
+        cmd = ['master', url, 'master', '--progress']
         Repo::Add.parse(cmd).run
       end
 


### PR DESCRIPTION
Git added a `--progress` option in 1.7.0 (earliest tag containing
https://github.com/git/git/commit/5a518ad4679c91f0d0afd38fcc3cbf04e8699c46).

This adds an option to Repo::Add to pass this to git, and makes
Setup pass it by default.

closes https://github.com/CocoaPods/CocoaPods/pull/5297