### PR TITLE
[Gemspec] Bump ruby-macho to '~ 1.1'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.5.7)
       nap (~> 1.0)
-      ruby-macho (~> 0.2.5)
+      ruby-macho (~> 1.1)
       xcodeproj (>= 1.4.3, < 2.0)
 
 GEM
@@ -231,7 +231,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
     ruby-graphviz (1.2.2)
-    ruby-macho (0.2.6)
+    ruby-macho (1.1.0)
     ruby-prof (0.15.2)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
@@ -292,4 +292,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '~> 2.0.1'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '~> 0.2.5'
+  s.add_runtime_dependency 'ruby-macho',    '~> 1.1'
 
   s.add_development_dependency 'bacon', '~> 1.1'
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
Hi, author of ruby-macho here.

ruby-macho 1.0 and above bring substantial performance improvements over pre-1.0 versions.
The methods that CocoaPods uses also haven't changed, so there's no compatibility concern.

Best,
William Woodruff