### PR TITLE
Copy dSYM for vendored frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Copy dSYM for vendored frameworks.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#1698](https://github.com/CocoaPods/CocoaPods/issues/1698) 
 
 ##### Bug Fixes
 

--- a/spec/unit/generator/embed_frameworks_script_spec.rb
+++ b/spec/unit/generator/embed_frameworks_script_spec.rb
@@ -4,13 +4,14 @@ module Pod
   describe Generator::EmbedFrameworksScript do
     it 'returns the embed frameworks script' do
       frameworks = {
-        'Debug'   => %w(Pods/Loopback.framework Reveal.framework),
-        'Release' => %w(CrashlyticsFramework.framework),
+        'Debug' => [{ :framework => 'Pods/Loopback.framework', :dSYM => 'Pods/Loopback.framework.dSYM' }, { :framework => 'Reveal.framework', :dSYM => nil }],
+        'Release' => [{ :framework => 'CrashlyticsFramework.framework', :dSYM => nil }],
       }
       generator = Pod::Generator::EmbedFrameworksScript.new(frameworks)
       generator.send(:script).should.include <<-SH.strip_heredoc
         if [[ "$CONFIGURATION" == "Debug" ]]; then
           install_framework "Pods/Loopback.framework"
+          install_dsym "Pods/Loopback.framework.dSYM"
           install_framework "Reveal.framework"
         fi
       SH


### PR DESCRIPTION
Part of #1698 

This adds an `install_dsym` command to the shell script but only for vendored frameworks. Xcode automatically does the right thing if the pod is not a vendored framework but it's built from source.

/cc @alloy @benasher44 @segiddins 