### PR TITLE
[Generator] Replace -iquote by -isystem for frameworks in xcconfig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,8 @@
 	url = https://github.com/tonymillion/Reachability.git
 [submodule "spec/cocoapods-integration-specs"]
 	path = spec/cocoapods-integration-specs
-	url = https://github.com/CocoaPods/cocoapods-integration-specs.git
+	url = https://github.com/guillaumealgis/cocoapods-integration-specs.git
+	branch = use-isystem-for-frameworks
 [submodule "spec/fixtures/spec-repos/test_repo"]
 	path = spec/fixtures/spec-repos/test_repo
 	url = https://github.com/CocoaPods/cocoapods-test-specs.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Xinyu Zhao](https://github.com/X140Yu)
   [#8064](https://github.com/CocoaPods/CocoaPods/issues/8064)
 
+* Silence warnings in headers for Pods with `inhibit_warnings => true`  
+  [Guillaume Algis](https://github.com/guillaumealgis)
+  [#6401](https://github.com/CocoaPods/CocoaPods/pull/6401)
+
 ##### Bug Fixes
 
 * Provide an installation option to disable usage of input/output paths.  

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -517,11 +517,15 @@ module Pod
     # @param [Boolean] include_dependent_targets_for_test_spec
     #        whether to include header search paths for test dependent targets
     #
+    # @param [Boolean] include_private_headers
+    #        whether to include header search paths for private headers of this
+    #        target
+    #
     # @return [Array<String>] The set of header search paths this target uses.
     #
-    def header_search_paths(include_dependent_targets_for_test_spec: nil)
+    def header_search_paths(include_dependent_targets_for_test_spec: nil, include_private_headers: true)
       header_search_paths = []
-      header_search_paths.concat(build_headers.search_paths(platform, nil, false))
+      header_search_paths.concat(build_headers.search_paths(platform, nil, false)) if include_private_headers
       header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name, uses_modular_headers?))
       dependent_targets = recursive_dependent_targets
       dependent_targets += recursive_test_dependent_targets(include_dependent_targets_for_test_spec) if include_dependent_targets_for_test_spec


### PR DESCRIPTION
🌈

- Replace usage of the `-iquote` compiler flag by `-isystem` when searching for framework headers. This will silence compilation warning in the Pods' headers files.
> "Header files found in directories added to the search path with the `-isystem` and `-idirafter` command-line options are treated as system headers for the purposes of diagnostics"
> "All warnings [...] are suppressed while GCC is processing a system header"
[https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html](https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html)

- Update unit tests to reflect the above change.

Integrations tests are updated in https://github.com/CocoaPods/cocoapods-integration-specs/pull/94.

This fixes #5589.

When I tested locally with `bundle exec rake spec:all`, it failed on the Alamofire example, but I *think* this is normal and the example was not updated for Xcode 8 (please correct me if I'm wrong). When running the same tests as Travis thought, everything passed.

```
bundle exec bacon spec/functional/command/cache/clean_spec.rb spec/unit/installer/pod_source_installer_spec.rb spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb spec/unit/target/pod_target_spec.rb spec/unit/validator_spec.rb spec/unit/installer/analyzer/pod_variant_set_spec.rb spec/unit/installer/xcode/pods_project_generator_spec.rb spec/unit/installer/pre_install_hooks_context_spec.rb spec/functional/command/ipc/list_spec.rb spec/unit/downloader/cache_spec.rb spec/functional/command/init_spec.rb spec/functional/command/spec_spec.rb spec/functional/command/install_spec.rb spec/functional/command_spec.rb spec/unit/sandbox/pod_dir_cleaner_spec.rb spec/unit/hooks_manager_spec.rb spec/unit/generator/module_map_spec.rb spec/unit/external_sources/abstract_external_source_spec.rb spec/functional/command/ipc/spec_spec.rb spec/unit/generator/header_spec.rb spec/unit/generator/acknowledgements/markdown_spec.rb spec/unit/external_sources/downloader_source_spec.rb spec/unit/installer/post_install_hooks_context_spec.rb spec/unit/installer/user_project_integrator/target_integrator/xcconfig_integrator_spec.rb spec/functional/command/repo/update_spec.rb spec/unit/generator/info_plist_file_spec.rb spec/unit/user_interface/inspector_reporter_spec.rb spec/unit/user_interface_spec.rb spec/unit/generator/dummy_source_spec.rb spec/unit/sandbox_spec.rb spec/functional/command/lib/create_spec.rb spec/unit/external_sources/path_source_spec.rb spec/functional/command/lib/list_spec.rb spec/unit/sandbox/file_accessor_spec.rb spec/unit/config_spec.rb spec/unit/user_interface/error_report_spec.rb spec/unit/generator/prefix_header_spec.rb spec/unit/installer_spec.rb spec/functional/user_interface_spec.rb spec/unit/sandbox/podspec_finder_spec.rb spec/unit/command_spec.rb spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb spec/functional/command/repo/push_spec.rb spec/functional/command/repo_spec.rb spec/unit/executable_spec.rb spec/unit/generator/embed_frameworks_script_spec.rb spec/unit/external_sources/podspec_source_spec.rb spec/unit/installer/analyzer/target_inspector_spec.rb spec/functional/command/repo/lint_spec.rb spec/functional/command/outdated_spec.rb spec/unit/generator/acknowledgements_spec.rb spec/functional/command/setup_spec.rb spec/unit/installer/podfile_validator_spec.rb spec/functional/command/cache/list_spec.rb spec/functional/command/update_spec.rb spec/unit/generator/xcconfig/pod_xcconfig_spec.rb spec/functional/command/ipc/update_search_index_spec.rb spec/unit/downloader_spec.rb spec/unit/installer/installation_options_spec.rb spec/functional/command/list_spec.rb spec/unit/installer/analyzer/pod_variant_spec.rb spec/unit/installer/user_project_integrator_spec.rb spec/unit/generator/copy_resources_script_spec.rb spec/unit/target_spec.rb spec/unit/project_spec.rb spec/unit/installer/source_provider_hooks_context_spec.rb spec/unit/downloader/request_spec.rb spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb spec/unit/installer/analyzer/sandbox_analyzer_spec.rb spec/functional/command/repo/list_spec.rb spec/unit/target/aggregate_target_spec.rb spec/unit/installer/analyzer_spec.rb spec/unit/installer/user_project_integrator/target_integrator_spec.rb spec/functional/command/repo/remove_spec.rb spec/functional/command/repo/add_spec.rb spec/unit/sandbox/headers_store_spec.rb spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb spec/unit/sources_manager_spec.rb spec/unit/generator/xcconfig_spec.rb spec/unit/resolver_spec.rb spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb spec/unit/external_sources_spec.rb spec/unit/generator/bridge_support_spec.rb spec/functional/command/ipc/repl_spec.rb spec/unit/generator/acknowledgements/plist_spec.rb spec/unit/sandbox/path_list_spec.rb spec/functional/command/ipc/podfile_spec.rb spec/unit/generator/xcconfig/xcconfig_helper_spec.rb spec/unit/library_spec.rb
```

This is my first PR to CocoaPods, please let me know if I missed anything 👍