### PR TITLE
Update Molinillo to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Show full requirement trees when a version conflict is encountered during
+  dependency resolution.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
 

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development do
   cp_gem 'cocoapods-stats',       'cocoapods-stats'
   cp_gem 'cocoapods-trunk',       'cocoapods-trunk'
   cp_gem 'cocoapods-try',         'cocoapods-try'
-  cp_gem 'molinillo',             'Molinillo'
+  cp_gem 'molinillo',             'Molinillo', path: true
   cp_gem 'nanaimo',               'Nanaimo'
   cp_gem 'xcodeproj',             'Xcodeproj'
 

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development do
   cp_gem 'cocoapods-stats',       'cocoapods-stats'
   cp_gem 'cocoapods-trunk',       'cocoapods-trunk'
   cp_gem 'cocoapods-try',         'cocoapods-try'
-  cp_gem 'molinillo',             'Molinillo', path: true
+  cp_gem 'molinillo',             'Molinillo'
   cp_gem 'nanaimo',               'Nanaimo'
   cp_gem 'xcodeproj',             'Xcodeproj'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,13 +16,6 @@ GIT
       nap (~> 1.0)
 
 GIT
-  remote: https://github.com/CocoaPods/Molinillo.git
-  revision: c2f655cd697812574a8537cc7c9cf68a0c0357b3
-  branch: master
-  specs:
-    molinillo (0.5.7)
-
-GIT
   remote: https://github.com/CocoaPods/Nanaimo.git
   revision: c9b1cf5734523cf523497fd6de11f7240fd18944
   branch: master
@@ -98,6 +91,11 @@ GIT
   branch: seg-1.7.7-ruby-2.2
   specs:
     json (1.7.7)
+
+PATH
+  remote: ../Molinillo
+  specs:
+    molinillo (0.5.7)
 
 PATH
   remote: .
@@ -293,4 +291,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,13 @@ GIT
       nap (~> 1.0)
 
 GIT
+  remote: https://github.com/CocoaPods/Molinillo.git
+  revision: 04dd4c8789823654bde00569d28b189a79926c9f
+  branch: master
+  specs:
+    molinillo (0.5.7)
+
+GIT
   remote: https://github.com/CocoaPods/Nanaimo.git
   revision: c9b1cf5734523cf523497fd6de11f7240fd18944
   branch: master
@@ -91,11 +98,6 @@ GIT
   branch: seg-1.7.7-ruby-2.2
   specs:
     json (1.7.7)
-
-PATH
-  remote: ../Molinillo
-  specs:
-    molinillo (0.5.7)
 
 PATH
   remote: .
@@ -291,4 +293,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,10 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo.git
-  revision: 04dd4c8789823654bde00569d28b189a79926c9f
+  revision: b17c754d2b93680e627b5a555ffe93c4ce4fc67c
   branch: master
   specs:
-    molinillo (0.5.7)
+    molinillo (0.6.0)
 
 GIT
   remote: https://github.com/CocoaPods/Nanaimo.git
@@ -117,7 +117,7 @@ PATH
       escape (~> 0.0.4)
       fourflusher (~> 2.0.1)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.5.7)
