### PR TITLE
Truncate shared parent folders in Development Pods to the nearest ancestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Truncate extra groups in Development Pods when they are parents of all files
+  [Eric Amorde](https://github.com/amorde)
+  [#6814](https://github.com/CocoaPods/CocoaPods/pull/6814)
+
 * Remove 0.34 migration for a small boost in `pod install` time  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6783](hhttps://github.com/CocoaPods/CocoaPods/pull/6783)

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -239,6 +239,47 @@ module Pod
               end
             end
 
+            describe '#common_path' do
+              it 'calculates the correct common path' do
+                paths = [
+                  '/Base/Sub/A/1.txt',
+                  '/Base/Sub/A/2.txt',
+                  '/Base/Sub/A/B/1.txt',
+                  '/Base/Sub/A/B/2.txt',
+                  '/Base/Sub/A/D/E/1.txt',
+                ].map { |p| Pathname.new(p) }
+                result = @installer.send(:common_path, paths)
+                result.should == Pathname.new('/Base/Sub/A')
+              end
+
+              it 'should not consider root \'/\' a common path' do
+                paths = [
+                  '/A/B/C',
+                  '/D/E/F',
+                  '/G/H/I',
+                ].map { |p| Pathname.new(p) }
+                result = @installer.send(:common_path, paths)
+                result.should.be.nil
+              end
+
+              it 'raises when given a relative path' do
+                paths = [
+                  '/A/B/C',
+                  '/D/E/F',
+                  'bad/path',
+                ].map { |p| Pathname.new(p) }
+                should.raise ArgumentError do
+                  @installer.send(:common_path, paths)
+                end
+              end
+
+              it 'returns nil when given an empty path list' do
+                paths = []
+                result = @installer.send(:common_path, paths)
+                result.should.be.nil
+              end
+            end
+
             describe '#vendored_frameworks_header_mappings' do
               it 'returns the vendored frameworks header mappings' do
                 headers_sandbox = Pathname.new('BananaLib')

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -168,6 +168,7 @@ module Pod
         before do
           @project.add_pod_group('BananaLib', config.sandbox.pod_dir('BananaLib'), false)
           @file = config.sandbox.pod_dir('BananaLib') + 'file.m'
+          @pod_dir = config.sandbox.pod_dir('BananaLib')
           @nested_file = config.sandbox.pod_dir('BananaLib') + 'Dir/SubDir/nested_file.m'
           @localized_file = config.sandbox.pod_dir('BananaLib') + 'Dir/SubDir/de.lproj/Foo.strings'
           @group = @project.group_for_spec('BananaLib')
@@ -195,6 +196,15 @@ module Pod
           Pathname.any_instance.stubs(:realpath).returns(@nested_file)
           ref = @project.add_file_reference(@nested_file, @group, false)
           ref.hierarchy_path.should == '/Pods/BananaLib/nested_file.m'
+        end
+
+        it 'adds subgroups relative to shared base if requested' do
+          base_path = @pod_dir + 'Dir'
+          Pathname.any_instance.stubs(:realdirpath).returns(@pod_dir + 'Dir')
+          Pathname.any_instance.stubs(:realpath).returns(@nested_file)
+          ref = @project.add_file_reference(@nested_file, @group, true, base_path)
+          ref.hierarchy_path.should == '/Pods/BananaLib/SubDir/nested_file.m'
+          ref.parent.path.should == 'Dir/SubDir'
         end
 
         it "it doesn't duplicate file references for a single path" do


### PR DESCRIPTION
Closes #4719

This will leave source files and directories at the same level as "Supporting Files" and "Resources", which may or may not have been the desired effect.

Depends on https://github.com/CocoaPods/cocoapods-integration-specs/pull/116