### PR TITLE
Ensure transitive dependencies are linked to test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Ensure transitive dependencies are linked to test targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6917](https://github.com/CocoaPods/CocoaPods/pull/6917)
+
 * Add `--skip-tests` support `push` to push command  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6893](https://github.com/CocoaPods/CocoaPods/pull/6893)

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -72,10 +72,10 @@ module Pod
           recursive_dependent_targets = target.recursive_dependent_targets
           @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, recursive_dependent_targets, @test_xcconfig)
           if @test_xcconfig
-            test_dependent_targets = [target, *target.test_dependent_targets]
+            test_dependent_targets = [target, *target.recursive_test_dependent_targets].uniq
             @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, test_dependent_targets - recursive_dependent_targets, @test_xcconfig)
-            XCConfigHelper.generate_vendored_build_settings(nil, test_dependent_targets, @xcconfig)
-            XCConfigHelper.generate_other_ld_flags(nil, test_dependent_targets, @xcconfig)
+            XCConfigHelper.generate_vendored_build_settings(nil, target.all_test_dependent_targets, @xcconfig)
+            XCConfigHelper.generate_other_ld_flags(nil, target.all_test_dependent_targets, @xcconfig)
             XCConfigHelper.generate_ld_runpath_search_paths(target, false, true, @xcconfig)
           end
           @xcconfig

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -498,6 +498,7 @@ module Pod
           pod_targets.each do |target|
             dependencies = transitive_dependencies_for_specs(target.specs.reject(&:test_specification?), target.platform, all_specs).group_by(&:root)
             test_dependencies = transitive_dependencies_for_specs(target.specs.select(&:test_specification?), target.platform, all_specs).group_by(&:root)
+            test_dependencies.delete_if { |k| dependencies.key? k }
             target.dependent_targets = filter_dependencies(dependencies, pod_targets_by_name, target)
             target.test_dependent_targets = filter_dependencies(test_dependencies, pod_targets_by_name, target)
           end
@@ -512,6 +513,7 @@ module Pod
             pod_targets.each do |target|
               dependencies = transitive_dependencies_for_specs(target.specs, target.platform, specs).group_by(&:root)
               test_dependencies = transitive_dependencies_for_specs(target.specs.select(&:test_specification?), target.platform, all_specs).group_by(&:root)
+              test_dependencies.delete_if { |k| dependencies.key? k }
               target.dependent_targets = pod_targets.reject { |t| dependencies[t.root_spec].nil? }
               target.test_dependent_targets = pod_targets.reject { |t| test_dependencies[t.root_spec].nil? }
             end

--- a/lib/cocoapods/installer/pods_project_integrator/pod_target_integrator.rb
+++ b/lib/cocoapods/installer/pods_project_integrator/pod_target_integrator.rb
@@ -47,7 +47,7 @@ module Pod
       def add_copy_resources_script_phase(native_target)
         test_type = target.test_type_for_product_type(native_target.symbol_type)
         script_path = "${PODS_ROOT}/#{target.copy_resources_script_path_for_test_type(test_type).relative_path_from(target.sandbox.root)}"
-        resource_paths = [target, *target.test_dependent_targets].flat_map(&:resource_paths)
+        resource_paths = target.all_test_dependent_targets.flat_map(&:resource_paths)
         input_paths = []
         output_paths = []
         unless resource_paths.empty?
@@ -64,7 +64,7 @@ module Pod
       def add_embed_frameworks_script_phase(native_target)
         test_type = target.test_type_for_product_type(native_target.symbol_type)
         script_path = "${PODS_ROOT}/#{target.embed_frameworks_script_path_for_test_type(test_type).relative_path_from(target.sandbox.root)}"
-        framework_paths = [target, *target.test_dependent_targets].flat_map(&:framework_paths)
+        framework_paths = target.all_test_dependent_targets.flat_map(&:framework_paths)
         input_paths = []
         output_paths = []
         unless framework_paths.empty?

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -266,7 +266,7 @@ module Pod
         private
 
         def add_pod_target_test_dependencies(pod_target, frameworks_group)
-          test_dependent_targets = [pod_target, *pod_target.test_dependent_targets]
+          test_dependent_targets = pod_target.all_test_dependent_targets
           pod_target.test_native_targets.each do |test_native_target|
             test_dependent_targets.reject(&:should_build?).each do |test_dependent_target|
               add_resource_bundles_to_native_target(test_dependent_target, test_native_target)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -333,7 +333,7 @@ module Pod
           #
           def create_test_target_copy_resources_script(test_type)
             path = target.copy_resources_script_path_for_test_type(test_type)
-            pod_targets = [target, *target.test_dependent_targets]
+            pod_targets = target.all_test_dependent_targets
             resource_paths_by_config = { 'Debug' => pod_targets.flat_map(&:resource_paths) }
             generator = Generator::CopyResourcesScript.new(resource_paths_by_config, target.platform)
             update_changed_file(generator, path)
