### PR TITLE
Add support for source static library frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   dependency resolution.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Add support for source static library frameworks
+  [Paul Beusterien](https://github.com/paulb777)
+  [#6811](https://github.com/CocoaPods/CocoaPods/pull/6811)
+
 ##### Bug Fixes
 
 * None.
@@ -111,7 +115,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 ## 1.3.0.beta.2 (2017-06-22)
 
 ##### Enhancements
-
 * Add inputs and outputs for resources script phase  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6806](https://github.com/CocoaPods/CocoaPods/pull/6806)

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -225,9 +225,10 @@ module Pod
               aggregate_target.native_target.add_dependency(pod_target.native_target)
               configure_app_extension_api_only_for_target(pod_target) if is_app_extension
 
-              add_dependent_targets_to_native_target(pod_target.dependent_targets, pod_target.native_target, is_app_extension, pod_target.requires_frameworks?, frameworks_group)
-
-              add_pod_target_test_dependencies(pod_target, frameworks_group)
+              unless pod_target.static_framework?
+                add_dependent_targets_to_native_target(pod_target.dependent_targets, pod_target.native_target, is_app_extension, pod_target.requires_frameworks?, frameworks_group)
+                add_pod_target_test_dependencies(pod_target, frameworks_group)
+              end
             end
           end
         end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -81,7 +81,11 @@ module Pod
             end
 
             if target.requires_frameworks?
-              settings['PRODUCT_NAME'] = target.product_module_name
+              framework_name = target.product_module_name
+              settings['PRODUCT_NAME'] = framework_name
+              if target.static_framework?
+                settings['PUBLIC_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/Headers'
+              end
             else
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -73,7 +73,7 @@ module Pod
             aggregate_target.user_build_configurations.keys.each do |config|
               pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
 
-              dependencies = pod_targets.select(&:should_build?).flat_map(&:dependencies)
+              dependencies = pod_targets.select(&:should_build?).reject(&:static_framework?).flat_map(&:dependencies)
               depended_upon_targets = pod_targets.select { |t| dependencies.include?(t.pod_name) && !t.should_build? }
 
               static_libs = depended_upon_targets.flat_map(&:file_accessors).flat_map(&:vendored_static_artifacts)

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -72,7 +72,7 @@ module Pod
     #         #requires_frameworks?.
     #
     def product_type
-      requires_frameworks? ? :framework : :static_library
+      requires_frameworks? && !static_framework? ? :framework : :static_library
     end
 
     # @return [String] A string suitable for debugging.
@@ -88,6 +88,12 @@ module Pod
     #
     def requires_frameworks?
       host_requires_frameworks? || false
+    end
+
+    # @return [Boolean] Whether the target should build a static framework.
+    #
+    def static_framework?
+      !is_a?(Pod::AggregateTarget) && specs.any? && specs.all?(&:static_framework)
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -219,7 +219,7 @@ module Pod
           end
           frameworks << framework
         end
-        if should_build? && requires_frameworks?
+        if should_build? && requires_frameworks? && !static_framework?
           frameworks << { :name => product_name,
                           :input_path => build_product_path('${BUILT_PRODUCTS_DIR}'),
                           :output_path => "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{product_name}" }

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -207,6 +207,16 @@ module Pod
               script.read.should.not.include?('BananaLib.framework')
             end
 
+            it 'does not add pods to the embed frameworks script if they are static' do
+              @pod_target.stubs(:static_framework? => true)
+              @pod_target.stubs(:requires_frameworks? => true)
+              @target.stubs(:requires_frameworks? => true)
+              @installer.install!
+              support_files_dir = config.sandbox.target_support_files_dir('Pods-SampleProject')
+              script = support_files_dir + 'Pods-SampleProject-frameworks.sh'
+              script.read.should.not.include?('BananaLib.framework')
+            end
+
             it 'creates the acknowledgements files ' do
               @installer.install!
               support_files_dir = config.sandbox.target_support_files_dir('Pods-SampleProject')

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -603,6 +603,18 @@ module Pod
                 end
                 build_phase.should.not.be.nil
               end
+
+              it 'creates a build phase to set up a static library framework' do
+                @pod_target.stubs(:static_framework?).returns(true)
+
+                @installer.install!
+
+                target = @project.native_targets.first
+                build_phase = target.shell_script_build_phases.find do |bp|
+                  bp.name == 'Setup Static Framework Archive'
+                end
+                build_phase.should.not.be.nil
+              end
             end
 
             it "doesn't create a build phase to symlink header folders by default on OS X" do

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -60,6 +60,18 @@ module Pod
               'AppStore' => nil,
             }
           end
+
+          it 'verify header path for a static library framework' do
+            @pod_target.stubs(:requires_frameworks?).returns(true)
+            @pod_target.stubs(:static_framework?).returns(true)
+            @installer.send(:add_target)
+            @installer.send(:native_target).resolved_build_setting('PUBLIC_HEADERS_FOLDER_PATH').should == {
+              'Release' => 'BananaLib.framework/Headers',
+              'Debug' => 'BananaLib.framework/Headers',
+              'Test' => 'BananaLib.framework/Headers',
+              'AppStore' => 'BananaLib.framework/Headers',
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
Address #6772 

https://github.com/CocoaPods/Core/pull/386 adds the static_framework podspec attribute.

This PR uses that attribute to build a source pod into a static library framework. All dependents and dependencies should interact with the source pod just as if it were a vendored_framework static library framework CocoaPod.