### PR TITLE
Do not use target definition label for key caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not use target definition label for key caching  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6810](https://github.com/CocoaPods/CocoaPods/pull/6810)
+
 * Remove 0.34 migration for a small boost in `pod install` time  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
-  [#6783](hhttps://github.com/CocoaPods/CocoaPods/pull/6783)
+  [#6783](https://github.com/CocoaPods/CocoaPods/pull/6783)
 
 * Use a cache when figuring out if a pod target is test only  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -290,7 +290,7 @@ module Pod
     #         The name of the build configuration.
     #
     def include_in_build_config?(target_definition, configuration_name)
-      key = [target_definition.label, configuration_name]
+      key = [target_definition, configuration_name]
       if @build_config_cache.key?(key)
         return @build_config_cache[key]
       end


### PR DESCRIPTION
This method can be slow when the key is being generated as it compares the platforms of the `target_definition`.

<img width="516" alt="screen_shot_2017-06-16_at_10_57_42_pm" src="https://user-images.githubusercontent.com/310370/27250530-456fa744-52e7-11e7-9448-b6784624a39d.png">

If you do not like this change, we could perhaps cache the `label` method within `target_definition.rb`.

Also `include_in_build_config?` is invoked in multiple places, not just in the screenshot above.
