### PR TITLE
[Resolver] Improve error message when specs not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Alfredo Delli Bovi](https://github.com/adellibovi)
   [#6033](https://github.com/CocoaPods/CocoaPods/issues/6033)
 
+* Provide better error message when spec not found  
+  [Alfredo Delli Bovi](https://github.com/adellibovi)
+  [#6033](https://github.com/CocoaPods/CocoaPods/issues/6033)
+
 
 ## 1.2.1.beta.1 (2017-03-08)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -156,6 +156,11 @@ module Pod
 
       private
 
+      # @return [Bool] Whether the analysis has updated sources repositories.
+      #
+      attr_accessor :specs_updated
+      alias_method :specs_updated?, :specs_updated
+
       def validate_podfile!
         validator = Installer::PodfileValidator.new(podfile)
         validator.validate
@@ -222,6 +227,7 @@ module Pod
             UI.message "Skipping `#{source.name}` update because the repository is not a git source repository."
           end
         end
+        @specs_updated = true
       end
 
       private
@@ -716,6 +722,7 @@ module Pod
         specs_by_target = nil
         UI.section "Resolving dependencies of #{UI.path(podfile.defined_in_file) || 'Podfile'}" do
           resolver = Resolver.new(sandbox, podfile, locked_dependencies, sources)
+          resolver.specs_updated = specs_updated?
           specs_by_target = resolver.resolve
           specs_by_target.values.flatten(1).each(&:validate_cocoapods_version)
         end

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -35,6 +35,11 @@ module Pod
     #
     attr_accessor :sources
 
+    # @return [Bool] Whether the resolver has sources repositories up-to-date.
+    #
+    attr_accessor :specs_updated
+    alias specs_updated? specs_updated
+
     # Init a new Resolver
     #
     # @param  [Sandbox] sandbox @see sandbox
@@ -438,9 +443,11 @@ module Pod
               dependencies = conflicts.count == 1 ? 'dependency' : 'dependencies'
               message << "\n\nNone of your spec sources contain a spec satisfying "\
                 "the #{dependencies}: `#{conflicts.join(', ')}`." \
-                "\n\nYou have either:" \
-                "\n * out-of-date source repos which you can update with `pod repo update`." \
-                "\n * mistyped the name or version." \
+                "\n\nYou have either:"
+              unless specs_updated?
+                message << "\n * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`."
+              end
+              message << "\n * mistyped the name or version." \
                 "\n * not added the source repo that hosts the Podspec to your Podfile." \
                 "\n\nNote: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default."
 

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -378,9 +378,28 @@ module Pod
         e.message.should.match(/`AFNetworking \(= 999\.999\.999\)` required by `Podfile`/)
         e.message.should.match(/None of your spec sources contain a spec satisfying the dependency: `AFNetworking \(= 999\.999\.999\)`./)
         e.message.should.match(/You have either:/)
-        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update`/)
+        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`./)
+        e.message.should.match(/ * mistyped the name or version./)
         e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
-        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update`/)
+        e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
+        e.exit_status.should.equal(31)
+      end
+
+      it 'raises if repo are updated and no such version of a dependency exists' do
+        podfile = Podfile.new do
+          platform :ios
+          pod 'AFNetworking', '999.999.999'
+        end
+        resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
+        resolver.specs_updated = true
+        e = lambda { resolver.resolve }.should.raise NoSpecFoundError
+        e.message.should.match(/Unable to satisfy the following requirements/)
+        e.message.should.match(/`AFNetworking \(= 999\.999\.999\)` required by `Podfile`/)
+        e.message.should.match(/None of your spec sources contain a spec satisfying the dependency: `AFNetworking \(= 999\.999\.999\)`./)
+        e.message.should.match(/You have either:/)
+        e.message.should.not.match(/ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`./)
+        e.message.should.match(/ * mistyped the name or version./)
+        e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
         e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
         e.exit_status.should.equal(31)
       end
@@ -400,9 +419,9 @@ module Pod
         e.message.should.match(/None of your spec sources contain a spec satisfying the dependencies:/)
         e.message.should.match(/`AFNetworking \(= 3.0.1\), AFNetworking \(= 1.4\)`/)
         e.message.should.match(/You have either:/)
-        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update`/)
+        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`./)
+        e.message.should.match(/ * mistyped the name or version./)
         e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
-        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update`/)
         e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
         e.exit_status.should.equal(31)
       end


### PR DESCRIPTION
Hi,

As part of #6033, this improves the error message when specs not found (i.e. source repo out-dated), and there is also a small fix in the tests.

Another thought, I think it would be nice to hide the message about "try `pod install --repo-update`" if the error is raised while executing that command, since it means that user have updated the repos but the error is probably one of the other two (mistyped or no source repo).
Should I change the analyser init to pass if it's called within a repo update? Or do you have any other ideas on how I can access that property?