### PR TITLE
[Gemspec] Bump Molinillo to `~> 0.6.1`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,10 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo.git
-  revision: 4ff9652b3b58566ea70dd7919de799e2b3b7beb0
+  revision: 53e4c90d21a318a13332fa94b12fa00c900db1ee
   branch: master
   specs:
-    molinillo (0.6.0)
+    molinillo (0.6.1)
 
 GIT
   remote: https://github.com/CocoaPods/Nanaimo.git
@@ -117,7 +117,7 @@ PATH
       escape (~> 0.0.4)
       fourflusher (~> 2.0.1)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.6.0)
+      molinillo (~> 0.6.1)
       nap (~> 1.0)
       ruby-macho (~> 1.1)
       xcodeproj (>= 1.5.1, < 2.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cocoapods-stats',       '>= 1.0.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.2.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-try',         '>= 1.1.0', '< 2.0'
-  s.add_runtime_dependency 'molinillo',             '~> 0.6.0'
+  s.add_runtime_dependency 'molinillo',             '~> 0.6.1'
   s.add_runtime_dependency 'xcodeproj',             '>= 1.5.1', '< 2.0'
 
   ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby


### PR DESCRIPTION
trivial bump, 0.6.1 has a slightly improved algorithm that fixes a 0.6.0 regression