### PR TITLE
Provide installation option to disable multiple pod sources warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6534](https://github.com/CocoaPods/CocoaPods/issues/6534)
   
+* Provide installation option to disable multiple pod sources warnings.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6497](https://github.com/CocoaPods/CocoaPods/pull/6497)
+
 * Use the colored2 gem instead of colored.  
   [Orta Therox](https://github.com/orta)
   [xcodeproj#463](https://github.com/CocoaPods/Xcodeproj/pull/463)

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -106,6 +106,7 @@ module Pod
       option :deterministic_uuids, true
       option :integrate_targets, true
       option :lock_pod_sources, true
+      option :warn_for_multiple_pod_sources, true
       option :share_schemes_for_development_pods, false
 
       module Mixin

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -6,6 +6,10 @@ module Pod
   # by target for a given Podfile.
   #
   class Resolver
+    include Pod::Installer::InstallationOptions::Mixin
+
+    delegate_installation_options { podfile }
+
     # @return [Sandbox] the Sandbox used by the resolver to find external
     #         dependencies.
     #
@@ -288,7 +292,7 @@ module Pod
     def specifications_for_dependency(dependency, additional_requirements = [])
       requirement = Requirement.new(dependency.requirement.as_list + additional_requirements)
       find_cached_set(dependency).
-        all_specifications.
+        all_specifications(installation_options.warn_for_multiple_pod_sources).
         select { |s| requirement.satisfied_by? s.version }.
         map { |s| s.subspec_by_name(dependency.name, false) }.
         compact.

--- a/lib/cocoapods/resolver/lazy_specification.rb
+++ b/lib/cocoapods/resolver/lazy_specification.rb
@@ -32,12 +32,12 @@ module Pod
       end
 
       class External
-        def all_specifications
+        def all_specifications(_warn_for_multiple_pod_sources)
           [specification]
         end
       end
 
-      def all_specifications
+      def all_specifications(warn_for_multiple_pod_sources)
         @all_specifications ||= begin
           sources_by_version = {}
           versions_by_source.each do |source, versions|
@@ -45,13 +45,15 @@ module Pod
             sources_by_version
           end
 
-          duplicate_versions = sources_by_version.select { |_version, sources| sources.count > 1 }
+          if warn_for_multiple_pod_sources
+            duplicate_versions = sources_by_version.select { |_version, sources| sources.count > 1 }
 
-          duplicate_versions.each do |version, sources|
-            UI.warn "Found multiple specifications for `#{name} (#{version})`:\n" +
-              sources.
-                map { |s| s.specification_path(name, version) }.
-                map { |v| "- #{v}" }.join("\n")
+            duplicate_versions.each do |version, sources|
+              UI.warn "Found multiple specifications for `#{name} (#{version})`:\n" +
+                sources.
+                  map { |s| s.specification_path(name, version) }.
+                  map { |v| "- #{v}" }.join("\n")
+            end
           end
 
           versions_by_source.flat_map do |source, versions|

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -63,6 +63,7 @@ module Pod
           'deterministic_uuids' => false,
           'integrate_targets' => true,
           'lock_pod_sources' => true,
+          'warn_for_multiple_pod_sources' => true,
           'share_schemes_for_development_pods' => false,
         }
       end


### PR DESCRIPTION
We have 100+ pods where we publish both as sources and as binary. Sometimes these warnings can become extremely long during `pod install`. 

Resolving this issue also requires to re-enter these pods in the `Podfile` and provide an explicit `:source` to silence this warning. This in turn forces the pods to be linked to a target even though they do not necessarily have to.

The best (long term solution) is to provide:

```ruby
source 'https://github.com/CocoaPods/Specs' do
  pod ...
  pod ...
end
```

But this option here is a good balance to prevent the warning from happening. Please note the default still is to warn so this shouldn't affect anyone.

Usage:

```ruby
install! 'cocoapods', warn_for_multiple_pod_sources: false
```
