### PR TITLE
Make analyzer consider static libs as dependent targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix building with static lib subprojects (previously only supported framework subprojects).  
+  [Ben Asher](https://github.com/benasher44)
+  [#5830](https://github.com/CocoaPods/CocoaPods/issues/5830)
+  [#6306](https://github.com/CocoaPods/CocoaPods/issues/6306)
+
 * Fix regression from #6457 to ensure a correct error message is given when a spec is not found.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6457](https://github.com/CocoaPods/CocoaPods/issues/6457)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -242,11 +242,17 @@ module Pod
       # @param  [Array<AggregateTarget>] embedded_aggregate_targets the aggregate targets
       #         representing the embedded targets to be integrated
       #
-      def copy_embedded_target_pod_targets_to_host(aggregate_target, embedded_aggregate_targets)
+      # @param  [Boolean] libraries_only if true, only library-type embedded
+      #         targets are considered, otherwise, all other types are have
+      #         their pods copied to their host targets as well (extensions, etc.)
+      #
+      def copy_embedded_target_pod_targets_to_host(aggregate_target, embedded_aggregate_targets, libraries_only)
         return if aggregate_target.requires_host_target?
         pod_target_names = Set.new(aggregate_target.pod_targets.map(&:name))
         aggregate_user_target_uuids = Set.new(aggregate_target.user_targets.map(&:uuid))
         embedded_aggregate_targets.each do |embedded_aggregate_target|
+          # Skip non libraries in library-only mode
+          next if libraries_only && !embedded_aggregate_target.library?
           next unless embedded_aggregate_target.user_targets.any? do |embedded_user_target|
             # You have to ask the host target's project for the host targets of
             # the embedded target, as opposed to asking user_project for the
@@ -357,11 +363,21 @@ module Pod
           generate_target(target_definition, pod_targets)
         end
         if installation_options.integrate_targets?
-          # Copy embedded target pods that cannot have their pods embedded as frameworks to their host targets
-          embedded_targets = aggregate_targets.select(&:requires_host_target?).select(&:requires_frameworks?)
+          # Copy embedded target pods that cannot have their pods embedded as frameworks to
+          # their host targets, and ensure we properly link library pods to their host targets
+          embedded_targets = aggregate_targets.select(&:requires_host_target?)
           analyze_host_targets_in_podfile(aggregate_targets, embedded_targets)
+
+          use_frameworks_embedded_targets = embedded_targets.select(&:requires_frameworks?)
+          non_use_frameworks_embedded_targets = embedded_targets.reject(&:requires_frameworks?)
           aggregate_targets.each do |target|
-            copy_embedded_target_pod_targets_to_host(target, embedded_targets)
+            # For targets that require frameworks, we always have to copy their pods to their
+            # host targets because those frameworks will all be loaded from the host target's bundle
+            copy_embedded_target_pod_targets_to_host(target, use_frameworks_embedded_targets, false)
+
+            # For targets that don't require frameworks, we only have to consider library-type
+            # targets because their host targets will still need to link their pods
+            copy_embedded_target_pod_targets_to_host(target, non_use_frameworks_embedded_targets, true)
           end
         end
         aggregate_targets.each do |target|

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -9,7 +9,7 @@ module Pod
 
     # Product types where the product's frameworks must be embedded in a host target
     #
-    EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :messages_extension, :watch_extension, :xpc_service].freeze
+    EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :static_library, :messages_extension, :watch_extension, :xpc_service].freeze
 
     # Initialize a new instance
     #
@@ -25,6 +25,18 @@ module Pod
       @search_paths_aggregate_targets = []
       @file_accessors = []
       @xcconfigs = {}
+    end
+
+    # @return [Boolean] True if the user_target refers to a
+    #         library (framework, static or dynamic lib).
+    #
+    def library?
+      # Without a user_project, we can't say for sure
+      # that this is a library
+      return false if user_project.nil?
+      symbol_types = user_targets.map(&:symbol_type).uniq
+      raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}." unless symbol_types.count == 1
+      [:framework, :dynamic_library, :static_library].include? symbol_types.first
     end
 
     # @return [Boolean] True if the user_target's pods are

