### PR TITLE
Stop adding `$(inherited)` for every static library linked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5117](https://github.com/CocoaPods/CocoaPods/issues/5117)
 
+* Stop adding `$(inherited)` for every static library linked  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6756](https://github.com/CocoaPods/CocoaPods/pull/6756)
+
 * Only check for valid Swift version for pod targets that use Swift  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6733](https://github.com/CocoaPods/CocoaPods/pull/6733) 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -212,7 +212,7 @@ module Pod
           name = File.basename(library_path, extension).sub(/\Alib/, '')
           dirname = '${PODS_ROOT}/' + library_path.dirname.relative_path_from(sandbox_root).to_s
           build_settings = {
-            'LIBRARY_SEARCH_PATHS' => '$(inherited) ' + quote([dirname]),
+            'LIBRARY_SEARCH_PATHS' => quote([dirname]),
           }
           build_settings['OTHER_LDFLAGS'] = "-l#{name}" if include_other_ldflags
           xcconfig.merge!(build_settings)

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -159,7 +159,7 @@ module Pod
             @coconut_pod_target.test_dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "$PODS_CONFIGURATION_BUILD_DIR/BananaLib" $(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "$PODS_CONFIGURATION_BUILD_DIR/BananaLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
           end
 
           it 'does not include other ld flags for test dependent targets if its not a test xcconfig' do

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -156,7 +156,7 @@ module Pod
             @sut.add_library_build_settings(path, xcconfig, config.sandbox.root)
             hash_config = xcconfig.to_hash
             hash_config['OTHER_LDFLAGS'].should == '-l"Proj4"'
-            hash_config['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/MapBox/Proj4"'
+            hash_config['LIBRARY_SEARCH_PATHS'].should == '"${PODS_ROOT}/MapBox/Proj4"'
           end
 
           it 'adds dylib build settings to the given xcconfig' do
@@ -165,7 +165,7 @@ module Pod
             @sut.add_library_build_settings(path, xcconfig, config.sandbox.root)
             hash_config = xcconfig.to_hash
             hash_config['OTHER_LDFLAGS'].should == '-l"Proj4"'
-            hash_config['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/MapBox/Proj4"'
+            hash_config['LIBRARY_SEARCH_PATHS'].should == '"${PODS_ROOT}/MapBox/Proj4"'
           end
         end
 
@@ -238,7 +238,7 @@ module Pod
             pod_target = stub(:sandbox => config.sandbox)
             xcconfig = Xcodeproj::Config.new
             @sut.add_static_dependency_build_settings(aggregate_target, pod_target, xcconfig, @accessor)
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['OTHER_LDFLAGS'].should.be.nil
           end
@@ -249,7 +249,7 @@ module Pod
             aggregate_target = stub(:target_definition => target_definition, :pod_targets => [pod_target], :search_paths_aggregate_targets => [])
             xcconfig = Xcodeproj::Config.new
             @sut.add_static_dependency_build_settings(aggregate_target, pod_target, xcconfig, @accessor)
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-l"Bananalib" -framework "Bananalib"'
           end
@@ -260,7 +260,7 @@ module Pod
             pod_target = stub(:sandbox => config.sandbox)
             xcconfig = Xcodeproj::Config.new
             @sut.add_static_dependency_build_settings(aggregate_target, pod_target, xcconfig, @accessor)
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-l"Bananalib" -framework "Bananalib"'
           end
@@ -269,7 +269,7 @@ module Pod
             pod_target = stub(:sandbox => config.sandbox)
             xcconfig = Xcodeproj::Config.new
             @sut.add_static_dependency_build_settings(nil, pod_target, xcconfig, @accessor)
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '"${PODS_ROOT}/../../spec/fixtures/banana-lib"'
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-l"Bananalib" -framework "Bananalib"'
           end


### PR DESCRIPTION
For every binary static library pod target we have we noticed `$(inherited)` is added.

*Before*
```
$(inherited) myLib1/myLib1 $(inherited) myLib2/myLib2
```
*After*
```
$(inherited) myLib1/myLib1 myLib2/myLib2
```
This is now fixed.