### PR TITLE
Return different exit status (31) when spec not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Alfredo Delli Bovi](https://github.com/adellibovi)
   [#6525](https://github.com/CocoaPods/CocoaPods/issues/6525)
 
+* Return new exit code (31) when spec not found  
+  [Alfredo Delli Bovi](https://github.com/adellibovi)
+  [#6033](https://github.com/CocoaPods/CocoaPods/issues/6033)
+
 
 ## 1.2.1.beta.1 (2017-03-08)
 

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -21,6 +21,10 @@ module Pod
         This will configure the project to reference the Pods static library,
         add a build configuration file, and add a post build script to copy
         Pod resources.
+
+        This may return one of several error codes if it encounters problems.
+        * `1` Generic error code
+        * `31` Spec not found (i.e out-of-date source repos, mistyped Pod name etc...)
       DESC
 
       def self.options

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -373,7 +373,7 @@ module Pod
           pod 'AFNetworking', '999.999.999'
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
-        e = lambda { resolver.resolve }.should.raise Informative
+        e = lambda { resolver.resolve }.should.raise NoSpecFoundError
         e.message.should.match(/Unable to satisfy the following requirements/)
         e.message.should.match(/`AFNetworking \(= 999\.999\.999\)` required by `Podfile`/)
         e.message.should.match(/None of your spec sources contain a spec satisfying the dependency: `AFNetworking \(= 999\.999\.999\)`./)
@@ -382,6 +382,7 @@ module Pod
         e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
         e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update`/)
         e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
+        e.exit_status.should.equal(31)
       end
 
       it 'raises with a list of dependencies if there are many dependencies but no versions of a dependency exists' do
@@ -392,7 +393,7 @@ module Pod
         locked_deps = dependency_graph_from_array([Dependency.new('AFNetworking', '= 1.4')])
 
         resolver = Resolver.new(config.sandbox, podfile, locked_deps, config.sources_manager.all)
-        e = lambda { resolver.resolve }.should.raise Informative
+        e = lambda { resolver.resolve }.should.raise NoSpecFoundError
         e.message.should.match(/Unable to satisfy the following requirements/)
         e.message.should.match(/`AFNetworking \(= 3.0.1\)` required by `Podfile`/)
         e.message.should.match(/`AFNetworking \(= 1.4\)` required by `Podfile.lock`/)
@@ -403,6 +404,7 @@ module Pod
         e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
         e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update`/)
         e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
+        e.exit_status.should.equal(31)
       end
 
       it 'takes into account locked dependencies' do


### PR DESCRIPTION
Hi,

As part of #6033, this returns a different exit code when spec not found (i.e. master repo out-dated).
I couldn't find any other examples in the project of exit codes, so I'm not sure if we have any convention to follow on this, do you have any hint?
I have few other questions:
Should we document exit codes somewhere?
Is having a NoSpecFound class the right approach, if so where is the right place? Or is good enough to just set @exit_status?