### PR TITLE
Avoid unneeded master specs cloning for pod lib lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* No master specs cloning when not needed for `pod lib lint`.  
+  [Alfredo Delli Bovi](https://github.com/adellibovi)
+  [#6154](https://github.com/CocoaPods/CocoaPods/issues/6154)
 
 
 ## 1.2.1.rc.1 (2017-04-05)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -71,6 +71,7 @@ module Pod
       @lockfile = lockfile
 
       @use_default_plugins = true
+      @has_dependencies = true
     end
 
     # @return [Hash, Boolean, nil] Pods that have been requested to be
@@ -79,6 +80,11 @@ module Pod
     #         not taken into account for deciding what Pods to install.
     #
     attr_accessor :update
+
+    # @return [Boolean] Whether it has dependencies. Defaults to true.
+    #
+    attr_accessor :has_dependencies
+    alias_method :has_dependencies?, :has_dependencies
 
     # @return [Boolean] Whether the spec repos should be updated.
     #
@@ -240,6 +246,7 @@ module Pod
     def create_analyzer
       Analyzer.new(sandbox, podfile, lockfile).tap do |analyzer|
         analyzer.installation_options = installation_options
+        analyzer.has_dependencies = has_dependencies?
       end
     end
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -45,6 +45,7 @@ module Pod
 
         @update = false
         @allow_pre_downloads = true
+        @has_dependencies = true
       end
 
       # Performs the analysis.
@@ -151,6 +152,15 @@ module Pod
       #
       attr_accessor :allow_pre_downloads
       alias_method :allow_pre_downloads?, :allow_pre_downloads
+
+      # @return [Bool] Whether the analysis has dependencies and thus
+      #         sources must be configured.
+      #
+      # @note   This is used by the `pod lib lint` command to prevent
+      #         update of specs when not needed.
+      #
+      attr_accessor :has_dependencies
+      alias_method :has_dependencies?, :has_dependencies
 
       #-----------------------------------------------------------------------#
 
@@ -819,11 +829,11 @@ module Pod
 
           # Add any sources specified using the :source flag on individual dependencies.
           dependency_sources = podfile.dependencies.map(&:podspec_repo).compact
-
           all_dependencies_have_sources = dependency_sources.count == podfile.dependencies.count
+
           if all_dependencies_have_sources
             sources = dependency_sources
-          elsif sources.empty?
+          elsif has_dependencies? && sources.empty?
             sources = ['https://github.com/CocoaPods/Specs.git']
           else
             sources += dependency_sources

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -28,8 +28,12 @@ module Pod
     #         the Source URLs to use in creating a {Podfile}.
     #
     def initialize(spec_or_path, source_urls)
-      @source_urls = source_urls.map { |url| config.sources_manager.source_with_name_or_url(url) }.map(&:url)
       @linter = Specification::Linter.new(spec_or_path)
+      @source_urls = if @linter.spec && @linter.spec.dependencies.empty?
+                       []
+                     else
+                       source_urls.map { |url| config.sources_manager.source_with_name_or_url(url) }.map(&:url)
+                     end
     end
 
     #-------------------------------------------------------------------------#
@@ -405,6 +409,7 @@ module Pod
       sandbox = Sandbox.new(config.sandbox_root)
       @installer = Installer.new(sandbox, podfile)
       @installer.use_default_plugins = false
+      @installer.has_dependencies = !spec.dependencies.empty?
       %i(prepare resolve_dependencies download_dependencies).each { |m| @installer.send(m) }
       @file_accessor = @installer.pod_targets.flat_map(&:file_accessors).find { |fa| fa.spec.name == consumer.spec.name }
     end


### PR DESCRIPTION
This fixes #6154.

It avoids creating or updating the default master specs repo while executing `pod lib lint` if there aren't any dependency.