### PR TITLE
pass actual spec name to PodSourcePreparer

### DIFF
--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -30,7 +30,8 @@ module Pod
       request,
       target,
       can_cache: true,
-      cache_path: Config.instance.cache_root + 'Pods'
+      cache_path: Config.instance.cache_root + 'Pods',
+      spec_name: nil
     )
       can_cache &&= !Config.instance.skip_download_cache
 
@@ -39,13 +40,13 @@ module Pod
       if can_cache
         raise ArgumentError, 'Must provide a `cache_path` when caching.' unless cache_path
         cache = Cache.new(cache_path)
-        result = cache.download_pod(request)
+        result = cache.download_pod(request, spec_name)
       else
         raise ArgumentError, 'Must provide a `target` when caching is disabled.' unless target
 
         require 'cocoapods/installer/pod_source_preparer'
         result, = download_request(request, target)
-        Installer::PodSourcePreparer.new(result.spec, result.location).prepare!
+        Installer::PodSourcePreparer.new(result.spec, result.location, spec_name).prepare!
       end
 
       if target && result.location && target != result.location

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -107,12 +107,12 @@ module Pod
       #
       # @return [void]
       #
-      def pre_download(sandbox)
+      def pre_download(sandbox, spec_name = nil)
         title = "Pre-downloading: `#{name}` #{description}"
         UI.titled_section(title,  :verbose_prefix => '-> ') do
           target = sandbox.pod_dir(name)
           begin
-            download_result = Downloader.download(download_request, target, :can_cache => can_cache)
+            download_result = Downloader.download(download_request, target, :can_cache => can_cache, :spec_name => spec_name)
           rescue Pod::DSLError => e
             raise Informative, "Failed to load '#{name}' podspec: #{e.message}"
           rescue => _

--- a/lib/cocoapods/external_sources/downloader_source.rb
+++ b/lib/cocoapods/external_sources/downloader_source.rb
@@ -9,8 +9,8 @@ module Pod
     class DownloaderSource < AbstractExternalSource
       # @see AbstractExternalSource#fetch
       #
-      def fetch(sandbox)
-        pre_download(sandbox)
+      def fetch(sandbox, spec_name = nil)
+        pre_download(sandbox, spec_name)
       end
 
       # @see AbstractExternalSource#description

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -630,7 +630,7 @@ module Pod
         unless dependencies_to_fetch.empty?
           UI.section 'Fetching external sources' do
             dependencies_to_fetch.sort.each do |dependency|
-              fetch_external_source(dependency, !pods_to_fetch.include?(dependency.root_name))
+              fetch_external_source(dependency, !pods_to_fetch.include?(dependency.root_name), dependency.name)
             end
           end
         end
@@ -646,7 +646,7 @@ module Pod
         end
       end
 
-      def fetch_external_source(dependency, use_lockfile_options)
+      def fetch_external_source(dependency, use_lockfile_options, spec_name = nil)
         checkout_options = lockfile.checkout_options_for_pod_named(dependency.root_name) if lockfile
         source = if checkout_options && use_lockfile_options
                    ExternalSources.from_params(checkout_options, dependency, podfile.defined_in_file)
@@ -654,7 +654,7 @@ module Pod
                    ExternalSources.from_dependency(dependency, podfile.defined_in_file)
         end
         source.can_cache = installation_options.clean?
-        source.fetch(sandbox)
+        source.fetch(sandbox, spec_name)
       end
 
       def dependencies_to_fetch

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -58,7 +58,7 @@ module Pod
       #
       def install!
         download_source unless predownloaded? || local?
-        PodSourcePreparer.new(root_spec, root).prepare! if local?
+        PodSourcePreparer.new(root_spec, root, specs.first.name).prepare! if local?
       end
 
       # Cleans the installations if appropriate.

--- a/lib/cocoapods/installer/pod_source_preparer.rb
+++ b/lib/cocoapods/installer/pod_source_preparer.rb
@@ -12,15 +12,20 @@ module Pod
       #
       attr_reader :path
 
+      # @return [String] the name of the specification (root or not) of the Pod.
+      attr_reader :spec_name
+
       # Initialize a new instance
       #
       # @param [Specification] spec the root specification of the Pod.
       # @param [Pathname] path the folder where the source of the Pod is located.
+      # @param [String] spec_name the name of the specification of the Pod.
       #
-      def initialize(spec, path)
+      def initialize(spec, path, spec_name = nil)
         raise "Given spec isn't a root spec, but must be." unless spec.root?
         @spec = spec
         @path = path
+        @spec_name = spec_name || spec.name
       end
 
       #-----------------------------------------------------------------------#
@@ -61,11 +66,13 @@ module Pod
             begin
               ENV.delete('CDPATH')
               ENV['COCOAPODS_VERSION'] = Pod::VERSION
+              ENV['COCOAPODS_SPEC'] = spec_name
               prepare_command = spec.prepare_command.strip_heredoc.chomp
               full_command = "\nset -e\n" + prepare_command
               bash!('-c', full_command)
             ensure
               ENV.delete('COCOAPODS_VERSION')
+              ENV.delete('COCOAPODS_SPEC')
             end
           end
         end


### PR DESCRIPTION
and set `COCOAPODS_SPEC` environment variable when running `prepare_command`.

Because prepare commands can't be set on subspecs, this is the least-bad way I could come up with to allow having custom behavior in prepare commands depending on which subspecs are being installed.

My main motivation for this is to add subspecs to Realm Objective-C and Realm Swift to allow building entirely from source, including the core database engine.

I have a PR towards Realm that does this (realm/realm-cocoa#4851) but it requires specifying an environment variable when installing: e.g. `REALM_DISABLE_SYNC=1 pod install`

I did this to test the feasibility and "test the waters", so to speak, to see if the CocoaPods maintainers would be amenable to changes along these lines. If so, I can add tests, update docs and see if there's a way to simplify these changes.

I'm quite open to other ideas on how to accomplish my high-level goal of providing source-only builds for Realm Objective-C & Realm Swift. Either in CocoaPods directly, or in our podspecs.

Thanks for your consideration!