### PR TITLE
Fix build phase resource references to point at PBXVariantGroups where relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix build phase resource references to point at PBXVariantGroups where relevant
+  [Wes Campaigne](https://github.com/Westacular)
+  [#6373](https://github.com/CocoaPods/CocoaPods/issues/6373)
 
 
 ## 1.2.0.beta.3 (2016-12-28)


### PR DESCRIPTION
Fixes issue reported at https://github.com/CocoaPods/CocoaPods/issues/6373

This just aligns the `add_files_to_build_phases` behaviour with what is
already (correctly) done in `add_resources_bundle_targets`.