### PR TITLE
`VALID_ARCHS` does not include the right archs to strip for a framework so use `ARCHS` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6787](https://github.com/CocoaPods/CocoaPods/pull/6787)
 
+* `VALID_ARCHS` does not include the right archs to strip for a framework so use `ARCHS` instead  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6774](https://github.com/CocoaPods/CocoaPods/issues/6774)
+
 * Do not double add search paths to test xcconfig from parent  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6767](https://github.com/CocoaPods/CocoaPods/pull/6767)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -122,7 +122,7 @@ module Pod
             archs="$(lipo -info "$binary" | rev | cut -d ':' -f1 | rev)"
             stripped=""
             for arch in $archs; do
-              if ! [[ "${VALID_ARCHS}" == *"$arch"* ]]; then
+              if ! [[ "${ARCHS}" == *"$arch"* ]]; then
                 # Strip non-valid architectures in-place
                 lipo -remove "$arch" -output "$binary" "$binary" || exit 1
                 stripped="$stripped $arch"


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/6774

This might require integration specs update.