### PR TITLE
[WIP] Remove redundant `recursive_dependent_targets` method from `pod_target`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Remove redundant `recursive_dependent_targets` method from `pod_target`
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6789](https://github.com/CocoaPods/CocoaPods/pull/6789)
+
 * Remove 0.34 migration for a small boost in `pod install` time  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6783](hhttps://github.com/CocoaPods/CocoaPods/pull/6783)

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -69,11 +69,11 @@ module Pod
             @xcconfig.merge!(file_accessor.spec_consumer.pod_target_xcconfig)
           end
           XCConfigHelper.add_target_specific_settings(target, @xcconfig)
-          recursive_dependent_targets = target.recursive_dependent_targets
-          @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, recursive_dependent_targets)
+          dependent_targets = target.dependent_targets
+          @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, dependent_targets)
           if @test_xcconfig
             test_dependent_targets = [target, *target.test_dependent_targets]
-            @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, test_dependent_targets - recursive_dependent_targets)
+            @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, test_dependent_targets - dependent_targets)
             XCConfigHelper.generate_vendored_build_settings(nil, test_dependent_targets, @xcconfig)
             XCConfigHelper.generate_other_ld_flags(nil, test_dependent_targets, @xcconfig)
             XCConfigHelper.generate_ld_runpath_search_paths(target, false, true, @xcconfig)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -317,7 +317,7 @@ module Pod
           #
           def test_target_swift_debug_hack(test_target_bc)
             return unless test_target_bc.debug?
-            return unless [target, *target.recursive_dependent_targets].any?(&:uses_swift?)
+            return unless [target, *target.dependent_targets].any?(&:uses_swift?)
             ldflags = test_target_bc.build_settings['OTHER_LDFLAGS'] ||= '$(inherited)'
             ldflags << ' -lswiftSwiftOnoneSupport'
           end

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -265,21 +265,6 @@ module Pod
       end.uniq
     end
 
-    # @return [Array<PodTarget>] the recursive targets that this target has a
-    #         dependency upon.
-    #
-    def recursive_dependent_targets
-      targets = dependent_targets.clone
-
-      targets.each do |target|
-        target.dependent_targets.each do |t|
-          targets.push(t) unless t == self || targets.include?(t)
-        end
-      end
-
-      targets
-    end
-
     # Checks if the target should be included in the build configuration with
     # the given name of a given target definition.
     #

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -293,7 +293,7 @@ module Pod
         end
 
         it 'resolves simple dependencies' do
-          @pod_target.recursive_dependent_targets.should == [@pod_dependency]
+          @pod_target.dependent_targets.should == [@pod_dependency]
         end
 
         describe 'With cyclic dependencies' do
@@ -304,7 +304,7 @@ module Pod
           end
 
           it 'resolves the cycle' do
-            @pod_target.recursive_dependent_targets.should == [@pod_dependency]
+            @pod_target.dependent_targets.should == [@pod_dependency]
           end
         end
       end


### PR DESCRIPTION
The analyzer already sets all `dependent_targets` recursively. This method was unnecessary to invoke to recalculate dependent targets.

Keeping it WIP since I need to double triple check it :)

From https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/installer/analyzer.rb#L498-L503

```ruby
pod_targets.each do |target|
  dependencies = transitive_dependencies_for_specs(target.specs.reject(&:test_specification?),
  target.platform, all_specs).group_by(&:root)
  test_dependencies = transitive_dependencies_for_specs(target.specs.select(&:test_specification?),
  target.platform, all_specs).group_by(&:root)
  target.dependent_targets = filter_dependencies(dependencies, pod_targets_by_name, target)
  target.test_dependent_targets = filter_dependencies(test_dependencies, pod_targets_by_name, target)
end
```