### PR TITLE
Ensure resource bundle and test dependencies are set for test native targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Ensure resource bundle and test dependencies are set for test native targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6829](https://github.com/CocoaPods/CocoaPods/pull/6829)
 
 ## 1.3.0.beta.2 (2017-06-22)
 

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -269,6 +269,7 @@ module Pod
 
               dependent_target = mock('dependent-target', :should_build? => true, :native_target => dependent_native_target)
               test_dependent_target = mock('dependent-test-target', :should_build? => true, :native_target => test_dependent_native_target)
+              test_dependent_target.expects(:should_build?).returns(true)
 
               @pod_target.stubs(:native_target).returns(mock_native_target)
               @pod_target.stubs(:test_native_targets).returns([mock_test_native_target])
@@ -284,6 +285,35 @@ module Pod
               mock_test_native_target.expects(:add_dependency).with(dependent_native_target).never
               mock_test_native_target.expects(:add_dependency).with(test_dependent_native_target)
               mock_test_native_target.expects(:add_dependency).with(mock_native_target)
+
+              @generator.send(:set_target_dependencies)
+            end
+
+            it 'adds test dependencies to test native targets for a pod target that should not be built' do
+              mock_test_native_target = mock('CoconutLib-Unit-Tests')
+              test_dependent_native_target = mock('TestDependentNativeTarget')
+              test_dependent_target = mock('dependent-test-target', :should_build? => true, :native_target => test_dependent_native_target)
+              test_dependent_target.expects(:should_build?).returns(true)
+
+              @pod_target.stubs(:test_native_targets).returns([mock_test_native_target])
+              @pod_target.stubs(:test_dependent_targets).returns([test_dependent_target])
+              @pod_target.stubs(:should_build? => false)
+
+              mock_test_native_target.expects(:add_dependency).with(test_dependent_native_target)
+
+              @generator.send(:set_target_dependencies)
+            end
+
+            it 'sets resource bundles for not build pods as target dependencies of the test target' do
+              mock_test_native_target = mock('CoconutLib-Unit-Tests')
+
+              @pod_target.stubs(:test_native_targets).returns([mock_test_native_target])
+              @pod_target.stubs(:test_dependent_targets).returns([])
+              @pod_target.stubs(:should_build? => false)
+              @pod_target.stubs(:resource_bundle_targets).returns(['dummy'])
+
+              @mock_target.expects(:add_dependency).with('dummy')
+              mock_test_native_target.expects(:add_dependency).with('dummy')
 
               @generator.send(:set_target_dependencies)
             end


### PR DESCRIPTION
predates https://github.com/CocoaPods/CocoaPods/pull/6828

If a pre-built binary pod provides test specs then its dependencies were not being added.

The same goes for resource bundles which are now handled as well.

This is required to complete shipping tests specs for 1.3.0.