### PR TITLE
[embed_frameworks_script] Added condition to install framework only when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#6814](https://github.com/CocoaPods/CocoaPods/pull/6814)
 
+* Added condition to install framework only when necessary
+	[Aizat Omar](https://github.com/aizatomar)
+  [#6870](https://github.com/CocoaPods/CocoaPods/pull/6870)
+
 ##### Bug Fixes
 
 * Ensure resource bundle and test dependencies are set for test native targets  

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -45,6 +45,15 @@ module Pod
 
           install_framework()
           {
+            if [ -e "$1" ]; then
+              version=$(defaults read "${PODS_ROOT}/Target Support Files/$(basename -s .framework "$1")/Info.plist" CFBundleShortVersionString)
+              current_version=$(defaults read "$1/Info.plist" CFBundleShortVersionString)
+              
+              if [ ${version} == ${current_version} ] ; then
+                return 0
+              fi
+            fi
+            
             if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
               local source="${BUILT_PRODUCTS_DIR}/$1"
             elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then


### PR DESCRIPTION
Previously:
- Cocoapods will try to install all libraries again whenever the workspace is being build

Now:
- This change will check if frameworks need to be install again by first checking if the framework already exist. 2ndly, checking if the framework built has a different version than the source codes. This way, build time can be cut by avoiding unnecessary build.