@@ -349,7 +349,7 @@ module Pod
           #
           def create_test_target_embed_frameworks_script(test_type)
             path = target.embed_frameworks_script_path_for_test_type(test_type)
-            pod_targets = [target, *target.test_dependent_targets]
+            pod_targets = target.all_test_dependent_targets
             framework_paths_by_config = { 'Debug' => pod_targets.flat_map(&:framework_paths) }
             generator = Generator::EmbedFrameworksScript.new(framework_paths_by_config)
             update_changed_file(generator, path)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -355,15 +355,41 @@ module Pod
     #         dependency upon.
     #
     def recursive_dependent_targets
-      targets = dependent_targets.clone
+      @recursive_dependent_targets ||= begin
+        targets = dependent_targets.clone
 
-      targets.each do |target|
-        target.dependent_targets.each do |t|
-          targets.push(t) unless t == self || targets.include?(t)
+        targets.each do |target|
+          target.dependent_targets.each do |t|
+            targets.push(t) unless t == self || targets.include?(t)
+          end
         end
-      end
 
-      targets
+        targets
+      end
+    end
+
+    # @return [Array<PodTarget>] the recursive targets that this target has a
+    #         test dependency upon.
+    #
+    def recursive_test_dependent_targets
+      @recursive_test_dependent_targets ||= begin
+        targets = test_dependent_targets.clone
+
+        targets.each do |target|
+          target.test_dependent_targets.each do |t|
+            targets.push(t) unless t == self || targets.include?(t)
+          end
+        end
+
+        targets
+      end
+    end
+
+    # @return [Array<PodTarget>] the canonical list of test dependent targets this target has a dependency upon.
+    #         This includes the parent target as well as its transitive dependencies.
+    #
+    def all_test_dependent_targets
+      [self, *recursive_dependent_targets, *recursive_test_dependent_targets].uniq
     end
 
     # Checks if the target should be included in the build configuration with

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -165,6 +165,13 @@ module Pod
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-ObjC -framework "CoconutLib"'
           end
 
+          it 'includes other ld flags for transitive dependent targets' do
+            @coconut_pod_target.dependent_targets = [@monkey_pod_target]
+            generator = PodXCConfig.new(@coconut_pod_target, true)
+            xcconfig = generator.generate
+            xcconfig.to_hash['OTHER_LDFLAGS'].should == '-ObjC -l"CoconutLib" -l"monkey" -framework "dynamic-monkey"'
+          end
+
           it 'includes other ld flags for test dependent targets' do
             @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -260,16 +260,18 @@ module Pod
               @generator.stubs(:aggregate_targets).returns([@target])
             end
 
-            it 'adds test dependent targets to test native targets' do
+            it 'adds all test dependent targets to test native targets' do
               mock_native_target = mock('CoconutLib')
               mock_test_native_target = mock('CoconutLib-Unit-Tests')
 
               dependent_native_target = mock('DependentNativeTarget')
               test_dependent_native_target = mock('TestDependentNativeTarget')
 
-              dependent_target = mock('dependent-target', :should_build? => true, :native_target => dependent_native_target)
-              test_dependent_target = mock('dependent-test-target', :should_build? => true, :native_target => test_dependent_native_target)
-              test_dependent_target.expects(:should_build?).returns(true)
+              dependent_target = mock('dependent-target', :dependent_targets => [])
+              dependent_target.stubs(:should_build?).returns(true)
+              dependent_target.stubs(:native_target).returns(dependent_native_target)
+              test_dependent_target = mock('dependent-test-target', :native_target => test_dependent_native_target, :test_dependent_targets => [])
+              test_dependent_target.stubs(:should_build?).returns(true)
 
               @pod_target.stubs(:native_target).returns(mock_native_target)
               @pod_target.stubs(:test_native_targets).returns([mock_test_native_target])
@@ -282,7 +284,7 @@ module Pod
               mock_native_target.expects(:add_dependency).with(test_dependent_native_target).never
               mock_native_target.expects(:add_dependency).with(mock_native_target).never
 
-              mock_test_native_target.expects(:add_dependency).with(dependent_native_target).never
+              mock_test_native_target.expects(:add_dependency).with(dependent_native_target)
               mock_test_native_target.expects(:add_dependency).with(test_dependent_native_target)
               mock_test_native_target.expects(:add_dependency).with(mock_native_target)
 
@@ -296,7 +298,7 @@ module Pod
               test_dependent_target.expects(:should_build?).returns(true)
 
               @pod_target.stubs(:test_native_targets).returns([mock_test_native_target])
-              @pod_target.stubs(:test_dependent_targets).returns([test_dependent_target])
+              @pod_target.stubs(:all_test_dependent_targets).returns([test_dependent_target])
               @pod_target.stubs(:should_build? => false)
 
               mock_test_native_target.expects(:add_dependency).with(test_dependent_native_target)


### PR DESCRIPTION
if PodA depends on PodB which brings in a vendored `.a` or `.framework` then the test target fails to link this vendored library or framework.

Further more all input and output paths for the scripts did not take account transitive dependencies.

This PR fixes both of those issues.