### PR TITLE
 Updates how .swift-version file is validated to prevent it from being needed in Objective-C pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#1698](https://github.com/CocoaPods/CocoaPods/issues/1698) 
 
+* Prevents need for .swift-version file in Objective-C pods  
+  [Austin Emmons](https://github.com/atreat)
+  [#6742](https://github.com/CocoaPods/CocoaPods/issues/6742) 
+
 ##### Bug Fixes
 
 * Fix pod install error from 1.2.1 when working with static lib-only projects.  

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -146,15 +146,8 @@ module Pod
         reasons << 'all results apply only to public specs, but you can use ' \
                    '`--private` to ignore them if linting the specification for a private pod'
       end
-      if dot_swift_version.nil?
-        reasons.to_sentence + ".\n[!] The validator for Swift projects uses " \
-          'Swift 3.0 by default, if you are using a different version of ' \
-          'swift you can use a `.swift-version` file to set the version for ' \
-          "your Pod. For example to use Swift 2.3, run: \n" \
-          '    `echo "2.3" > .swift-version`'
-      else
-        reasons.to_sentence
-      end
+
+      reasons.to_sentence
     end
 
     #-------------------------------------------------------------------------#
@@ -308,6 +301,7 @@ module Pod
           download_pod
           check_file_patterns
           install_pod
+          validate_dot_swift_version
           add_app_project_import
           validate_vendored_dynamic_frameworks
           build_pod
@@ -380,6 +374,17 @@ module Pod
     #
     def validate_documentation_url(spec)
       validate_url(spec.documentation_url) if spec.documentation_url
+    end
+
+    def validate_dot_swift_version
+      if !used_swift_version.nil? && dot_swift_version.nil?
+        warning(:swift_version,
+                'The validator for Swift projects uses ' \
+                'Swift 3.0 by default, if you are using a different version of ' \
+                'swift you can use a `.swift-version` file to set the version for ' \
+                "your Pod. For example to use Swift 2.3, run: \n" \
+                '    `echo "2.3" > .swift-version`')
+      end
     end
 
     def setup_validation_environment


### PR DESCRIPTION
Updates the check for the .swift-version file to only perform this check if the targets include swift sources. 

Addresses #6742