### PR TITLE
Only share pod target xcscheme if present during validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Only share pod target xcscheme if present during validation.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6558](https://github.com/CocoaPods/CocoaPods/pull/6558)
+
 * Properly compile storyboard for watch device family.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6516](https://github.com/CocoaPods/CocoaPods/issues/6516)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -428,7 +428,8 @@ module Pod
       add_xctest(app_target) if @installer.pod_targets.any? { |pt| pt.spec_consumers.any? { |c| c.frameworks.include?('XCTest') } }
       app_project.save
       Xcodeproj::XCScheme.share_scheme(app_project.path, 'App')
-      Xcodeproj::XCScheme.share_scheme(@installer.pods_project.path, pod_target.label)
+      # Share the pods xcscheme only if it exists. For pre-built vendored pods there is no xcscheme generated.
+      Xcodeproj::XCScheme.share_scheme(@installer.pods_project.path, pod_target.label) if shares_pod_target_xcscheme?(pod_target)
     end
 
     def add_swift_version(app_target)
@@ -667,6 +668,10 @@ module Pod
 
     def note(*args)
       add_result(:note, *args)
+    end
+
+    def shares_pod_target_xcscheme?(pod_target)
+      Pathname.new(@installer.pods_project.path + pod_target.label).exist?
     end
 
     def add_result(type, attribute_name, message, public_only = false)


### PR DESCRIPTION
@segiddins this regressed from https://github.com/CocoaPods/CocoaPods/issues/5670. When linting pre-built pods then there is no xcscheme generated to share.

Caught in an internal project of ours and verified this fixes it. Also added a test.