### PR TITLE
Fix integration with vendored static frameworks and libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix integration with vendored static frameworks and libraries.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6477](https://github.com/CocoaPods/CocoaPods/pull/6477)
+
 * Use `${SRCROOT}` rather than `${PODS_ROOT}` in the generated manifest lock script phase.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5499](https://github.com/CocoaPods/CocoaPods/issues/5499)


### PR DESCRIPTION
This fixes a few things:

* Search paths will now properly be added even for targets with vendored static frameworks or libraries (regression from https://github.com/CocoaPods/CocoaPods/pull/5514)
* Just like static frameworks, static libraries will now **not** be linked to targets that use `inherit! search_paths` (from https://github.com/CocoaPods/CocoaPods/issues/6065#issuecomment-276815528)
* Fixes an issue where if a target with `inherit! search_paths` explicitly defines a pod that brings in a static framework or library will not have its `other_ldflags` properly wired up, now it will.
* Also fixes an issue where transitive static dependencies would still get linked when they should not be.

/cc @plu @benasher44 @DanToml @segiddins 