### PR TITLE
Correctly handle `OTHER_LDFLAGS` for targets with inherit search path…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Correctly handle `OTHER_LDFLAGS` for targets with inherit search paths and source pods.  
+  [Justin Martin](https://github.com/justinseanmartin)
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6481](https://github.com/CocoaPods/CocoaPods/pull/6481)
+
 * Do not generate `UIRequiredDeviceCapabilities` for `tvOS` Info.plists.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6193](https://github.com/CocoaPods/CocoaPods/issues/6193)

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -198,11 +198,11 @@ module Pod
             if pod_target.requires_frameworks?
               %(-framework "#{pod_target.product_basename}")
             else
-              %(-l "#{pod_target.product_basename}")
+              %(-l "#{pod_target.product_basename}") if XCConfigHelper.links_dependency?(target, pod_target)
             end
           end
 
-          @xcconfig.merge!('OTHER_LDFLAGS' => other_ld_flags.join(' '))
+          @xcconfig.merge!('OTHER_LDFLAGS' => other_ld_flags.compact.join(' '))
         end
 
         # Ensure to add the default linker run path search paths as they could


### PR DESCRIPTION
…s and source pods.

@plu This fixes the last issue we have with source pods being double linked. I would appreciate if you can run this branch against your test project to ensure things still work.

I ran it on your other sample project and it still works just fine.

None of the previous tests broke and added a bunch of new ones to include cases with transitive dependencies.

/cc @segiddins @benasher44 @DanToml @justinseanmartin