### PR TITLE
generator: prevent header from importing UIKit on iOS & tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Generator: prevent header from importing UIKit on iOS & tvOS 
+  [Romain Bertozzi](https://github.com/r-mckay)
+  [#6816](https://github.com/CocoaPods/CocoaPods/pull/6816)
+
 * Add inputs and outputs for resources script phase  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6806](https://github.com/CocoaPods/CocoaPods/pull/6806)

--- a/lib/cocoapods/generator/header.rb
+++ b/lib/cocoapods/generator/header.rb
@@ -92,8 +92,8 @@ module Pod
       #
       def generate_platform_import_header
         case platform.name
-        when :ios then "#import <UIKit/UIKit.h>\n"
-        when :tvos then "#import <UIKit/UIKit.h>\n"
+        when :ios then "#import <Foundation/Foundation.h>\n"
+        when :tvos then "#import <Foundation/Foundation.h>\n"
         when :osx then "#import <Cocoa/Cocoa.h>\n"
         else "#import <Foundation/Foundation.h>\n"
         end

--- a/spec/unit/generator/header_spec.rb
+++ b/spec/unit/generator/header_spec.rb
@@ -10,7 +10,7 @@ module Pod
       @gen.imports << 'header.h'
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -29,7 +29,7 @@ module Pod
       @gen.module_imports << 'Module'
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -47,7 +47,7 @@ module Pod
 
     it 'imports UIKit in iOS platforms' do
       @gen.stubs(:platform).returns(Pod::Platform.ios)
-      @gen.generate.should.include?('#import <UIKit/UIKit.h>')
+      @gen.generate.should.include?('#import <Foundation/Foundation.h>')
     end
 
     it 'imports Cocoa for OS X platforms' do
@@ -62,7 +62,7 @@ module Pod
 
     it 'imports Foundation for tvOS platforms' do
       @gen.stubs(:platform).returns(Pod::Platform.tvos)
-      @gen.generate.should.include?('#import <UIKit/UIKit.h>')
+      @gen.generate.should.include?('#import <Foundation/Foundation.h>')
     end
 
     it 'writes the header file to the disk' do
@@ -70,7 +70,7 @@ module Pod
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)

--- a/spec/unit/generator/prefix_header_spec.rb
+++ b/spec/unit/generator/prefix_header_spec.rb
@@ -13,7 +13,7 @@ module Pod
       @spec.prefix_header_file = nil
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -37,7 +37,7 @@ module Pod
       end
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -66,7 +66,7 @@ module Pod
 
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -84,7 +84,7 @@ module Pod
     it "includes the contents of the specification's prefix header file" do
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -111,7 +111,7 @@ module Pod
 
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -130,7 +130,7 @@ module Pod
       @gen.imports << 'header.h'
       @gen.generate.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)
@@ -151,7 +151,7 @@ module Pod
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
       #ifdef __OBJC__
-      #import <UIKit/UIKit.h>
+      #import <Foundation/Foundation.h>
       #else
       #ifndef FOUNDATION_EXPORT
       #if defined(__cplusplus)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -445,7 +445,7 @@ module Pod
               generated = @pod_target.prefix_header_path.read
               expected = <<-EOS.strip_heredoc
           #ifdef __OBJC__
-          #import <UIKit/UIKit.h>
+          #import <Foundation/Foundation.h>
           #else
           #ifndef FOUNDATION_EXPORT
           #if defined(__cplusplus)


### PR DESCRIPTION
This commit replaces the UIKit import made in the header generator
by a Foundation import when targetting iOS and tvOS.

This is done because we don't know if the framework that is built
depends or not on UIKit. For example, frameworks that do not use UI
do not need to import UIKit.

Issue: #6815