### PR TITLE
Updated colored2 gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5670](https://github.com/CocoaPods/CocoaPods/issues/5670)
 
+* Updated the colored2 gem (previous version removed from rubygems.org).  
+  [Ben Asher](https://github.com/benasher44)
+  [#6533](https://github.com/CocoaPods/CocoaPods/pull/6533)
 
 ## 1.2.0 (2017-01-28)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       pry (= 0.10.3)
     coderay (1.1.0)
     colored (1.2)
-    colored2 (3.1.1)
+    colored2 (3.1.2)
     cork (0.1.0)
       colored (~> 1.2)
     crack (0.4.3)
@@ -293,4 +293,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.14.3
+   1.14.5


### PR DESCRIPTION
It was locked to 3.1.1 before, which appears to have been removed from rubygems.org. This updates it to 3.1.2. The diff looks like mostly travis and readme changes in their repo: https://github.com/kigster/colored2/compare/v3.1.1...v3.1.2.