--- a/spec/fixtures/SampleProject/Sample Lib/Sample Lib.xcodeproj/project.pbxproj
+++ b/spec/fixtures/SampleProject/Sample Lib/Sample Lib.xcodeproj/project.pbxproj
@@ -28,11 +28,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		137F16131D3AFC2900029696 /* Sample Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Sample Framework.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		137F16131D3AFC2900029696 /* SampleFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SampleFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		137F16151D3AFC2900029696 /* Sample Framework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sample Framework.h"; sourceTree = "<group>"; };
 		137F16171D3AFC2900029696 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		137F161B1D3AFC6700029696 /* Sample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Sample.m; sourceTree = "<group>"; };
-		51E94E0F164472080035348C /* libSample Lib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libSample Lib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		51E94E0F164472080035348C /* libSampleLib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSampleLib.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		51E94E12164472080035348C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		51E94E16164472090035348C /* Sample Lib-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sample Lib-Prefix.pch"; sourceTree = "<group>"; };
 		51E94E17164472090035348C /* Sample_Lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Sample_Lib.h; sourceTree = "<group>"; };
@@ -81,8 +81,8 @@
 		51E94E10164472080035348C /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				51E94E0F164472080035348C /* libSample Lib.a */,
-				137F16131D3AFC2900029696 /* Sample Framework.framework */,
+				51E94E0F164472080035348C /* libSampleLib.a */,
+				137F16131D3AFC2900029696 /* SampleFramework.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -127,9 +127,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		137F16121D3AFC2900029696 /* Sample Framework */ = {
+		137F16121D3AFC2900029696 /* SampleFramework */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 137F161A1D3AFC2900029696 /* Build configuration list for PBXNativeTarget "Sample Framework" */;
+			buildConfigurationList = 137F161A1D3AFC2900029696 /* Build configuration list for PBXNativeTarget "SampleFramework" */;
 			buildPhases = (
 				137F160E1D3AFC2900029696 /* Sources */,
 				137F160F1D3AFC2900029696 /* Frameworks */,
@@ -140,14 +140,14 @@
 			);
 			dependencies = (
 			);
-			name = "Sample Framework";
+			name = SampleFramework;
 			productName = "Sample Framework";
-			productReference = 137F16131D3AFC2900029696 /* Sample Framework.framework */;
+			productReference = 137F16131D3AFC2900029696 /* SampleFramework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		51E94E0E164472080035348C /* Sample Lib */ = {
+		51E94E0E164472080035348C /* SampleLib */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 51E94E1D164472090035348C /* Build configuration list for PBXNativeTarget "Sample Lib" */;
+			buildConfigurationList = 51E94E1D164472090035348C /* Build configuration list for PBXNativeTarget "SampleLib" */;
 			buildPhases = (
 				51E94E0B164472080035348C /* Sources */,
 				51E94E0C164472080035348C /* Frameworks */,
@@ -157,9 +157,9 @@
 			);
 			dependencies = (
 			);
-			name = "Sample Lib";
+			name = SampleLib;
 			productName = "Sample Lib";
-			productReference = 51E94E0F164472080035348C /* libSample Lib.a */;
+			productReference = 51E94E0F164472080035348C /* libSampleLib.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -188,8 +188,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				51E94E0E164472080035348C /* Sample Lib */,
-				137F16121D3AFC2900029696 /* Sample Framework */,
+				51E94E0E164472080035348C /* SampleLib */,
+				137F16121D3AFC2900029696 /* SampleFramework */,
 			);
 		};
 /* End PBXProject section */
@@ -381,13 +381,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		137F161A1D3AFC2900029696 /* Build configuration list for PBXNativeTarget "Sample Framework" */ = {
+		137F161A1D3AFC2900029696 /* Build configuration list for PBXNativeTarget "SampleFramework" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				137F16181D3AFC2900029696 /* Debug */,
 				137F16191D3AFC2900029696 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		51E94E09164472080035348C /* Build configuration list for PBXProject "Sample Lib" */ = {
 			isa = XCConfigurationList;
@@ -398,7 +399,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		51E94E1D164472090035348C /* Build configuration list for PBXNativeTarget "Sample Lib" */ = {
+		51E94E1D164472090035348C /* Build configuration list for PBXNativeTarget "SampleLib" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				51E94E1E164472090035348C /* Debug */,

--- a/spec/fixtures/SampleProject/SampleProject.xcodeproj/project.pbxproj
+++ b/spec/fixtures/SampleProject/SampleProject.xcodeproj/project.pbxproj
@@ -52,6 +52,13 @@
 			remoteGlobalIDString = 137F16131D3AFC2900029696;
 			remoteInfo = "Sample Framework";
 		};
+		13C5653F1E816CB40059B3C3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 51E94E201644721F0035348C /* Sample Lib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 51E94E0E164472080035348C;
+			remoteInfo = "Sample Lib";
+		};
 		13C6236F1D3B00F900EFB98B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 51E94E201644721F0035348C /* Sample Lib.xcodeproj */;
@@ -303,6 +310,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				13C565401E816CB40059B3C3 /* PBXTargetDependency */,
 				13C623701D3B00F900EFB98B /* PBXTargetDependency */,
 			);
 			name = SampleProject;
@@ -459,6 +467,11 @@
 			isa = PBXTargetDependency;
 			name = "Sample Framework";
 			targetProxy = 130F34EB1D73B132009D968D /* PBXContainerItemProxy */;
+		};
+		13C565401E816CB40059B3C3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Sample Lib";
+			targetProxy = 13C5653F1E816CB40059B3C3 /* PBXContainerItemProxy */;
 		};
 		13C623701D3B00F900EFB98B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -757,7 +757,31 @@ module Pod
               pod 'JSONKit'
             end
 
