### PR TITLE
Only_resave_changed_pod_configure_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Rob Contreras](https://github.com/robcontreras)
   [#2379](https://github.com/CocoaPods/CocoaPods/pull/2379)
 
+  
+* Only resave changed pod configure file to impove compile speed after pod intall.
+  [dingjingpisces2015](https://github.com/dingjingpisces2015)
+  [#1](https://github.com/dingjingpisces2015/CocoaPods/pull/1)
+  
 ##### Bug Fixes
 
 * Ensure Core Data models get added to the compile sources phase for header generation.  

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -234,7 +234,7 @@ module Pod
           def create_xcconfig_file
             path = target.xcconfig_path
             xcconfig_gen = Generator::XCConfig::PodXCConfig.new(target)
-            xcconfig_gen.save_as(path)
+            update_changed_file(xcconfig_gen, path)
             xcconfig_file_ref = add_file_to_support_group(path)
 
             native_target.build_configurations.each do |c|
@@ -278,7 +278,7 @@ module Pod
           def create_prefix_header
             path = target.prefix_header_path
             generator = Generator::PrefixHeader.new(target.file_accessors, target.platform)
-            generator.save_as(path)
+            update_changed_file(generator, path)
             add_file_to_support_group(path)
 
             native_target.build_configurations.each do |c|

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -59,6 +59,36 @@ module Pod
             target.native_target = @native_target
           end
 
+          # Remove temp file whose store .prefix/config/dummy file.
+          #
+          def clean_tempfile
+            FileUtils.rm(target_configure_tempfile_path)
+          end
+
+          # @return [String] The temp file path whose store .prefix/config/dummy file.
+          #
+          def target_configure_tempfile_path
+            sandbox.target_support_files_dir('target_configure_tempfile')
+          end
+
+          # @param  [Content] Content to be save.
+          # @param  [Path]  Path to save Content.
+          #
+          # Resave Content when Content is different to exist file in Path.
+          # Do nothing when Content is same as exist file in Path.
+          #
+          # @return [Void]
+          #
+          def update_changed_file(content, path)
+            content.save_as(target_configure_tempfile_path)
+            if File.exist?(path)
+              content.save_as(path) unless FileUtils.cmp(target_configure_tempfile_path, path)
+            else
+              content.save_as(path)
+            end
+            clean_tempfile if File.exist?(target_configure_tempfile_path)
+          end
+
           # @return [String] The deployment target.
           #
           def deployment_target
@@ -89,7 +119,7 @@ module Pod
           # Creates the directory where to store the support files of the target.
           #
           def create_support_files_dir
-            target.support_files_dir.mkdir
+            target.support_files_dir.mkpath
           end
 
           # Creates the Info.plist file which sets public framework attributes
@@ -166,7 +196,7 @@ module Pod
           def create_dummy_source
             path = target.dummy_source_path
             generator = Generator::DummySource.new(target.label)
-            generator.save_as(path)
+            update_changed_file(generator, path)
             file_reference = add_file_to_support_group(path)
             native_target.source_build_phase.add_file_reference(file_reference)
           end

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -98,7 +98,6 @@ module Pod
     #
     def prepare
       FileUtils.rm_rf(headers_root)
-      FileUtils.rm_rf(target_support_files_root)
 
       FileUtils.mkdir_p(headers_root)
       FileUtils.mkdir_p(sources_root)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -371,13 +371,58 @@ module Pod
               build_file.file_ref.path.should == dummy_source_basename
               @pod_target.dummy_source_path.read.should.include?('@interface PodsDummy_BananaLib')
             end
-
             #--------------------------------------------------------------------------------#
 
-            it 'does not create a target if the specification does not define source files' do
-              @pod_target.file_accessors.first.stubs(:source_files).returns([])
-              @installer.install!
-              @project.targets.should == []
+            describe 'only resave changed pod configure file' do
+              before do
+                @installer.install!
+                diff_string = "different content"
+                xcconfig_path = config.sandbox.root + @pod_target.xcconfig_path
+                xcconfig = File.new(xcconfig_path, "w")
+                prefix_header = File.new(@pod_target.prefix_header_path, "w")
+                dummy = File.new(@pod_target.dummy_source_path, "w")
+                xcconfig_path.puts diff_string
+                prefix_header.puts diff_string
+                dummy.puts diff_string
+
+              end
+
+              it 'should rewrite when xcconfig file change' do
+                @installer.install!
+                file = config.sandbox.root + @pod_target.xcconfig_path
+                xcconfig = Xcodeproj::Config.new(file)
+                xcconfig.to_hash['PODS_ROOT'].should == '${SRCROOT}'
+              end
+              it "should rewrite when prefix header file change'" do
+                @installer.install!
+                generated = @pod_target.prefix_header_path.read
+                expected = <<-EOS.strip_heredoc
+          #ifdef __OBJC__
+          #import <UIKit/UIKit.h>
+          #else
+          #ifndef FOUNDATION_EXPORT
+          #if defined(__cplusplus)
+          #define FOUNDATION_EXPORT extern "C"
+          #else
+          #define FOUNDATION_EXPORT extern
+          #endif
+          #endif
+          #endif
+
+          #import <BananaTree/BananaTree.h>
+                EOS
+                generated.should == expected
+              end
+
+              it 'should rewrite when dummy file change' do
+                @installer.install!
+                dummy_source_basename = @pod_target.dummy_source_path.basename.to_s
+                build_files = @installer.target.native_target.source_build_phase.files
+                build_file = build_files.find { |bf| bf.file_ref.display_name == dummy_source_basename }
+                build_file.should.be.not.nil
+                build_file.file_ref.path.should == dummy_source_basename
+                @pod_target.dummy_source_path.read.should.include?('@interface PodsDummy_BananaLib')
+              end
             end
 
             #--------------------------------------------------------------------------------#


### PR DESCRIPTION
My respository depends on many pods , it tooks my a lot time to re-compile project after pod install.
Finally, I find this old issus [#3991](https://github.com/CocoaPods/CocoaPods/issues/3991).
After experience I found out the change of `.xcconfig/.pch` would raise re-compile of pod source files.
So I made this pull request made `.xcconfig/.pch` file stay when their not changed(not remove & rewrite them).
Though @segiddins point out that is a Xcode mistake, it real delay build time, hope to be accepted.