### PR TITLE
Remove bogus PROVISIONING_PROFILE_SPECIFIER value from Pods project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7460](https://github.com/CocoaPods/CocoaPods/issues/7460)
 
+* Remove bogus `PROVISIONING_PROFILE_SPECIFIER` value from Pods project.  
+  [Ruenzuo](https://github.com/Ruenzuo)
+  [#6964](https://github.com/CocoaPods/CocoaPods/issues/6964)
+
 ## 1.4.0 (2018-01-18)
 
 ##### Enhancements

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -153,7 +153,6 @@ module Pod
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
               build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
-              build_configuration.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = 'NO_SIGNING/' # a bogus provisioning profile ID assumed to be invalid
             end
           end
         end

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -153,6 +153,7 @@ module Pod
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
               build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+              build_configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
             end
           end
         end


### PR DESCRIPTION
It's a bit tough to prepare an example project for this, as you need a project with valid code signing settings to reproduce this, but I'm happy to send one if you need it.

CocoaPods 1.3.1 sets the value of `PROVISIONING_PROFILE_SPECIFIER` to `NO_SIGNING/` which breaks the archiving action on Xcode 9 (but also believe it happens in the latest versions of Xcode 8, as some users reported below) using CODE_SIGN_IDENTITY environment variable.

This is how my build settings look like, automatic code signing is disabled.

```
//Config.release.xcconfig
#include "Pods/Target Support Files/Pods-Piggy/Pods-Piggy.release.xcconfig"

DEVELOPMENT_TEAM = TEAM_ID
PRODUCT_BUNDLE_IDENTIFIER = com.company.app
PROVISIONING_PROFILE_SPECIFIER = My Provisioning profile
```

Some logs running the following command:

```bash
xcodebuild -workspace Piggy.xcworkspace/ -scheme Piggy -configuration Release -destination 'generic/platform=iOS' -archivePath './archive' archive CODE_SIGN_IDENTITY="iPhone Distribution: COMPANY_NAME (TEAM_ID)"
```

```
User defaults from command line:
    IDEArchivePathOverride = /Users/crisosto/Downloads/Piggy/archive

Build settings from command line:
    CODE_SIGN_IDENTITY = iPhone Distribution: COMPANY_NAME (TEAM_ID)

=== BUILD TARGET AFNetworking OF PROJECT Pods WITH CONFIGURATION Release ===

Check dependencies
Code Signing Error: AFNetworking does not support provisioning profiles. AFNetworking does not support provisioning profiles, but provisioning profile NO_SIGNING/ has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.

** ARCHIVE FAILED **
```

But if you use build setting value in your project instead of the environment variable, like:

```
xcodebuild -workspace Piggy.xcworkspace/ -scheme Piggy -configuration Release -destination 'generic/platform=iOS' -archivePath './archive' archive
```
```
//Config.release.xcconfig
#include "Pods/Target Support Files/Pods-Piggy/Pods-Piggy.release.xcconfig"

...
CODE_SIGN_IDENTITY = iPhone Distribution: COMPANY_NAME (TEAM_ID)
...
```

Everything works as expected.

Removing the bogus value from the Pods project also solves the issue, like some users already noticed. ([#1](https://github.com/CocoaPods/CocoaPods/pull/5528#issuecomment-316735830), [#2](https://github.com/realm-demos/realm-tasks/commit/d0da07a87b1324af58adae7cd2324c75fd0f0a6b))

I guess you could ignore this PR if there's a valid reason to set that bogus value in the Pods project, as there are plenty of workarounds for this and so far and I've been only able to reproduce it if I try to override `CODE_SIGN_IDENTITY` with environment variables.

Closes #7038 