-            target 'Sample Framework' do
+            target 'SampleFramework' do
+              project 'SampleProject/Sample Lib/Sample Lib'
+              pod 'monkey'
+            end
+          end
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          result = analyzer.analyze
+
+          result.targets.select { |at| at.name == 'Pods-SampleProject' }.flat_map(&:pod_targets).map(&:name).sort.uniq.should == %w(
+            JSONKit
+            monkey
+          ).sort
+        end
+
+        it "copy a static library's pod target, when the static library is in a sub project" do
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            platform :ios, '8.0'
+            project 'SampleProject/SampleProject'
+
+            target 'SampleProject' do
+              pod 'JSONKit'
+            end
+
+            target 'SampleLib' do
               project 'SampleProject/Sample Lib/Sample Lib'
               pod 'monkey'
             end
@@ -793,7 +817,7 @@ module Pod
             source SpecHelper.test_repo_url
             use_frameworks!
             platform :ios, '8.0'
-            target 'Sample Framework' do
+            target 'SampleFramework' do
               project 'SampleProject/Sample Lib/Sample Lib'
               pod 'monkey'
             end

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -256,6 +256,42 @@ module Pod
         end
       end
 
+      describe 'Target might be a library target' do
+        before do
+          target_definition = Podfile::TargetDefinition.new('Pods', nil)
+          target_definition.abstract = false
+          @target = AggregateTarget.new(target_definition, config.sandbox)
+          project_path = SpecHelper.fixture('SampleProject/SampleProject.xcodeproj')
+          @target.user_project = Xcodeproj::Project.open(project_path)
+          @target.user_target_uuids = ['A346496C14F9BE9A0080D870']
+        end
+
+        it 'is a library target if the user_target is a framework' do
+          @target.user_targets.first.stubs(:symbol_type).returns(:framework)
+          @target.library?.should == true
+        end
+
+        it 'is a library target if the user_target is a static library' do
+          @target.user_targets.first.stubs(:symbol_type).returns(:static_library)
+          @target.library?.should == true
+        end
+
+        it 'is a library target if the user_target is a dynamic library' do
+          @target.user_targets.first.stubs(:symbol_type).returns(:dynamic_library)
+          @target.library?.should == true
+        end
+
+        it 'is not a library target if the user_target is an application' do
+          @target.user_targets.first.stubs(:symbol_type).returns(:application)
+          @target.library?.should == false
+        end
+
+        it 'is not a library target if the user_target is an app extension' do
+          @target.user_targets.first.stubs(:symbol_type).returns(:app_extension)
+          @target.library?.should == false
+        end
+      end
+
       describe 'With frameworks' do
         before do
           @pod_target = fixture_pod_target('orange-framework/OrangeFramework.podspec', [fixture_target_definition('iOS Example')])


### PR DESCRIPTION
This fixes #5830 and #6306. The scenario this fixes is when you're installing pods into a static library and an app, and the static library is a sub project of the app project.

I have a local test project that I'll push to github shortly, but I have this working locally in the test project. I just want to make sure there aren't any further changes that need to be made for dynamic libraries before I push it (so far it seems like those just work).

Other minor changes:
- Renamed Sample Framework to SampleFramework in the specs fixtures, since the former isn't a valid C99 target name.
- Updated the Sample Lib project to include its SampleLib static lib subproject target as a dependency