### PR TITLE
Only check for valid Swift version for pod targets that use Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Only check for valid Swift version for pod targets that use Swift  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6733](https://github.com/CocoaPods/CocoaPods/pull/6733) 
+
 * Fix pod install error from 1.2.1 when working with static lib-only projects.  
   [Ben Asher](https://github.com/benasher44)
   [#6673](https://github.com/CocoaPods/CocoaPods/issues/6673)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -367,7 +367,6 @@ module Pod
       #
       def generate_targets
         specs_by_target = result.specs_by_target.reject { |td, _| td.abstract? }
-        check_pod_target_swift_versions(specs_by_target)
         pod_targets = generate_pod_targets(specs_by_target)
         aggregate_targets = specs_by_target.keys.map do |target_definition|
           generate_target(target_definition, pod_targets)
@@ -433,39 +432,6 @@ module Pod
         end
 
         target
-      end
-
-      # Verify that targets using a pod have the same swift version
-      #
-      # @param  [Hash{Podfile::TargetDefinition => Array<Specification>}] specs_by_target
-      #         the resolved specifications grouped by target.
-      #
-      # @note raises Informative if targets using a pod do not have
-      #       the same swift version
-      #
-      def check_pod_target_swift_versions(specs_by_target)
-        targets_by_spec = {}
-        specs_by_target.each do |target, specs|
-          specs.each do |spec|
-            (targets_by_spec[spec] ||= []) << target
-          end
-        end
-
-        error_message_for_target = lambda do |target|
-          "#{target.name} (Swift #{target.swift_version})"
-        end
-
-        error_messages = targets_by_spec.map do |spec, targets|
-          swift_targets = targets.reject { |target| target.swift_version.blank? }
-          next if swift_targets.empty? || swift_targets.uniq(&:swift_version).count == 1
-          target_errors = swift_targets.map(&error_message_for_target).join(', ')
-          "- #{spec.name} required by #{target_errors}"
-        end.compact
-
-        unless error_messages.empty?
-          raise Informative, 'The following pods are integrated into targets ' \
-            "that do not have the same Swift version:\n\n#{error_messages.join("\n")}"
-        end
       end
 
       # Setup the pod targets for an aggregate target. Deduplicates resulting

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -662,40 +662,6 @@ module Pod
         should.raise(Informative) { analyzer.analyze }
       end
 
-      it 'raises when targets integrate the same swift pod but have different swift versions' do
-        podfile = Podfile.new do
-          source SpecHelper.test_repo_url
-          project 'SampleProject/SampleProject'
-          platform :ios, '8.0'
-          pod 'OrangeFramework'
-          target 'SampleProject'
-          target 'TestRunner'
-        end
-        podfile.target_definitions['SampleProject'].stubs(:swift_version).returns('3.0')
-        podfile.target_definitions['TestRunner'].stubs(:swift_version).returns('2.3')
-        analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
-
-        should.raise Informative do
-          analyzer.analyze
-        end.message.should.match /The following pods are integrated into targets that do not have the same Swift version:/
-      end
-
-      it 'does not raise when targets integrate the same pod but only one of the targets is a swift target' do
-        podfile = Podfile.new do
-          source SpecHelper.test_repo_url
-          project 'SampleProject/SampleProject'
-          platform :ios, '8.0'
-          pod 'OrangeFramework'
-          target 'SampleProject'
-          target 'TestRunner'
-        end
-        podfile.target_definitions['SampleProject'].stubs(:swift_version).returns('3.0')
-        # when the swift version is unset at the project level, but set in one target, swift_version is nil
-        podfile.target_definitions['TestRunner'].stubs(:swift_version).returns(nil)
-        analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
-        lambda { analyzer.analyze }.should.not.raise
-      end
-
       #--------------------------------------#
 
       it 'computes the state of the Sandbox respect to the resolved dependencies' do


### PR DESCRIPTION
The previous check does not make sense when consuming pods that do not have any Swift sources in them.

We have a local project I tried this on and it worked just fine.

Existing specs pass too and updated one.