### PR TITLE
Use a cache when figuring out if a pod target is test only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Use a cache when figuring out if a pod target is test only  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6787](https://github.com/CocoaPods/CocoaPods/pull/6787)
+
 * Do not double add search paths to test xcconfig from parent  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6767](https://github.com/CocoaPods/CocoaPods/pull/6767)


### PR DESCRIPTION
As of CP 1.3.0.beta.1 this method would add 7-10 seconds to out pod install time.

This adds a cache to the result but also prevents a number of calls to this method if they are not needed by short circuiting earlier.

There are no tests for this PR because the logic is the same. I hot patched CocoaPods for us and the `pod install` now remains the same.