### PR TITLE
Cache results of dynamic_binary?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Orta Therox](https://github.com/orta)
   [xcodeproj#463](https://github.com/CocoaPods/Xcodeproj/pull/463)
 
+* Cache results of dynamic_binary?  
+  [Ken Wigginton](https://github.com/hailstorm350)
+  [#6434](https://github.com/CocoaPods/CocoaPods/pull/6434)
+
 ##### Bug Fixes
 
 * Correctly handle `OTHER_LDFLAGS` for targets with inherit search paths and source pods.  

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -372,10 +372,13 @@ module Pod
       # @return [Boolean] Whether `binary` can be dynamically linked.
       #
       def dynamic_binary?(binary)
-        return unless binary.file?
-        MachO.open(binary).dylib?
+        @cached_dynamic_binary_results ||= {}
+        return @cached_dynamic_binary_results[binary] unless @cached_dynamic_binary_results[binary].nil?
+        return false unless binary.file?
+
+        @cached_dynamic_binary_results[binary] = MachO.open(binary).dylib?
       rescue MachO::MachOError
-        false
+        @cached_dynamic_binary_results[binary] = false
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -265,6 +265,21 @@ module Pod
           @accessor.send(:paths_for_attribute, :source_files)
         end
       end
+
+      describe '#dynamic_binary?' do
+        it 'not a dynamic binary if its not a file' do
+          binary = stub(:file? => false)
+          @accessor.send(:dynamic_binary?, binary).should.be.false
+        end
+
+        it 'uses the cache after the first time' do
+          binary = stub(:file? => true)
+          macho_file = stub(:dylib? => true)
+          MachO.stubs(:open).once.returns(macho_file)
+          @accessor.send(:dynamic_binary?, binary).should.be.true
+          @accessor.send(:dynamic_binary?, binary).should.be.true
+        end
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
This caches the results of MachO.open(...).dylib?

For large projects with hundreds of dependencies, this becomes quite an expensive operation.