### PR TITLE
Remove duplicate framework names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [David Airapetyan](https://github.com/davidair)
   [#4887](https://github.com/CocoaPods/CocoaPods/issues/4887)
 
+* Select unique module_name(s) across host target's and embedded targets' pod targets  
+  [Anand Biligiri](https://github.com/abiligiri)
+  [#6711](https://github.com/CocoaPods/CocoaPods/issues/6711)
+
 ## 1.3.0.beta.2 (2017-06-22)
 
 ##### Enhancements

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -47,7 +47,7 @@ module Pod
               file_accessors = pod_targets.flat_map(&:file_accessors)
 
               frameworks = file_accessors.flat_map(&:vendored_frameworks).uniq.map(&:basename)
-              frameworks += pod_targets.select { |pt| pt.should_build? && pt.requires_frameworks? }.map(&:product_module_name)
+              frameworks += pod_targets.select { |pt| pt.should_build? && pt.requires_frameworks? }.map(&:product_module_name).uniq
               verify_no_duplicate_names(frameworks, aggregate_target.label, 'frameworks')
 
               libraries = file_accessors.flat_map(&:vendored_libraries).uniq.map(&:basename)


### PR DESCRIPTION
closes #6711

A Pod target could require multiple subspecs, but the product_module_name can
be specified only at the root spec.