### PR TITLE
Use ${SRCROOT} rather than ${PODS_ROOT} in the generated manifest lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Use `${SRCROOT}` rather than `${PODS_ROOT}` in the generated manifest lock script phase.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#5499](https://github.com/CocoaPods/CocoaPods/issues/5499)
+  
 * Fix build phase resource references to point at PBXVariantGroups where relevant.  
   [Wes Campaigne](https://github.com/Westacular)
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -177,7 +177,7 @@ module Pod
             phase = create_or_update_build_phase(native_target, phase_name)
             native_target.build_phases.unshift(phase).uniq! unless native_target.build_phases.first == phase
             phase.shell_script = <<-SH.strip_heredoc
-              diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
+              diff "${SRCROOT}/Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
               if [ $? != 0 ] ; then
                   # print error to STDERR
                   echo "error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation." >&2

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -95,7 +95,7 @@ module Pod
           phase_name = @phase_prefix + Installer::UserProjectIntegrator::TargetIntegrator::CHECK_MANIFEST_PHASE_NAME
           phase = target.shell_script_build_phases.find { |bp| bp.name == phase_name }
           phase.shell_script.should == <<-EOS.strip_heredoc
-          diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
+          diff "${SRCROOT}/Podfile.lock" "${PODS_ROOT}/Manifest.lock" > /dev/null
           if [ $? != 0 ] ; then
               # print error to STDERR
               echo "error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation." >&2


### PR DESCRIPTION
closes #5499 

/cc @hborders @DanToml 