### PR TITLE
[PodspecSource] Enable webmock in network test

### DIFF
--- a/spec/unit/external_sources/podspec_source_spec.rb
+++ b/spec/unit/external_sources/podspec_source_spec.rb
@@ -57,6 +57,7 @@ module Pod
     describe 'http source' do
       it 'raises an Informative error if the specified url fails to load' do
         @subject.stubs(:params).returns(:podspec => 'https://github.com/username/TSMessages/TSMessages.podspec')
+        WebMock.enable!
         WebMock::API.stub_request(:get, 'https://github.com/username/TSMessages/TSMessages.podspec').
           to_return(:status => 404)
 


### PR DESCRIPTION
This test was passing when online due to the actual request being a 404, but
it was not being stubbed by webmock because we neer enabled it