### PR TITLE
Do not re-write generated files that have not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#6814](https://github.com/CocoaPods/CocoaPods/pull/6814)
 
+* Do not re-write generated files that have not changed  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [dingjingpisces2015](https://github.com/dingjingpisces2015)
+  [#6825](https://github.com/CocoaPods/CocoaPods/pull/6825)
+
 ##### Bug Fixes
 
 * Integrate test targets to embed frameworks and resources  

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -279,9 +279,17 @@ module Pod
     #
     def clean_sandbox
       sandbox.public_headers.implode!
+      target_support_dirs = sandbox.target_support_files_root.children.select(&:directory?)
       pod_targets.each do |pod_target|
         pod_target.build_headers.implode!
+        target_support_dirs.delete(pod_target.support_files_dir)
       end
+
+      aggregate_targets.each do |aggregate_target|
+        target_support_dirs.delete(aggregate_target.support_files_dir)
+      end
+
+      target_support_dirs.each { |dir| FileUtils.rm_rf(dir) }
 
       unless sandbox_state.deleted.empty?
         title_options = { :verbose_prefix => '-> '.red }

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -84,7 +84,7 @@ module Pod
             native_target.build_configurations.each do |configuration|
               path = target.xcconfig_path(configuration.name)
               gen = Generator::XCConfig::AggregateXCConfig.new(target, configuration.name)
-              gen.save_as(path)
+              update_changed_file(gen, path)
               target.xcconfigs[configuration.name] = gen.xcconfig
               xcconfig_file_ref = add_file_to_support_group(path)
               configuration.base_configuration_reference = xcconfig_file_ref
@@ -104,7 +104,7 @@ module Pod
               path = target.bridge_support_path
               headers = native_target.headers_build_phase.files.map { |bf| sandbox.root + bf.file_ref.path }
               generator = Generator::BridgeSupport.new(headers)
-              generator.save_as(path)
+              update_changed_file(generator, path)
               add_file_to_support_group(path)
             end
           end
@@ -120,7 +120,7 @@ module Pod
           def create_copy_resources_script
             path = target.copy_resources_script_path
             generator = Generator::CopyResourcesScript.new(target.resource_paths_by_config, target.platform)
-            generator.save_as(path)
+            update_changed_file(generator, path)
             add_file_to_support_group(path)
           end
 
@@ -136,7 +136,7 @@ module Pod
           def create_embed_frameworks_script
             path = target.embed_frameworks_script_path
             generator = Generator::EmbedFrameworksScript.new(target.framework_paths_by_config)
-            generator.save_as(path)
+            update_changed_file(generator, path)
             add_file_to_support_group(path)
           end
 
@@ -150,7 +150,7 @@ module Pod
               path = generator_class.path_from_basepath(basepath)
               file_accessors = target.pod_targets.map(&:file_accessors).flatten
               generator = generator_class.new(file_accessors)
-              generator.save_as(path)
+              update_changed_file(generator, path)
               add_file_to_support_group(path)
             end
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -89,10 +89,44 @@ module Pod
             settings
           end
 
+          # @param [Generator] generator
+          #        the generator to use for generating the content.
+          #
+          # @param [Pathname] path
+          #        the pathname to save the content into.
+          #
+          # Saves the content the provided path unless the path exists and the contents are exactly the same.
+          #
+          # @return [Void]
+          #
+          def update_changed_file(generator, path)
+            if path.exist?
+              generator.save_as(support_files_temp_dir)
+              unless FileUtils.identical?(support_files_temp_dir, path)
+                FileUtils.mv(support_files_temp_dir, path)
+              end
+            else
+              generator.save_as(path)
+            end
+            clean_support_files_temp_dir if support_files_temp_dir.exist?
+          end
+
           # Creates the directory where to store the support files of the target.
           #
           def create_support_files_dir
-            target.support_files_dir.mkdir
+            target.support_files_dir.mkpath
+          end
+
+          # Remove temp file whose store .prefix/config/dummy file.
+          #
+          def clean_support_files_temp_dir
+            support_files_temp_dir.rmtree
+          end
+
+          # @return [String] The temp file path to store temporary files.
+          #
+          def support_files_temp_dir
+            sandbox.target_support_files_dir('generated_files_tmp')
           end
 
           # Creates the Info.plist file which sets public framework attributes
@@ -103,7 +137,7 @@ module Pod
             path = target.info_plist_path
             UI.message "- Generating Info.plist file at #{UI.path(path)}" do
               generator = Generator::InfoPlistFile.new(target)
-              generator.save_as(path)
+              update_changed_file(generator, path)
               add_file_to_support_group(path)
 
               native_target.build_configurations.each do |c|
@@ -126,7 +160,7 @@ module Pod
             UI.message "- Generating module map file at #{UI.path(path)}" do
               generator = Generator::ModuleMap.new(target)
               yield generator if block_given?
-              generator.save_as(path)
+              update_changed_file(generator, path)
               add_file_to_support_group(path)
 
               native_target.build_configurations.each do |c|
@@ -147,7 +181,7 @@ module Pod
             UI.message "- Generating umbrella header at #{UI.path(path)}" do
               generator = Generator::UmbrellaHeader.new(target)
               yield generator if block_given?
-              generator.save_as(path)
+              update_changed_file(generator, path)
 
               # Add the file to the support group and the native target,
               # so it will been added to the header build phase
@@ -169,7 +203,7 @@ module Pod
           def create_dummy_source
             path = target.dummy_source_path
             generator = Generator::DummySource.new(target.label)
-            generator.save_as(path)
+            update_changed_file(generator, path)
             file_reference = add_file_to_support_group(path)
             native_target.source_build_phase.add_file_reference(file_reference)
           end

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -89,8 +89,8 @@ module Pod
         path = pod_dir(name)
         path.rmtree if path.exist?
       end
-      podspe_path = specification_path(name)
-      podspe_path.rmtree if podspe_path
+      podspec_path = specification_path(name)
+      podspec_path.rmtree if podspec_path
     end
 
     # Prepares the sandbox for a new installation removing any file that will
@@ -98,7 +98,6 @@ module Pod
     #
     def prepare
       FileUtils.rm_rf(headers_root)
-      FileUtils.rm_rf(target_support_files_root)
 
       FileUtils.mkdir_p(headers_root)
       FileUtils.mkdir_p(sources_root)


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/3991 and completes/supersedes https://github.com/CocoaPods/CocoaPods/pull/6496

This is a huge performance boost for projects that frequently perform `pod install` and have to re-built because Xcode "thinks" the `.xcconfig` files or `.pch` or any other file for that matter is "dirty" and forces a re build.

We should not wait for Xcode to do the right thing and instead we should work around it to speed up all of the iOS ecosystem.

I tried this in a medium sized project of 50+ pods and after `pod install` the build succeeded almost instantly (including the caching of input/output paths for the shell scripts!).

I *highly* recommend we land this and I will update it based on feedback.