### PR TITLE
Ensure source urls are set when spec has subspecs with dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Ensure source urls are set when spec has subspecs with dependencies  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6888](https://github.com/CocoaPods/CocoaPods/pull/6888)
 
 ## 1.3.0.beta.3 (2017-07-19)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -29,7 +29,7 @@ module Pod
     #
     def initialize(spec_or_path, source_urls)
       @linter = Specification::Linter.new(spec_or_path)
-      @source_urls = if @linter.spec && @linter.spec.dependencies.empty?
+      @source_urls = if @linter.spec && @linter.spec.dependencies.empty? && @linter.spec.recursive_subspecs.all? { |s| s.dependencies.empty? }
                        []
                      else
                        source_urls.map { |url| config.sources_manager.source_with_name_or_url(url) }.map(&:url)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -381,7 +381,7 @@ module Pod
         podfile.sources.should == %w()
       end
 
-      it 'repects the source_urls parameter when there are dependencies' do
+      it 'respects the source_urls parameter when there are dependencies' do
         podspec = stub_podspec(/.*name.*/, '"name": "SBJson",').gsub(/.*version.*/, '"version": "3.2",')
         file = write_podspec(podspec, 'SBJson.podspec.json')
         spec = Specification.from_file(file)
@@ -391,6 +391,28 @@ module Pod
 
         podspec = stub_podspec(/.*name.*/, '"name": "ZKit",')
         podspec.gsub!(/.*requires_arc.*/, '"dependencies": { "SBJson": [ "~> 3.2" ] }, "requires_arc": false')
+        file = write_podspec(podspec, 'ZKit.podspec.json')
+
+        spec = Specification.from_file(file)
+
+        sources = %w(master https://github.com/CocoaPods/Specs.git)
+        Command::Repo::Add.any_instance.stubs(:run)
+        validator = Validator.new(spec, sources)
+        validator.stubs(:validate_url)
+        podfile = validator.send(:podfile_from_spec, :ios, '5.0')
+        podfile.sources.should == %w(https://github.com/CocoaPods/Specs.git)
+      end
+
+      it 'respects the source_urls parameter when there are dependencies within subspecs' do
+        podspec = stub_podspec(/.*name.*/, '"name": "SBJson",').gsub(/.*version.*/, '"version": "3.2",')
+        file = write_podspec(podspec, 'SBJson.podspec.json')
+        spec = Specification.from_file(file)
+        set = mock
+        set.stubs(:all_specifications).returns([spec])
+        Source::Aggregate.any_instance.stubs(:search).with(Dependency.new('SBJson', '~> 3.2')).returns(set)
+
+        podspec = stub_podspec(/.*name.*/, '"name": "ZKit",')
+        podspec.gsub!(/.*requires_arc.*/, '"subspecs": [ { "name":"SubSpecA", "dependencies": { "SBJson": [ "~> 3.2" ] } } ], "requires_arc": false')
         file = write_podspec(podspec, 'ZKit.podspec.json')
 
         spec = Specification.from_file(file)


### PR DESCRIPTION
Regressed from https://github.com/CocoaPods/CocoaPods/pull/6576/files#diff-c40545c38369a7fb9be6a8849d065059R32