### PR TITLE
Use `git!` when executing `push` command in order to raise informativ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Use `git!` when executing `push` command in order to raise informative and set exit code.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6700](https://github.com/CocoaPods/CocoaPods/pull/6700) 
+
 * Make copy resources echoes always return true to work around issue where Xcode stops handling build script output greater than ~440 characters (rdar://30607704).  
   [postmechanical](https://github.com/postmechanical)
   [#6595](https://github.com/CocoaPods/CocoaPods/issues/6595)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -213,7 +213,7 @@ module Pod
         #
         def push_repo
           UI.puts "\nPushing the `#{@repo}' repo\n".yellow
-          UI.puts `git -C "#{repo_dir}" push origin master 2>&1`
+          repo_git('-C', repo_dir, 'push', 'origin', 'master')
         end
 
         #---------------------------------------------------------------------#

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -177,7 +177,11 @@ module Pod
       Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, true).twice
 
       cmd = command('repo', 'push', 'master')
-      Dir.chdir(temporary_directory) { cmd.run }
+      # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
+      # tests so the exception is swallowed.
+      lambda do
+        Dir.chdir(temporary_directory) { cmd.run }
+      end.should.raise Informative
     end
 
     it 'validates specs as libraries if requested' do
@@ -187,7 +191,19 @@ module Pod
       Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false).twice
 
       cmd = command('repo', 'push', 'master', '--use-libraries')
-      Dir.chdir(temporary_directory) { cmd.run }
+      # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
+      # tests so the exception is swallowed.
+      lambda do
+        Dir.chdir(temporary_directory) { cmd.run }
+      end.should.raise Informative
+    end
+
+    it 'raises error and exit code when push fails' do
+      cmd = command('repo', 'push', 'master')
+      e = lambda do
+        Dir.chdir(temporary_directory) { cmd.run }
+      end.should.raise Informative
+      e.exit_status.should.equal(1)
     end
   end
 end


### PR DESCRIPTION
…e and set exit code.

We had a false positive build in which our CI failed to `push` to the repo but it never threw an exception to and set the exit code.

This PR will change `push` to use `git!` (via `repo_git`) in order to do that.