### PR TITLE
Simplify logic around framework input and output paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Simplify logic around framework input and output paths  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6803](https://github.com/CocoaPods/CocoaPods/pull/6803)
+
 * Add inputs and outputs to check manifest lock and embed framework script phases  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6797](https://github.com/CocoaPods/CocoaPods/issues/6797)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -139,10 +139,10 @@ module Pod
           unless frameworks_with_dsyms.empty?
             script << %(if [[ "$CONFIGURATION" == "#{config}" ]]; then\n)
             frameworks_with_dsyms.each do |framework_with_dsym|
-              script << %(  install_framework "#{framework_with_dsym[:framework]}"\n)
+              script << %(  install_framework "#{framework_with_dsym[:input_path]}"\n)
               # Vendored frameworks might have a dSYM file next to them so ensure its copied. Frameworks built from
               # sources will have their dSYM generated and copied by Xcode.
-              script << %(  install_dsym "#{framework_with_dsym[:dsym]}"\n) unless framework_with_dsym[:dsym].nil?
+              script << %(  install_dsym "#{framework_with_dsym[:dsym_input_path]}"\n) unless framework_with_dsym[:dsym_input_path].nil?
             end
             script << "fi\n"
           end

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -135,10 +135,10 @@ module Pod
           phase = create_or_update_build_phase(native_target, EMBED_FRAMEWORK_PHASE_NAME)
           script_path = target.embed_frameworks_script_relative_path
           phase.shell_script = %("#{script_path}"\n)
-          frameworks_by_config = target.frameworks_by_config.values.flatten.uniq
-          unless frameworks_by_config.empty?
-            phase.input_paths = [target.embed_frameworks_script_relative_path, *frameworks_by_config.map { |fw| [fw[:framework], fw[:dsym]] }.flatten.compact]
-            phase.output_paths = frameworks_by_config.map { |fw| [fw[:install_path], fw[:dsym_install_path]] }.flatten.compact
+          framework_paths_by_config = target.framework_paths_by_config.values.flatten.uniq
+          unless framework_paths_by_config.empty?
+            phase.input_paths = [target.embed_frameworks_script_relative_path, *framework_paths_by_config.map { |fw| [fw[:input_path], fw[:dsym_input_path]] }.flatten.compact]
+            phase.output_paths = framework_paths_by_config.map { |fw| [fw[:output_path], fw[:dsym_output_path]] }.flatten.compact
           end
         end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -135,7 +135,7 @@ module Pod
           #
           def create_embed_frameworks_script
             path = target.embed_frameworks_script_path
-            generator = Generator::EmbedFrameworksScript.new(target.frameworks_by_config)
+            generator = Generator::EmbedFrameworksScript.new(target.framework_paths_by_config)
             generator.save_as(path)
             add_file_to_support_group(path)
           end

--- a/spec/unit/generator/embed_frameworks_script_spec.rb
+++ b/spec/unit/generator/embed_frameworks_script_spec.rb
@@ -4,8 +4,8 @@ module Pod
   describe Generator::EmbedFrameworksScript do
     it 'returns the embed frameworks script' do
       frameworks = {
-        'Debug' => [{ :framework => 'Pods/Loopback.framework', :dsym => 'Pods/Loopback.framework.dSYM' }, { :framework => 'Reveal.framework', :dsym => nil }],
-        'Release' => [{ :framework => 'CrashlyticsFramework.framework', :dsym => nil }],
+        'Debug' => [{ :name => 'Loopback.framework', :input_path => 'Pods/Loopback.framework', :dsym_input_path => 'Pods/Loopback.framework.dSYM' }, { :name => 'Reveal.framework', :input_path => 'Reveal.framework' }],
+        'Release' => [{ :name => 'CrashlyticsFramework.framework', :input_path => 'CrashlyticsFramework.framework' }],
       }
       generator = Pod::Generator::EmbedFrameworksScript.new(frameworks)
       generator.send(:script).should.include <<-SH.strip_heredoc

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -285,7 +285,7 @@ module Pod
         end
 
         it 'does not add embed frameworks build phase input output paths with no frameworks' do
-          @pod_bundle.stubs(:frameworks_by_config => {})
+          @pod_bundle.stubs(:framework_paths_by_config => {})
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
@@ -294,24 +294,29 @@ module Pod
         end
 
         it 'adds embed frameworks build phase input and output paths for vendored and non vendored frameworks' do
-          debug_vendored_framework = { :framework => '${PODS_ROOT}/DebugVendoredFramework/ios/DebugVendoredFramework.framework',
-                                       :dsym => '${PODS_ROOT}/DebugVendoredFramework/ios/DebugVendoredFramework.framework.dSYM',
-                                       :install_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DebugVendoredFramework.framework',
-                                       :dsym_install_path => '${DWARF_DSYM_FOLDER_PATH}/DebugVendoredFramework.framework.dSYM' }
+          debug_vendored_framework = { :name => 'DebugVendoredFramework.framework',
+                                       :input_path => '${PODS_ROOT}/DebugVendoredFramework/ios/DebugVendoredFramework.framework',
+                                       :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DebugVendoredFramework.framework',
+                                       :dsym_name => 'DebugVendoredFramework.framework.dSYM',
+                                       :dsym_input_path => '${PODS_ROOT}/DebugVendoredFramework/ios/DebugVendoredFramework.framework.dSYM',
+                                       :dsym_output_path => '${DWARF_DSYM_FOLDER_PATH}/DebugVendoredFramework.framework.dSYM' }
 
-          debug_non_vendored_framework = { :framework => '${BUILT_PRODUCTS_DIR}/DebugCompiledFramework/DebugCompiledFramework.framework',
-                                           :install_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DebugCompiledFramework.framework' }
+          debug_non_vendored_framework = { :name => 'DebugCompiledFramework.framework',
+                                           :input_path => '${BUILT_PRODUCTS_DIR}/DebugCompiledFramework/DebugCompiledFramework.framework',
+                                           :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DebugCompiledFramework.framework' }
 
-          release_vendored_framework = { :framework => '${PODS_ROOT}/ReleaseVendoredFramework/ios/ReleaseVendoredFramework.framework',
-                                         :dsym => '${PODS_ROOT}/ReleaseVendoredFramework/ios/ReleaseVendoredFramework.framework.dSYM',
-                                         :install_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReleaseVendoredFramework.framework',
-                                         :dsym_install_path => '${DWARF_DSYM_FOLDER_PATH}/ReleaseVendoredFramework.framework.dSYM' }
+          release_vendored_framework = { :name => 'ReleaseVendoredFramework.framework',
+                                         :input_path => '${PODS_ROOT}/ReleaseVendoredFramework/ios/ReleaseVendoredFramework.framework',
+                                         :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReleaseVendoredFramework.framework',
+                                         :dsym_name => 'ReleaseVendoredFramework.framework.dSYM',
+                                         :dsym_input_path => '${PODS_ROOT}/ReleaseVendoredFramework/ios/ReleaseVendoredFramework.framework.dSYM',
+                                         :dsym_output_path => '${DWARF_DSYM_FOLDER_PATH}/ReleaseVendoredFramework.framework.dSYM' }
 
-          frameworks_by_config = {
+          framework_paths_by_config = {
             'Debug' => [debug_vendored_framework, debug_non_vendored_framework],
             'Release' => [release_vendored_framework],
           }
-          @pod_bundle.stubs(:frameworks_by_config => frameworks_by_config)
+          @pod_bundle.stubs(:framework_paths_by_config => framework_paths_by_config)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }


### PR DESCRIPTION
This adds tests and cleans up a bit the method for returning all framework input and output paths. It was getting hard to follow but I think now its much better.