### PR TITLE
Inherit pod defined values for SWIFT_ACTIVE_COMPILATION_CONDITIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [postmechanical](https://github.com/postmechanical)
   [#6595](https://github.com/CocoaPods/CocoaPods/issues/6595)
 
-
+* Inherit pod defined values for `SWIFT_ACTIVE_COMPILATION_CONDITIONS`.    
+  [Louis D'hauwe](https://github.com/louisdh)
+  [#6629](https://github.com/CocoaPods/CocoaPods/pull/6629)
+  
 ## 1.2.1 (2017-04-11)
 
 ##### Enhancements

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -54,6 +54,7 @@ module Pod
             'PODS_TARGET_SRCROOT' => target.pod_target_srcroot,
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
             'SKIP_INSTALL' => 'YES',
+            'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ',
             # 'USE_HEADERMAP' => 'NO'
           }
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -59,6 +59,8 @@ module Pod
             settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = ''
             settings['CODE_SIGN_IDENTITY[sdk=watchos*]'] = ''
 
+            settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = '$(inherited) '
+
             if target.swift_version
               settings['SWIFT_VERSION'] = target.swift_version
             end

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -254,6 +254,11 @@ module Pod
         end
       end
       settings['GCC_PREPROCESSOR_DEFINITIONS'] = definitions
+
+      if type == :debug
+        settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = 'DEBUG'
+      end
+
       build_configuration
     end
 


### PR DESCRIPTION
This will make sure that pod defined values for `SWIFT_ACTIVE_COMPILATION_CONDITIONS[debug]` are correctly inherited. This got broken with the release of Xcodeproj 1.4.3, where Apple's default `DEBUG` value overwrote any values. 

Adding `$(inherited)` to both `pod_xcconfig.rb` and `pod_target_installer.rb` seems essential for the `DEBUG` value not to override everything. Removing it from either one removes `$(inherited)` in the end result. 

Fixes #6625 