### PR TITLE
Fix globbing to traverse symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Alfredo Delli Bovi](https://github.com/adellibovi)
   [#6033](https://github.com/CocoaPods/CocoaPods/issues/6033)
 
+* Fix globbing to traverse symlinks 
+  [robertjpayne](https://github.com/robertjpayne)
+  [#6603](https://github.com/CocoaPods/CocoaPods/issues/6603)
+
 
 ## 1.2.1.beta.1 (2017-03-08)
 

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -57,10 +57,11 @@ module Pod
         absolute_paths = absolute_paths.map do |path|
           if File.symlink?(path)
             realpath = path.realpath
-            children = Pathname.glob(realpath + '**/*', File::FNM_DOTMATCH)
-            children = children.map { |child_path| path + child_path.relative_path_from(realpath) }
-            children = children.reject { |child_path| child_path.basename.to_s =~ /^\.\.?$/ }
-            children = children.reject { |child_path| child_path == path}
+            children = Pathname.glob(realpath + '**/*', File::FNM_DOTMATCH).
+              map { |child_path| path + child_path.relative_path_from(realpath) }.
+              reject { |child_path| child_path.basename.to_s =~ /^\.\.?$/ }.
+              reject { |child_path| child_path == path }
+            children
           else
             [path]
           end

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -52,8 +52,9 @@ module Pod
         end
         escaped_root = escape_path_for_glob(root)
 
-        absolute_paths = Pathname.glob(escaped_root + '**/*', File::FNM_DOTMATCH).lazy
+        absolute_paths = Pathname.glob(escaped_root + '**{,/*/**}/*', File::FNM_DOTMATCH).lazy
         dirs_and_files = absolute_paths.reject { |path| path.basename.to_s =~ /^\.\.?$/ }
+        dirs_and_files = dirs_and_files.reject { |path| path.to_s =~ /^#{escaped_root}\/\.\/.*?$/ }
         dirs, files = dirs_and_files.partition { |path| File.directory?(path) }
 
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -52,10 +52,20 @@ module Pod
         end
         escaped_root = escape_path_for_glob(root)
 
-        absolute_paths = Pathname.glob(escaped_root + '**{,/*/**}/*', File::FNM_DOTMATCH).lazy
-        dirs_and_files = absolute_paths.reject { |path| path.basename.to_s =~ /^\.\.?$/ }
-        dirs_and_files = dirs_and_files.reject { |path| path.to_s =~ /^#{escaped_root}\/\.\/.*?$/ }
-        dirs, files = dirs_and_files.partition { |path| File.directory?(path) }
+        absolute_paths = Pathname.glob(escaped_root + '**/*', File::FNM_DOTMATCH)
+        absolute_paths = absolute_paths.reject { |path| path.basename.to_s =~ /^\.\.?$/ }
+        absolute_paths = absolute_paths.map do |path|
+          if File.symlink?(path)
+            realpath = path.realpath
+            children = Pathname.glob(realpath + '**/*', File::FNM_DOTMATCH)
+            children = children.map { |child_path| path + child_path.relative_path_from(realpath) }
+            children = children.reject { |child_path| child_path.basename.to_s =~ /^\.\.?$/ }
+            children = children.reject { |child_path| child_path == path}
+          else
+            [path]
+          end
+        end.flatten.uniq
+        dirs, files = absolute_paths.partition { |path| File.directory?(path) }
 
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
         sorted_relative_paths_from_full_paths = lambda do |paths|

--- a/spec/fixtures/banana-symlinked/Classes
+++ b/spec/fixtures/banana-symlinked/Classes
@@ -1,0 +1,1 @@
+../banana-unordered/Classes

--- a/spec/fixtures/banana-symlinked/Test/Classes
+++ b/spec/fixtures/banana-symlinked/Test/Classes
@@ -1,0 +1,1 @@
+../../banana-unordered/Classes

--- a/spec/unit/sandbox/path_list_spec.rb
+++ b/spec/unit/sandbox/path_list_spec.rb
@@ -179,6 +179,19 @@ module Pod
         path_list.files.should == %w(Classes/NSFetchedResultsController+Banana.h Classes/NSFetchRequest+Banana.h)
       end
 
+      it 'traverses symlinks' do
+        root = fixture('banana-symlinked')
+        root_unsymlinked = fixture('banana-unordered')
+
+        # Let Pathname.glob result be ordered case-sensitively
+        Pathname.stubs(:glob).returns([Pathname.new("#{root_unsymlinked}/Classes/NSFetchRequest+Banana.h"),
+                                       Pathname.new("#{root_unsymlinked}/Classes/NSFetchedResultsController+Banana.h")])
+        File.stubs(:directory?).returns(false)
+
+        path_list = Sandbox::PathList.new(root)
+        path_list.files.should == %w(Classes/NSFetchedResultsController+Banana.h Classes/NSFetchRequest+Banana.h)
+      end
+
       it 'supports unicode paths' do
         # Load fixture("ü") with chars ["u", "̈"] instead of ["ü"]
         unicode_name = [117, 776].pack('U*')


### PR DESCRIPTION
This adjusts the globbing to ensure it traverses symlinks and also then cleans up some extra invalid paths it adds as a result of that.

I apologise I'm a bit short on time but need to write a spec that ensure we don't break symlink traversing in the future.

Fixes #6603