### PR TITLE
Fix pod install error when working on a static lib project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix pod install error from 1.2.1 when working with static lib-only projects.  
+  [Ben Asher](https://github.com/benasher44)
+  [#6673](https://github.com/CocoaPods/CocoaPods/issues/6673)
+
 * Use `git!` when executing `push` command in order to raise informative and set exit code.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6700](https://github.com/CocoaPods/CocoaPods/pull/6700) 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -317,7 +317,7 @@ module Pod
           #  If the targets missing hosts are only frameworks, then this is likely
           #  a project for doing framework development. In that case, just warn that
           #  the frameworks that these targets depend on won't be integrated anywhere
-          if embedded_targets_missing_hosts_product_types.subset?(Set.new [:framework, :static_library])
+          if embedded_targets_missing_hosts_product_types.subset?(Set.new([:framework, :static_library]))
             UI.warn 'The Podfile contains framework or static library targets, for which the Podfile does not contain host targets (targets which embed the framework).' \
               "\n" \
               'If this project is for doing framework development, you can ignore this message. Otherwise, add a target to the Podfile that embeds these frameworks to make this message go away (e.g. a test target).'

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -313,12 +313,12 @@ module Pod
         end
 
         unless embedded_targets_missing_hosts.empty?
-          embedded_targets_missing_hosts_product_types = embedded_targets_missing_hosts.map(&:user_targets).flatten.map(&:symbol_type).uniq
+          embedded_targets_missing_hosts_product_types = Set.new embedded_targets_missing_hosts.map(&:user_targets).flatten.map(&:symbol_type)
           #  If the targets missing hosts are only frameworks, then this is likely
           #  a project for doing framework development. In that case, just warn that
           #  the frameworks that these targets depend on won't be integrated anywhere
-          if embedded_targets_missing_hosts_product_types == [:framework]
-            UI.warn 'The Podfile contains framework targets, for which the Podfile does not contain host targets (targets which embed the framework).' \
+          if embedded_targets_missing_hosts_product_types.subset?(Set.new [:framework, :static_library])
+            UI.warn 'The Podfile contains framework or static library targets, for which the Podfile does not contain host targets (targets which embed the framework).' \
               "\n" \
               'If this project is for doing framework development, you can ignore this message. Otherwise, add a target to the Podfile that embeds these frameworks to make this message go away (e.g. a test target).'
           else

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -817,6 +817,21 @@ module Pod
             source SpecHelper.test_repo_url
             use_frameworks!
             platform :ios, '8.0'
+            target 'SampleLib' do
+              project 'SampleProject/Sample Lib/Sample Lib'
+              pod 'monkey'
+            end
+          end
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          analyzer.analyze
+          UI.warnings.should.match /The Podfile contains framework or static library targets, for which the Podfile does not contain host targets \(targets which embed the framework\)\./
+        end
+
+        it 'warns when using a Podfile for framework-only projects' do
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            use_frameworks!
+            platform :ios, '8.0'
             target 'SampleFramework' do
               project 'SampleProject/Sample Lib/Sample Lib'
               pod 'monkey'
@@ -824,7 +839,7 @@ module Pod
           end
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           analyzer.analyze
-          UI.warnings.should.match /The Podfile contains framework targets, for which the Podfile does not contain host targets \(targets which embed the framework\)\./
+          UI.warnings.should.match /The Podfile contains framework or static library targets, for which the Podfile does not contain host targets \(targets which embed the framework\)\./
         end
 
         it 'raises when the extension calls use_frameworks!, but the host target does not' do


### PR DESCRIPTION
Fixes #6673.

In 1.2.1, I added support for static library targets in your Podfile, similar to how it works for integrating framework targets. However, I forgot the piece that ensures that working on a static lib-only project still works (i.e. `pod install` works). Now, `pod install` generates the same warning for static lib-only projects as it does for frameworks-only projects.