+      molinillo (~> 0.6.0)
       nap (~> 1.0)
       ruby-macho (~> 1.1)
       xcodeproj (>= 1.5.1, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo.git
-  revision: b17c754d2b93680e627b5a555ffe93c4ce4fc67c
+  revision: 4ff9652b3b58566ea70dd7919de799e2b3b7beb0
   branch: master
   specs:
     molinillo (0.6.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cocoapods-stats',       '>= 1.0.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.2.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-try',         '>= 1.1.0', '< 2.0'
-  s.add_runtime_dependency 'molinillo',             '~> 0.5.7'
+  s.add_runtime_dependency 'molinillo',             '~> 0.6.0'
   s.add_runtime_dependency 'xcodeproj',             '>= 1.5.1', '< 2.0'
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby

--- a/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
@@ -208,13 +208,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-AFNetworking Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CC1632E381344B54BA63986B /* [CP] Copy Pods Resources */ = {

--- a/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -320,13 +320,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-AFNetworking iOS Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -349,9 +349,13 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
-        e.message.should.match(/Unable to satisfy the following requirements/)
-        e.message.should.match(/`JSONKit \(= 1.4\)` required by `Podfile`/)
-        e.message.should.match(/`JSONKit \(= 1.5pre\)` required by `Podfile`/)
+                e.message.should == <<-EOS.strip
+\e[31m[!] CocoaPods could not find compatible versions for pod "JSONKit":
+  In Podfile:
+    JSONKit (= 1.4)
+
+    JSONKit (= 1.5pre)\e[0m
+        EOS
       end
 
       it 'raises if it finds two conflicting dependencies' do
@@ -362,9 +366,16 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
-        e.message.should.match(/Unable to satisfy the following requirements/)
-        e.message.should.match(/`AFNetworking \(~> 1.3.0\)` required by `RestKit\/Network \(.*\)`/)
-        e.message.should.match(/`AFNetworking \(> 2\)` required by `Podfile`/)
+        e.message.should == <<-EOS.strip
+\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+  In Podfile:
+    AFNetworking (> 2)
+
+    RestKit (= 0.23.3) was resolved to 0.23.3, which depends on
+      RestKit/Core (= 0.23.3) was resolved to 0.23.3, which depends on
+        RestKit/Network (= 0.23.3) was resolved to 0.23.3, which depends on
+          AFNetworking (~> 1.3.0)\e[0m
+        EOS
       end
 
       it 'raises if no such version of a dependency exists' do
@@ -374,14 +385,20 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise NoSpecFoundError
-        e.message.should.match(/Unable to satisfy the following requirements/)
-        e.message.should.match(/`AFNetworking \(= 999\.999\.999\)` required by `Podfile`/)
-        e.message.should.match(/None of your spec sources contain a spec satisfying the dependency: `AFNetworking \(= 999\.999\.999\)`./)
-        e.message.should.match(/You have either:/)
-        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`./)
-        e.message.should.match(/ * mistyped the name or version./)
-        e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
-        e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
+        e.message.should == <<-EOS.strip
+\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+  In Podfile:
+    AFNetworking (= 999.999.999)
+
+None of your spec sources contain a spec satisfying the dependency: `AFNetworking \(= 999\.999\.999\)`.
+
+You have either:
+ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
+ * mistyped the name or version.
+ * not added the source repo that hosts the Podspec to your Podfile.
+
+Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.\e[0m
+        EOS
         e.exit_status.should.equal(31)
       end
 
@@ -393,14 +410,19 @@ module Pod
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         resolver.specs_updated = true
         e = lambda { resolver.resolve }.should.raise NoSpecFoundError
-        e.message.should.match(/Unable to satisfy the following requirements/)
-        e.message.should.match(/`AFNetworking \(= 999\.999\.999\)` required by `Podfile`/)
-        e.message.should.match(/None of your spec sources contain a spec satisfying the dependency: `AFNetworking \(= 999\.999\.999\)`./)
-        e.message.should.match(/You have either:/)
-        e.message.should.not.match(/ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`./)
-        e.message.should.match(/ * mistyped the name or version./)
-        e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
-        e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
+        e.message.should == <<-EOS.strip
+\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+  In Podfile:
+    AFNetworking (= 999.999.999)
+
+None of your spec sources contain a spec satisfying the dependency: `AFNetworking (= 999.999.999)`.
+
+You have either:
+ * mistyped the name or version.
+ * not added the source repo that hosts the Podspec to your Podfile.
+
+Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.\e[0m
+        EOS
         e.exit_status.should.equal(31)
       end
 
@@ -413,16 +435,23 @@ module Pod
 
         resolver = Resolver.new(config.sandbox, podfile, locked_deps, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise NoSpecFoundError
-        e.message.should.match(/Unable to satisfy the following requirements/)
-        e.message.should.match(/`AFNetworking \(= 3.0.1\)` required by `Podfile`/)
-        e.message.should.match(/`AFNetworking \(= 1.4\)` required by `Podfile.lock`/)
-        e.message.should.match(/None of your spec sources contain a spec satisfying the dependencies:/)
-        e.message.should.match(/`AFNetworking \(= 3.0.1\), AFNetworking \(= 1.4\)`/)
-        e.message.should.match(/You have either:/)
-        e.message.should.match(/ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`./)
-        e.message.should.match(/ * mistyped the name or version./)
-        e.message.should.match(/ * not added the source repo that hosts the Podspec to your Podfile./)
-        e.message.should.match(/Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default./)
+        e.message.should == <<-EOS.strip
+\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+  In snapshot (Podfile.lock):
+    AFNetworking (= 1.4)
+
+  In Podfile:
+    AFNetworking (= 3.0.1)
+
+None of your spec sources contain a spec satisfying the dependencies: `AFNetworking (= 3.0.1), AFNetworking (= 1.4)`.
+
+You have either:
+ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
+ * mistyped the name or version.
+ * not added the source repo that hosts the Podspec to your Podfile.
+
+Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.\e[0m
+        EOS
         e.exit_status.should.equal(31)
       end
 

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -349,7 +349,7 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
-                e.message.should == <<-EOS.strip
+        e.message.should == <<-EOS.strip
 \e[31m[!] CocoaPods could not find compatible versions for pod "JSONKit":
   In Podfile:
     JSONKit (= 1.4)

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -349,12 +349,12 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
-        e.message.should == <<-EOS.strip
-\e[31m[!] CocoaPods could not find compatible versions for pod "JSONKit":
+        e.message.should.include <<-EOS.strip
+[!] CocoaPods could not find compatible versions for pod "JSONKit":
   In Podfile:
     JSONKit (= 1.4)
 
-    JSONKit (= 1.5pre)\e[0m
+    JSONKit (= 1.5pre)
         EOS
       end
 
@@ -366,15 +366,15 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise Informative
-        e.message.should == <<-EOS.strip
-\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+        e.message.should.include <<-EOS.strip
+[!] CocoaPods could not find compatible versions for pod "AFNetworking":
   In Podfile:
     AFNetworking (> 2)
 
     RestKit (= 0.23.3) was resolved to 0.23.3, which depends on
       RestKit/Core (= 0.23.3) was resolved to 0.23.3, which depends on
         RestKit/Network (= 0.23.3) was resolved to 0.23.3, which depends on
-          AFNetworking (~> 1.3.0)\e[0m
+          AFNetworking (~> 1.3.0)
         EOS
       end
 
@@ -385,8 +385,8 @@ module Pod
         end
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise NoSpecFoundError
-        e.message.should == <<-EOS.strip
-\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+        e.message.should.include <<-EOS.strip
+[!] CocoaPods could not find compatible versions for pod "AFNetworking":
   In Podfile:
     AFNetworking (= 999.999.999)
 
@@ -397,7 +397,7 @@ You have either:
  * mistyped the name or version.
  * not added the source repo that hosts the Podspec to your Podfile.
 
-Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.\e[0m
+Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
         EOS
         e.exit_status.should.equal(31)
       end
@@ -410,8 +410,8 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         resolver = Resolver.new(config.sandbox, podfile, empty_graph, config.sources_manager.all)
         resolver.specs_updated = true
         e = lambda { resolver.resolve }.should.raise NoSpecFoundError
-        e.message.should == <<-EOS.strip
-\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+        e.message.should.include <<-EOS.strip
+[!] CocoaPods could not find compatible versions for pod "AFNetworking":
   In Podfile:
     AFNetworking (= 999.999.999)
 
@@ -421,7 +421,7 @@ You have either:
  * mistyped the name or version.
  * not added the source repo that hosts the Podspec to your Podfile.
 
-Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.\e[0m
+Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
         EOS
         e.exit_status.should.equal(31)
       end
@@ -435,8 +435,8 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
 
         resolver = Resolver.new(config.sandbox, podfile, locked_deps, config.sources_manager.all)
         e = lambda { resolver.resolve }.should.raise NoSpecFoundError
-        e.message.should == <<-EOS.strip
-\e[31m[!] CocoaPods could not find compatible versions for pod "AFNetworking":
+        e.message.should.include <<-EOS.strip
+[!] CocoaPods could not find compatible versions for pod "AFNetworking":
   In snapshot (Podfile.lock):
     AFNetworking (= 1.4)
 
@@ -450,7 +450,7 @@ You have either:
  * mistyped the name or version.
  * not added the source repo that hosts the Podspec to your Podfile.
 
-Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.\e[0m
+Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
         EOS
         e.exit_status.should.equal(31)
       end


### PR DESCRIPTION
This updates the resolver to handle some changes in Molinillo in 0.6, and also transitions CocoaPods to printing out tree-style conflict messages.