### PR TITLE
Swift Static Library support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [iv-mexx](https://github.com/iv-mexx)  
   [#7372](https://github.com/CocoaPods/CocoaPods/issues/7372)  
 
+* Add support for integrating swift pods as static libraries.  
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [Samuel Giddins](https://github.com/segiddins)
+  [#6899](https://github.com/CocoaPods/CocoaPods/issues/6899)
+
 ##### Bug Fixes
 
 * Clear input/output paths if they exceed an arbitrary limit  

--- a/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
@@ -152,8 +152,6 @@
 				F8129BF71591061B009BFE23 /* Sources */,
 				F8129BF81591061B009BFE23 /* Frameworks */,
 				F8129BF91591061B009BFE23 /* Resources */,
-				CC1632E381344B54BA63986B /* [CP] Copy Pods Resources */,
-				F0DC30B6798CF042746A5614 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -218,36 +216,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CC1632E381344B54BA63986B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F0DC30B6798CF042746A5614 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking Example/Pods-AFNetworking Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -227,8 +227,6 @@
 				F8E4695C1395739C00DB05C8 /* Sources */,
 				F8E4695D1395739C00DB05C8 /* Frameworks */,
 				F8E4695E1395739C00DB05C8 /* Resources */,
-				226FE837057C4F98AD9FFB32 /* [CP] Copy Pods Resources */,
-				CB0CF751F97DB411456460D5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -284,36 +282,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		226FE837057C4F98AD9FFB32 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CB0CF751F97DB411456460D5 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AFNetworking iOS Example/Pods-AFNetworking iOS Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		E4419DF1E8B742E49777FFE0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/examples/Alamofire Example/iOS Example.xcodeproj/project.pbxproj
+++ b/examples/Alamofire Example/iOS Example.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 				F8111E0219A951050040E7D1 /* Frameworks */,
 				F8111E0319A951050040E7D1 /* Resources */,
 				232F8168EB8673C9D2405BA7 /* [CP] Embed Pods Frameworks */,
-				B81850C1CB84CCCCFC8FFC52 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -200,21 +199,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B81850C1CB84CCCCFC8FFC52 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOS Example/Pods-iOS Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
@@ -91,7 +91,6 @@
 				295BB55B1CEA95DE00E79F82 /* Frameworks */,
 				295BB55C1CEA95DE00E79F82 /* Resources */,
 				6E2B4891468DB661A63F8065 /* [CP] Embed Pods Frameworks */,
-				0B71E1EA08FB405324201E97 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -147,21 +146,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0B71E1EA08FB405324201E97 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-App/Pods-App-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		62E9CD52D31153978437D4C2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/examples/Modules Example/CustomModuleMapPod/CustomModuleMapPod.podspec
+++ b/examples/Modules Example/CustomModuleMapPod/CustomModuleMapPod.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name         = "CustomModuleMapPod"
+  s.version      = "0.0.1"
+  s.summary      = "A long description of CustomModuleMapPod."
+  s.source       = { :git => "http://foo/CustomModuleMapPod.git", :tag => "#{s.version}" }
+  s.authors = ['me']
+  s.homepage = 'http://example.com'
+  s.license = 'proprietary'
+
+  s.source_files  = "src/**/*.{h,m,swift}"
+  s.private_header_files = "src/Private/*.h"
+
+  s.module_map = "src/CustomModuleMapPod.modulemap"
+
+  s.ios.deployment_target = '9.0'
+  s.macos.deployment_target = '10.10'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+end

--- a/examples/Modules Example/CustomModuleMapPod/CustomModuleMapPod.podspec
+++ b/examples/Modules Example/CustomModuleMapPod/CustomModuleMapPod.podspec
@@ -14,8 +14,4 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.0'
   s.macos.deployment_target = '10.10'
-
-  s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES',
-  }
 end

--- a/examples/Modules Example/CustomModuleMapPod/src/CMM.h
+++ b/examples/Modules Example/CustomModuleMapPod/src/CMM.h
@@ -1,0 +1,6 @@
+#import <CustomModuleMapPod/CMMFunctions.h>
+@import Foundation;
+
+@interface CMM : NSObject
++ (void)log;
+@end

--- a/examples/Modules Example/CustomModuleMapPod/src/CMM.m
+++ b/examples/Modules Example/CustomModuleMapPod/src/CMM.m
@@ -1,0 +1,13 @@
+#import <CustomModuleMapPod/CMM.h>
+#import <CustomModuleMapPod/CMM+Private.h>
+#import <CustomModuleMapPod/CMMFunctions.h>
+
+#import <Foundation/Foundation.h>
+
+@implementation CMM
++ (void)log { NSLog(@"module maps are the wurst"); }
+@end
+
+void CMM_doThing(void) {
+    NSLog(@"CMM doing thing");
+}

--- a/examples/Modules Example/CustomModuleMapPod/src/CMMFunctions.h
+++ b/examples/Modules Example/CustomModuleMapPod/src/CMMFunctions.h
@@ -1,0 +1,1 @@
+extern void CMM_doThing(void);

--- a/examples/Modules Example/CustomModuleMapPod/src/CustomModuleMapPod.modulemap
+++ b/examples/Modules Example/CustomModuleMapPod/src/CustomModuleMapPod.modulemap
@@ -1,0 +1,10 @@
+framework module CustomModuleMapPod {
+    umbrella header "CMM.h"
+
+    explicit module Private {
+        header "CMM+Private.h"
+    }
+
+    export *
+    module * { export * }
+}

--- a/examples/Modules Example/CustomModuleMapPod/src/Private/CMM+Private.h
+++ b/examples/Modules Example/CustomModuleMapPod/src/Private/CMM+Private.h
@@ -1,0 +1,4 @@
+#import <CustomModuleMapPod/CMM.h>
+
+@interface CMM (PrivateExtension)
+@end

--- a/examples/Modules Example/Examples.xcworkspace/contents.xcworkspacedata
+++ b/examples/Modules Example/Examples.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:iOS Modules.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:macOS Modules.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/Modules Example/Examples.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/examples/Modules Example/Examples.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/examples/Modules Example/MixedPod/MixedPod.podspec
+++ b/examples/Modules Example/MixedPod/MixedPod.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "MixedPod"
+  s.version      = "0.0.1"
+  s.summary      = "A long description of objc."
+  s.source       = { :git => "http://foo/objc.git", :tag => "#{s.version}" }
+  s.authors = ['me']
+  s.homepage = 'http://example.com'
+  s.license = 'proprietary'
+
+  s.source_files  = "src/**/*.{h,m,swift}"
+  s.public_header_files = "src/**/*.h"
+
+  s.dependency 'ObjCPod'
+  s.dependency 'SwiftPod'
+
+  s.ios.deployment_target = '9.0'
+  s.macos.deployment_target = '10.10'
+end

--- a/examples/Modules Example/MixedPod/src/bce.h
+++ b/examples/Modules Example/MixedPod/src/bce.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface BCE : NSObject
++ (void)meow;
+@end

--- a/examples/Modules Example/MixedPod/src/bce.m
+++ b/examples/Modules Example/MixedPod/src/bce.m
@@ -1,0 +1,23 @@
+#import <MixedPod/bce.h>
+
+#if __has_include(<MixedPod/MixedPod-Swift.h>)
+#    import <MixedPod/MixedPod-Swift.h>
+#else
+// This really shouldn't be neccessary (ideally the first would just work)
+// Additionally, it shouldn't show as "not found" in the navigator
+#    import "MixedPod-Swift.h"
+#endif
+
+@import ObjCPod;
+@import SwiftPod;
+
+#import <Foundation/Foundation.h>
+
+@implementation BCE
++ (void)meow {
+    id a = [ABC new]; // from ObjCPod
+    [[XYZ new] doThing:@"in bce.m"]; // from SwiftPod
+    NSLog(@"meow meow");
+    (void)[[Foo alloc] initWithS:a]; // from MixedPod
+}
+@end

--- a/examples/Modules Example/MixedPod/src/foo.swift
+++ b/examples/Modules Example/MixedPod/src/foo.swift
@@ -1,0 +1,21 @@
+import SwiftPod
+import ObjCPod
+
+func testImportedThings() {
+    print(XYZStruct(name: "string"))
+    print(ABC())
+}
+
+public func superMeow() -> BCE {
+    testImportedThings()
+    BCE.meow()
+    return BCE()
+}
+
+@objc public
+class Foo: NSObject {
+    @objc public
+    init(s: AnyObject) {
+        print("Initializing with \(s)")
+    }
+}

--- a/examples/Modules Example/ObjCPod/ObjCPod.podspec
+++ b/examples/Modules Example/ObjCPod/ObjCPod.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "ObjCPod"
+  s.version      = "0.0.1"
+  s.summary      = "A long description of objc."
+  s.source       = { :git => "http://foo/objc.git", :tag => "#{s.version}" }
+  s.authors = ['me']
+  s.homepage = 'http://example.com'
+  s.license = 'proprietary'
+
+  s.source_files  = "src/**/*.{h,m,swift}"
+  s.public_header_files = "src/**/*.h"
+
+  s.ios.deployment_target = '9.0'
+  s.macos.deployment_target = '10.10'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+end

--- a/examples/Modules Example/ObjCPod/ObjCPod.podspec
+++ b/examples/Modules Example/ObjCPod/ObjCPod.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.license = 'proprietary'
 
   s.source_files  = "src/**/*.{h,m,swift}"
+  s.private_header_files = "src/Private/*.h"
   s.public_header_files = "src/**/*.h"
 
   s.ios.deployment_target = '9.0'

--- a/examples/Modules Example/ObjCPod/ObjCPod.podspec
+++ b/examples/Modules Example/ObjCPod/ObjCPod.podspec
@@ -13,8 +13,4 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.0'
   s.macos.deployment_target = '10.10'
-
-  s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES',
-  }
 end

--- a/examples/Modules Example/ObjCPod/src/Private/abc_private.h
+++ b/examples/Modules Example/ObjCPod/src/Private/abc_private.h
@@ -1,0 +1,3 @@
+@interface ABC (Private)
++ (void)barkSuperLoudly;
+@end

--- a/examples/Modules Example/ObjCPod/src/abc.h
+++ b/examples/Modules Example/ObjCPod/src/abc.h
@@ -1,0 +1,3 @@
+@interface ABC : NSObject
++ (void)bark;
+@end

--- a/examples/Modules Example/ObjCPod/src/abc.m
+++ b/examples/Modules Example/ObjCPod/src/abc.m
@@ -1,0 +1,7 @@
+#import <ObjCPod/abc.h>
+
+#import <Foundation/Foundation.h>
+
+@implementation ABC
++ (void)bark { NSLog(@"woof woof"); }
+@end

--- a/examples/Modules Example/ObjCPod/src/abc.m
+++ b/examples/Modules Example/ObjCPod/src/abc.m
@@ -1,7 +1,9 @@
 #import <ObjCPod/abc.h>
+#import "abc_private.h"
 
 #import <Foundation/Foundation.h>
 
 @implementation ABC
 + (void)bark { NSLog(@"woof woof"); }
++ (void)barkSuperLoudly { NSLog(@"WOOF WOOF"); }
 @end

--- a/examples/Modules Example/Podfile
+++ b/examples/Modules Example/Podfile
@@ -1,0 +1,30 @@
+workspace 'Examples.xcworkspace'
+
+abstract_target 'Abstract Target' do
+    pod 'ObjCPod', path: 'ObjCPod'
+    pod 'SwiftPod', path: 'SwiftPod'
+    pod 'MixedPod', path: 'MixedPod'
+    pod 'CustomModuleMapPod', path: 'CustomModuleMapPod'
+
+    pod 'Alamofire', path: '../Alamofire Example/Alamofire'
+
+    %w[iOS macOS].each do |platform|
+        abstract_target "#{platform} Pods" do
+            project "#{platform} Modules.xcodeproj"
+
+            case platform
+            when 'iOS' then self.platform :ios, '10.0'
+            when 'macOS' then self.platform :macos, '10.10'
+            end
+
+            target 'Static' do
+                use_frameworks!(false)
+            end
+            target 'Dynamic' do
+                use_frameworks!(true)
+            end
+        end
+    end
+end
+
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/examples/Modules Example/Podfile
+++ b/examples/Modules Example/Podfile
@@ -1,6 +1,8 @@
 workspace 'Examples.xcworkspace'
 
 abstract_target 'Abstract Target' do
+    use_modular_headers!
+
     pod 'ObjCPod', path: 'ObjCPod'
     pod 'SwiftPod', path: 'SwiftPod'
     pod 'MixedPod', path: 'MixedPod'

--- a/examples/Modules Example/Static Swift/AppDelegate.swift
+++ b/examples/Modules Example/Static Swift/AppDelegate.swift
@@ -1,0 +1,20 @@
+#if os(iOS)
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+}
+#elseif os(macOS)
+import Cocoa
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+    }
+}
+#endif

--- a/examples/Modules Example/Static Swift/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/Modules Example/Static Swift/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/Modules Example/Static Swift/Base.lproj/LaunchScreen.storyboard
+++ b/examples/Modules Example/Static Swift/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/Modules Example/Static Swift/Base.lproj/Main.storyboard
+++ b/examples/Modules Example/Static Swift/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/Modules Example/Static Swift/Info.plist
+++ b/examples/Modules Example/Static Swift/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/Modules Example/Static Swift/ModelThing.h
+++ b/examples/Modules Example/Static Swift/ModelThing.h
@@ -1,0 +1,15 @@
+//
+//  ModelThing.h
+//  Static Swift
+//
+//  Created by Samuel Giddins on 1/23/18.
+//  Copyright © 2018 Samuel Giddins. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ModelThing : NSObject
+
++ (instancetype)copy;
+
+@end

--- a/examples/Modules Example/Static Swift/ModelThing.m
+++ b/examples/Modules Example/Static Swift/ModelThing.m
@@ -1,0 +1,28 @@
+//
+//  ModelThing.m
+//  Static Swift
+//
+//  Created by Samuel Giddins on 1/23/18.
+//  Copyright © 2018 Samuel Giddins. All rights reserved.
+//
+
+#import "ModelThing.h"
+
+@import MixedPod;
+@import SwiftPod;
+@import ObjCPod;
+
+@import CustomModuleMapPod;
+
+@import CustomModuleMapPod.Private;
+
+@implementation ModelThing
++ (instancetype)copy {
+    [CMM log]; // CustomModuleMapPod
+    CMM_doThing(); // CustomModuleMapPod.Private
+    [BCE meow]; // MixedPod
+    [ABC bark]; // ObjCPod
+    [XYZ.new doThing:@"objc thing?"]; // from SwiftPod
+    return [self.class new];
+}
+@end

--- a/examples/Modules Example/Static Swift/ViewController.swift
+++ b/examples/Modules Example/Static Swift/ViewController.swift
@@ -1,0 +1,45 @@
+#if os(iOS)
+import UIKit
+typealias BaseViewController = UIViewController
+#elseif os(macOS)
+import AppKit
+typealias BaseViewController = NSViewController
+#endif
+
+import ObjCPod
+import SwiftPod
+import MixedPod
+
+import Alamofire
+
+class ViewController: BaseViewController {
+
+    #if os(iOS)
+    override func viewDidAppear(_ animated: Bool) {
+        doThings()
+    }
+    #endif
+
+    func doThings() {
+        ABC.bark() // ObjCPod
+        print(XYZStruct(name: "")) // SwiftPod
+        XYZ().doThing("thiiiing") // SwiftPod
+        print(superMeow()) // MixedPod
+        BCE.meow() // MixedPod
+        print(NSClassFromString("ModelThing")?.copy() as Any) // App, done this way to avoid using a bridging header
+
+        networkRequest()
+    }
+
+    func networkRequest() {
+        Alamofire.request("https://httpbin.org/get").responseJSON { response in
+            print("\n\nAlamofire:\n")
+            print("Request: \(String(describing: response.request))")   // original url request
+
+            if let json = response.result.value {
+                print("JSON: \(json)") // serialized json response
+            }
+        }
+    }
+}
+

--- a/examples/Modules Example/SwiftPod/SwiftPod.podspec
+++ b/examples/Modules Example/SwiftPod/SwiftPod.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "SwiftPod"
+  s.version      = "0.0.1"
+  s.summary      = "A long description of objc."
+  s.source       = { :git => "http://foo/objc.git", :tag => "#{s.version}" }
+  s.authors = ['me']
+  s.homepage = 'http://example.com'
+  s.license = 'proprietary'
+
+  s.source_files  = "src/**/*.{h,m,swift}"
+  s.public_header_files = "src/**/*.h"
+
+  s.ios.deployment_target = '9.0'
+  s.macos.deployment_target = '10.10'
+end

--- a/examples/Modules Example/SwiftPod/src/xyz.swift
+++ b/examples/Modules Example/SwiftPod/src/xyz.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+private func doTheThing() {
+    print("doing the thing!")
+}
+
+@objc public
+class XYZ : NSObject {
+    @objc public
+    func doThing(_ x: String) {
+        print("do thing \(x):")
+        doTheThing()
+    }
+}
+
+public struct XYZStruct {
+    public let name: String
+
+    public init(name: String) { self.name = name }
+}

--- a/examples/Modules Example/iOS Modules.xcodeproj/project.pbxproj
+++ b/examples/Modules Example/iOS Modules.xcodeproj/project.pbxproj
@@ -1,0 +1,553 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4A97D3749BDE8B3E35AC9A3E /* Pods_Abstract_Target_iOS_Pods_Dynamic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66EF8CD87550366CE411E9E5 /* Pods_Abstract_Target_iOS_Pods_Dynamic.framework */; };
+		C00A217F2017E42500A11955 /* ModelThing.m in Sources */ = {isa = PBXBuildFile; fileRef = C00A217E2017E42500A11955 /* ModelThing.m */; };
+		C00A21802017E42500A11955 /* ModelThing.m in Sources */ = {isa = PBXBuildFile; fileRef = C00A217E2017E42500A11955 /* ModelThing.m */; };
+		C06248E92016A708009EF3DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248E82016A708009EF3DE /* AppDelegate.swift */; };
+		C06248EB2016A708009EF3DE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248EA2016A708009EF3DE /* ViewController.swift */; };
+		C06248EE2016A708009EF3DE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C06248EC2016A708009EF3DE /* Main.storyboard */; };
+		C06248F02016A708009EF3DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C06248EF2016A708009EF3DE /* Assets.xcassets */; };
+		C06248F32016A708009EF3DE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C06248F12016A708009EF3DE /* LaunchScreen.storyboard */; };
+		C06248FC2016AE3A009EF3DE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248EA2016A708009EF3DE /* ViewController.swift */; };
+		C06248FD2016AE3A009EF3DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248E82016A708009EF3DE /* AppDelegate.swift */; };
+		C06249002016AE3A009EF3DE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C06248F12016A708009EF3DE /* LaunchScreen.storyboard */; };
+		C06249012016AE3A009EF3DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C06248EF2016A708009EF3DE /* Assets.xcassets */; };
+		C06249022016AE3A009EF3DE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C06248EC2016A708009EF3DE /* Main.storyboard */; };
+		D4E1F29F12EAE0C62388EDDF /* libPods-Abstract Target-iOS Pods-Static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E99245D1CAE3EAEA11963B29 /* libPods-Abstract Target-iOS Pods-Static.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		33A84E66EBEDC738A1DC928D /* Pods-Abstract Target-iOS Pods-Static.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-iOS Pods-Static.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-iOS Pods-Static/Pods-Abstract Target-iOS Pods-Static.debug.xcconfig"; sourceTree = "<group>"; };
+		66EF8CD87550366CE411E9E5 /* Pods_Abstract_Target_iOS_Pods_Dynamic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Abstract_Target_iOS_Pods_Dynamic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCCB47A125EFE121F6CB0060 /* Pods-Abstract Target-iOS Pods-Static.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-iOS Pods-Static.release.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-iOS Pods-Static/Pods-Abstract Target-iOS Pods-Static.release.xcconfig"; sourceTree = "<group>"; };
+		BFD3374B6AE6E01A26161DF6 /* Pods-Abstract Target-iOS Pods-Dynamic.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-iOS Pods-Dynamic.release.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-iOS Pods-Dynamic/Pods-Abstract Target-iOS Pods-Dynamic.release.xcconfig"; sourceTree = "<group>"; };
+		C00A217D2017E42500A11955 /* ModelThing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelThing.h; sourceTree = "<group>"; };
+		C00A217E2017E42500A11955 /* ModelThing.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModelThing.m; sourceTree = "<group>"; };
+		C06248E52016A708009EF3DE /* Static.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Static.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C06248E82016A708009EF3DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C06248EA2016A708009EF3DE /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C06248ED2016A708009EF3DE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		C06248EF2016A708009EF3DE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C06248F22016A708009EF3DE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		C06248F42016A708009EF3DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C06249062016AE3A009EF3DE /* Dynamic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Dynamic.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8305F6CEF9F399F706F50A8 /* Pods-Abstract Target-iOS Pods-Dynamic.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-iOS Pods-Dynamic.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-iOS Pods-Dynamic/Pods-Abstract Target-iOS Pods-Dynamic.debug.xcconfig"; sourceTree = "<group>"; };
+		E99245D1CAE3EAEA11963B29 /* libPods-Abstract Target-iOS Pods-Static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Abstract Target-iOS Pods-Static.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C06248E22016A708009EF3DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D4E1F29F12EAE0C62388EDDF /* libPods-Abstract Target-iOS Pods-Static.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06248FE2016AE3A009EF3DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A97D3749BDE8B3E35AC9A3E /* Pods_Abstract_Target_iOS_Pods_Dynamic.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C06248DC2016A708009EF3DE = {
+			isa = PBXGroup;
+			children = (
+				C06248E72016A708009EF3DE /* Static Swift */,
+				C06248E62016A708009EF3DE /* Products */,
+				E0634AD47DB51DF85CD1FD7F /* Pods */,
+				C8E28305E444304C4C82CA36 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		C06248E62016A708009EF3DE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C06248E52016A708009EF3DE /* Static.app */,
+				C06249062016AE3A009EF3DE /* Dynamic.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C06248E72016A708009EF3DE /* Static Swift */ = {
+			isa = PBXGroup;
+			children = (
+				C06248E82016A708009EF3DE /* AppDelegate.swift */,
+				C06248EA2016A708009EF3DE /* ViewController.swift */,
+				C00A217D2017E42500A11955 /* ModelThing.h */,
+				C00A217E2017E42500A11955 /* ModelThing.m */,
+				C06248EC2016A708009EF3DE /* Main.storyboard */,
+				C06248EF2016A708009EF3DE /* Assets.xcassets */,
+				C06248F12016A708009EF3DE /* LaunchScreen.storyboard */,
+				C06248F42016A708009EF3DE /* Info.plist */,
+			);
+			path = "Static Swift";
+			sourceTree = "<group>";
+		};
+		C8E28305E444304C4C82CA36 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				66EF8CD87550366CE411E9E5 /* Pods_Abstract_Target_iOS_Pods_Dynamic.framework */,
+				E99245D1CAE3EAEA11963B29 /* libPods-Abstract Target-iOS Pods-Static.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E0634AD47DB51DF85CD1FD7F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C8305F6CEF9F399F706F50A8 /* Pods-Abstract Target-iOS Pods-Dynamic.debug.xcconfig */,
+				BFD3374B6AE6E01A26161DF6 /* Pods-Abstract Target-iOS Pods-Dynamic.release.xcconfig */,
+				33A84E66EBEDC738A1DC928D /* Pods-Abstract Target-iOS Pods-Static.debug.xcconfig */,
+				BCCB47A125EFE121F6CB0060 /* Pods-Abstract Target-iOS Pods-Static.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C06248E42016A708009EF3DE /* Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C06248F72016A708009EF3DE /* Build configuration list for PBXNativeTarget "Static" */;
+			buildPhases = (
+				1AE3CB4E770292D4D58BE8E1 /* [CP] Check Pods Manifest.lock */,
+				C06248E12016A708009EF3DE /* Sources */,
+				C06248E22016A708009EF3DE /* Frameworks */,
+				C06248E32016A708009EF3DE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Static;
+			productName = "Static Swift";
+			productReference = C06248E52016A708009EF3DE /* Static.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C06248FA2016AE3A009EF3DE /* Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C06249032016AE3A009EF3DE /* Build configuration list for PBXNativeTarget "Dynamic" */;
+			buildPhases = (
+				2F12433D31909FF2EF9D0658 /* [CP] Check Pods Manifest.lock */,
+				C06248FB2016AE3A009EF3DE /* Sources */,
+				C06248FE2016AE3A009EF3DE /* Frameworks */,
+				C06248FF2016AE3A009EF3DE /* Resources */,
+				74F94906590759F5A32D42CD /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Dynamic;
+			productName = "Static Swift";
+			productReference = C06249062016AE3A009EF3DE /* Dynamic.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C06248DD2016A708009EF3DE /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = "Samuel Giddins";
+				TargetAttributes = {
+					C06248E42016A708009EF3DE = {
+						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 0920;
+						ProvisioningStyle = Automatic;
+					};
+					C06248FA2016AE3A009EF3DE = {
+						LastSwiftMigration = 0920;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = C06248E02016A708009EF3DE /* Build configuration list for PBXProject "iOS Modules" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C06248DC2016A708009EF3DE;
+			productRefGroup = C06248E62016A708009EF3DE /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C06248E42016A708009EF3DE /* Static */,
+				C06248FA2016AE3A009EF3DE /* Dynamic */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C06248E32016A708009EF3DE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06248F32016A708009EF3DE /* LaunchScreen.storyboard in Resources */,
+				C06248F02016A708009EF3DE /* Assets.xcassets in Resources */,
+				C06248EE2016A708009EF3DE /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06248FF2016AE3A009EF3DE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06249002016AE3A009EF3DE /* LaunchScreen.storyboard in Resources */,
+				C06249012016AE3A009EF3DE /* Assets.xcassets in Resources */,
+				C06249022016AE3A009EF3DE /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		1AE3CB4E770292D4D58BE8E1 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Abstract Target-iOS Pods-Static-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2F12433D31909FF2EF9D0658 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Abstract Target-iOS Pods-Dynamic-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		74F94906590759F5A32D42CD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Abstract Target-iOS Pods-Dynamic/Pods-Abstract Target-iOS Pods-Dynamic-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire-framework-iOS/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/CustomModuleMapPod-framework-iOS/CustomModuleMapPod.framework",
+				"${BUILT_PRODUCTS_DIR}/MixedPod-framework-iOS/MixedPod.framework",
+				"${BUILT_PRODUCTS_DIR}/ObjCPod-framework-iOS/ObjCPod.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftPod-framework-iOS/SwiftPod.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CustomModuleMapPod.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MixedPod.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjCPod.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftPod.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Abstract Target-iOS Pods-Dynamic/Pods-Abstract Target-iOS Pods-Dynamic-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C06248E12016A708009EF3DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06248EB2016A708009EF3DE /* ViewController.swift in Sources */,
+				C00A217F2017E42500A11955 /* ModelThing.m in Sources */,
+				C06248E92016A708009EF3DE /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06248FB2016AE3A009EF3DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06248FC2016AE3A009EF3DE /* ViewController.swift in Sources */,
+				C00A21802017E42500A11955 /* ModelThing.m in Sources */,
+				C06248FD2016AE3A009EF3DE /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		C06248EC2016A708009EF3DE /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C06248ED2016A708009EF3DE /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		C06248F12016A708009EF3DE /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C06248F22016A708009EF3DE /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		C06248F52016A708009EF3DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C06248F62016A708009EF3DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C06248F82016A708009EF3DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 33A84E66EBEDC738A1DC928D /* Pods-Abstract Target-iOS Pods-Static.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C06248F92016A708009EF3DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BCCB47A125EFE121F6CB0060 /* Pods-Abstract Target-iOS Pods-Static.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C06249042016AE3A009EF3DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C8305F6CEF9F399F706F50A8 /* Pods-Abstract Target-iOS Pods-Dynamic.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		C06249052016AE3A009EF3DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BFD3374B6AE6E01A26161DF6 /* Pods-Abstract Target-iOS Pods-Dynamic.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C06248E02016A708009EF3DE /* Build configuration list for PBXProject "iOS Modules" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06248F52016A708009EF3DE /* Debug */,
+				C06248F62016A708009EF3DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C06248F72016A708009EF3DE /* Build configuration list for PBXNativeTarget "Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06248F82016A708009EF3DE /* Debug */,
+				C06248F92016A708009EF3DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C06249032016AE3A009EF3DE /* Build configuration list for PBXNativeTarget "Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06249042016AE3A009EF3DE /* Debug */,
+				C06249052016AE3A009EF3DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C06248DD2016A708009EF3DE /* Project object */;
+}

--- a/examples/Modules Example/iOS Modules.xcodeproj/project.pbxproj
+++ b/examples/Modules Example/iOS Modules.xcodeproj/project.pbxproj
@@ -380,6 +380,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-Wincomplete-umbrella",
+				);
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -432,6 +436,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-Wincomplete-umbrella",
+				);
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/examples/Modules Example/iOS Modules.xcodeproj/xcshareddata/xcschemes/Dynamic iOS.xcscheme
+++ b/examples/Modules Example/iOS Modules.xcodeproj/xcshareddata/xcschemes/Dynamic iOS.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+               BuildableName = "Dynamic.app"
+               BlueprintName = "Dynamic"
+               ReferencedContainer = "container:iOS Modules.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+            BuildableName = "Dynamic.app"
+            BlueprintName = "Dynamic"
+            ReferencedContainer = "container:iOS Modules.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+            BuildableName = "Dynamic.app"
+            BlueprintName = "Dynamic"
+            ReferencedContainer = "container:iOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+            BuildableName = "Dynamic.app"
+            BlueprintName = "Dynamic"
+            ReferencedContainer = "container:iOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/Modules Example/iOS Modules.xcodeproj/xcshareddata/xcschemes/Static iOS.xcscheme
+++ b/examples/Modules Example/iOS Modules.xcodeproj/xcshareddata/xcschemes/Static iOS.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C06248E42016A708009EF3DE"
+               BuildableName = "Static.app"
+               BlueprintName = "Static"
+               ReferencedContainer = "container:iOS Modules.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248E42016A708009EF3DE"
+            BuildableName = "Static.app"
+            BlueprintName = "Static"
+            ReferencedContainer = "container:iOS Modules.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248E42016A708009EF3DE"
+            BuildableName = "Static.app"
+            BlueprintName = "Static"
+            ReferencedContainer = "container:iOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248E42016A708009EF3DE"
+            BuildableName = "Static.app"
+            BlueprintName = "Static"
+            ReferencedContainer = "container:iOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/Modules Example/macOS Modules.xcodeproj/project.pbxproj
+++ b/examples/Modules Example/macOS Modules.xcodeproj/project.pbxproj
@@ -1,0 +1,512 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2F2D3E7DD8020F358D2B018A /* Pods_Abstract_Target_macOS_Pods_Dynamic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB2203E94F7BFB62CF9A4152 /* Pods_Abstract_Target_macOS_Pods_Dynamic.framework */; };
+		3BF69813355DB62D739E48D1 /* libPods-Abstract Target-macOS Pods-Static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5773DFEBB1F7D6376E3C6617 /* libPods-Abstract Target-macOS Pods-Static.a */; };
+		C00A217F2017E42500A11955 /* ModelThing.m in Sources */ = {isa = PBXBuildFile; fileRef = C00A217E2017E42500A11955 /* ModelThing.m */; };
+		C00A21802017E42500A11955 /* ModelThing.m in Sources */ = {isa = PBXBuildFile; fileRef = C00A217E2017E42500A11955 /* ModelThing.m */; };
+		C06248E92016A708009EF3DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248E82016A708009EF3DE /* AppDelegate.swift */; };
+		C06248EB2016A708009EF3DE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248EA2016A708009EF3DE /* ViewController.swift */; };
+		C06248FC2016AE3A009EF3DE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248EA2016A708009EF3DE /* ViewController.swift */; };
+		C06248FD2016AE3A009EF3DE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06248E82016A708009EF3DE /* AppDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1E949C071CEB4793A667756F /* Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig"; sourceTree = "<group>"; };
+		47E1D32B15E8199CE61CF31B /* Pods-Abstract Target-macOS Pods-Static.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-macOS Pods-Static.release.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Static/Pods-Abstract Target-macOS Pods-Static.release.xcconfig"; sourceTree = "<group>"; };
+		5773DFEBB1F7D6376E3C6617 /* libPods-Abstract Target-macOS Pods-Static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Abstract Target-macOS Pods-Static.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB2203E94F7BFB62CF9A4152 /* Pods_Abstract_Target_macOS_Pods_Dynamic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Abstract_Target_macOS_Pods_Dynamic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C00A217D2017E42500A11955 /* ModelThing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelThing.h; sourceTree = "<group>"; };
+		C00A217E2017E42500A11955 /* ModelThing.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModelThing.m; sourceTree = "<group>"; };
+		C06248E52016A708009EF3DE /* Static.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Static.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C06248E82016A708009EF3DE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C06248EA2016A708009EF3DE /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C06248F42016A708009EF3DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C06249062016AE3A009EF3DE /* Dynamic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Dynamic.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD9AE208D231588BF9A4C0D2 /* Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig"; sourceTree = "<group>"; };
+		CFDA82AEB5C8A1B1DD6949AC /* Pods-Abstract Target-macOS Pods-Static.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Abstract Target-macOS Pods-Static.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Static/Pods-Abstract Target-macOS Pods-Static.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C06248E22016A708009EF3DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3BF69813355DB62D739E48D1 /* libPods-Abstract Target-macOS Pods-Static.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06248FE2016AE3A009EF3DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F2D3E7DD8020F358D2B018A /* Pods_Abstract_Target_macOS_Pods_Dynamic.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4674A866F88199466931F160 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BB2203E94F7BFB62CF9A4152 /* Pods_Abstract_Target_macOS_Pods_Dynamic.framework */,
+				5773DFEBB1F7D6376E3C6617 /* libPods-Abstract Target-macOS Pods-Static.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		901AECEC8BB930DDFA940951 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				CD9AE208D231588BF9A4C0D2 /* Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig */,
+				1E949C071CEB4793A667756F /* Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig */,
+				CFDA82AEB5C8A1B1DD6949AC /* Pods-Abstract Target-macOS Pods-Static.debug.xcconfig */,
+				47E1D32B15E8199CE61CF31B /* Pods-Abstract Target-macOS Pods-Static.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		C06248DC2016A708009EF3DE = {
+			isa = PBXGroup;
+			children = (
+				C06248E72016A708009EF3DE /* Static Swift */,
+				C06248E62016A708009EF3DE /* Products */,
+				901AECEC8BB930DDFA940951 /* Pods */,
+				4674A866F88199466931F160 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		C06248E62016A708009EF3DE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C06248E52016A708009EF3DE /* Static.app */,
+				C06249062016AE3A009EF3DE /* Dynamic.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C06248E72016A708009EF3DE /* Static Swift */ = {
+			isa = PBXGroup;
+			children = (
+				C06248E82016A708009EF3DE /* AppDelegate.swift */,
+				C06248EA2016A708009EF3DE /* ViewController.swift */,
+				C00A217D2017E42500A11955 /* ModelThing.h */,
+				C00A217E2017E42500A11955 /* ModelThing.m */,
+				C06248F42016A708009EF3DE /* Info.plist */,
+			);
+			path = "Static Swift";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C06248E42016A708009EF3DE /* Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C06248F72016A708009EF3DE /* Build configuration list for PBXNativeTarget "Static" */;
+			buildPhases = (
+				FDE12D3B73D1A84536C81922 /* [CP] Check Pods Manifest.lock */,
+				C06248E12016A708009EF3DE /* Sources */,
+				C06248E22016A708009EF3DE /* Frameworks */,
+				C06248E32016A708009EF3DE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Static;
+			productName = "Static Swift";
+			productReference = C06248E52016A708009EF3DE /* Static.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C06248FA2016AE3A009EF3DE /* Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C06249032016AE3A009EF3DE /* Build configuration list for PBXNativeTarget "Dynamic" */;
+			buildPhases = (
+				9421DA4FCECB32C49E205BEF /* [CP] Check Pods Manifest.lock */,
+				C06248FB2016AE3A009EF3DE /* Sources */,
+				C06248FE2016AE3A009EF3DE /* Frameworks */,
+				C06248FF2016AE3A009EF3DE /* Resources */,
+				CCC86C1196895CEB7F2D0C9B /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Dynamic;
+			productName = "Static Swift";
+			productReference = C06249062016AE3A009EF3DE /* Dynamic.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C06248DD2016A708009EF3D0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = "Samuel Giddins";
+				TargetAttributes = {
+					C06248E42016A708009EF3DE = {
+						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 0920;
+						ProvisioningStyle = Automatic;
+					};
+					C06248FA2016AE3A009EF3DE = {
+						LastSwiftMigration = 0920;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = C06248E02016A708009EF3DE /* Build configuration list for PBXProject "macOS Modules" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C06248DC2016A708009EF3DE;
+			productRefGroup = C06248E62016A708009EF3DE /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C06248E42016A708009EF3DE /* Static */,
+				C06248FA2016AE3A009EF3DE /* Dynamic */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C06248E32016A708009EF3DE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06248FF2016AE3A009EF3DE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9421DA4FCECB32C49E205BEF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Abstract Target-macOS Pods-Dynamic-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CCC86C1196895CEB7F2D0C9B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire-framework-macOS/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/CustomModuleMapPod-framework-macOS/CustomModuleMapPod.framework",
+				"${BUILT_PRODUCTS_DIR}/MixedPod-framework-macOS/MixedPod.framework",
+				"${BUILT_PRODUCTS_DIR}/ObjCPod-framework-macOS/ObjCPod.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftPod-framework-macOS/SwiftPod.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CustomModuleMapPod.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MixedPod.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjCPod.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftPod.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FDE12D3B73D1A84536C81922 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Abstract Target-macOS Pods-Static-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C06248E12016A708009EF3DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06248EB2016A708009EF3DE /* ViewController.swift in Sources */,
+				C00A217F2017E42500A11955 /* ModelThing.m in Sources */,
+				C06248E92016A708009EF3DE /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C06248FB2016AE3A009EF3DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C06248FC2016AE3A009EF3DE /* ViewController.swift in Sources */,
+				C00A21802017E42500A11955 /* ModelThing.m in Sources */,
+				C06248FD2016AE3A009EF3DE /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C06248F52016A708009EF3DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C06248F62016A708009EF3DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C06248F82016A708009EF3DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CFDA82AEB5C8A1B1DD6949AC /* Pods-Abstract Target-macOS Pods-Static.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C06248F92016A708009EF3DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 47E1D32B15E8199CE61CF31B /* Pods-Abstract Target-macOS Pods-Static.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C06249042016AE3A009EF3DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CD9AE208D231588BF9A4C0D2 /* Pods-Abstract Target-macOS Pods-Dynamic.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		C06249052016AE3A009EF3DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1E949C071CEB4793A667756F /* Pods-Abstract Target-macOS Pods-Dynamic.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "Static Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.segiddins.Static-Swift";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C06248E02016A708009EF3DE /* Build configuration list for PBXProject "macOS Modules" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06248F52016A708009EF3DE /* Debug */,
+				C06248F62016A708009EF3DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C06248F72016A708009EF3DE /* Build configuration list for PBXNativeTarget "Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06248F82016A708009EF3DE /* Debug */,
+				C06248F92016A708009EF3DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C06249032016AE3A009EF3DE /* Build configuration list for PBXNativeTarget "Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C06249042016AE3A009EF3DE /* Debug */,
+				C06249052016AE3A009EF3DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C06248DD2016A708009EF3D0 /* Project object */;
+}

--- a/examples/Modules Example/macOS Modules.xcodeproj/project.pbxproj
+++ b/examples/Modules Example/macOS Modules.xcodeproj/project.pbxproj
@@ -342,6 +342,10 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-Wincomplete-umbrella",
+				);
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -393,6 +397,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-Wincomplete-umbrella",
+				);
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/examples/Modules Example/macOS Modules.xcodeproj/xcshareddata/xcschemes/Dynamic macOS.xcscheme
+++ b/examples/Modules Example/macOS Modules.xcodeproj/xcshareddata/xcschemes/Dynamic macOS.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+               BuildableName = "Dynamic.app"
+               BlueprintName = "Dynamic"
+               ReferencedContainer = "container:macOS Modules.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+            BuildableName = "Dynamic.app"
+            BlueprintName = "Dynamic"
+            ReferencedContainer = "container:macOS Modules.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+            BuildableName = "Dynamic.app"
+            BlueprintName = "Dynamic"
+            ReferencedContainer = "container:macOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248FA2016AE3A009EF3DE"
+            BuildableName = "Dynamic.app"
+            BlueprintName = "Dynamic"
+            ReferencedContainer = "container:macOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/Modules Example/macOS Modules.xcodeproj/xcshareddata/xcschemes/Static macOS.xcscheme
+++ b/examples/Modules Example/macOS Modules.xcodeproj/xcshareddata/xcschemes/Static macOS.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C06248E42016A708009EF3DE"
+               BuildableName = "Static.app"
+               BlueprintName = "Static"
+               ReferencedContainer = "container:macOS Modules.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248E42016A708009EF3DE"
+            BuildableName = "Static.app"
+            BlueprintName = "Static"
+            ReferencedContainer = "container:macOS Modules.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248E42016A708009EF3DE"
+            BuildableName = "Static.app"
+            BlueprintName = "Static"
+            ReferencedContainer = "container:macOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C06248E42016A708009EF3DE"
+            BuildableName = "Static.app"
+            BlueprintName = "Static"
+            ReferencedContainer = "container:macOS Modules.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
+++ b/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
@@ -115,7 +115,6 @@
 				A8C77C4C1C9DA931000AFF69 /* Frameworks */,
 				A8C77C4D1C9DA931000AFF69 /* Resources */,
 				E1D153F1317B0ED8A0A98DE0 /* [CP] Embed Pods Frameworks */,
-				41F27F05FA87A7FE9EA1A2BF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -172,21 +171,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		41F27F05FA87A7FE9EA1A2BF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Resource Bundle Example/Pods-Resource Bundle Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8FB5EE32BFE997FC437DE638 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
+++ b/examples/TestInclusions/TestInclusions.xcodeproj/project.pbxproj
@@ -154,7 +154,6 @@
 				F58833CB1CBBC0C9007D4DA4 /* Sources */,
 				F58833CC1CBBC0C9007D4DA4 /* Frameworks */,
 				F58833CD1CBBC0C9007D4DA4 /* Resources */,
-				2D7DA37C114DD6E56D290D94 /* [CP] Embed Pods Frameworks */,
 				BEB56E0CAF877FA9577BF299 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -174,7 +173,6 @@
 				F58833E41CBBC0C9007D4DA4 /* Sources */,
 				F58833E51CBBC0C9007D4DA4 /* Frameworks */,
 				F58833E61CBBC0C9007D4DA4 /* Resources */,
-				6D3C9E5647F2F9BE1B8CA805 /* [CP] Embed Pods Frameworks */,
 				23FBFF6CF467540E5F102610 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -345,36 +343,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2D7DA37C114DD6E56D290D94 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusions/Pods-TestInclusionsPods-TestInclusions-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6D3C9E5647F2F9BE1B8CA805 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestInclusionsPods-TestInclusionsTests/Pods-TestInclusionsPods-TestInclusionsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BEB56E0CAF877FA9577BF299 /* [CP] Copy Pods Resources */ = {

--- a/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/project.pbxproj
+++ b/examples/Vendored Framework Example/Vendored Framework Example.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 				5CAF4FE51CC1125900B44520 /* Frameworks */,
 				5CAF4FE61CC1125900B44520 /* Resources */,
 				4697BF2DD055B93C3DE0E375 /* [CP] Embed Pods Frameworks */,
-				9C2933733E94154FB1F30218 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -194,21 +193,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9C2933733E94154FB1F30218 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Vendored Framework Example/Pods-Vendored Framework Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
+++ b/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
@@ -206,7 +206,6 @@
 				A129F8BE1B2CA81600EBC1DD /* Resources */,
 				A129F8F61B2CA81700EBC1DD /* Embed Watch Content */,
 				B55D105F75FDCEAD4A12BE64 /* [CP] Embed Pods Frameworks */,
-				1E232F64274BFFA8F587E155 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -245,7 +244,6 @@
 				A865B2771CAF18FF0031EFC6 /* Frameworks */,
 				A865B2781CAF18FF0031EFC6 /* Resources */,
 				766BB1279F3F20E30F8D82AC /* [CP] Embed Pods Frameworks */,
-				9404B5E651690A16E40B8F95 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -328,21 +326,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1E232F64274BFFA8F587E155 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-watchOSsample/Pods-watchOSsample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		1E8987D060C89B71B6F2E504 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -395,21 +378,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9404B5E651690A16E40B8F95 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-watchOSsample WatchKit Extension/Pods-watchOSsample WatchKit Extension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B55D105F75FDCEAD4A12BE64 /* [CP] Embed Pods Frameworks */ = {

--- a/lib/cocoapods.rb
+++ b/lib/cocoapods.rb
@@ -57,6 +57,7 @@ module Pod
     autoload :Markdown,                'cocoapods/generator/acknowledgements/markdown'
     autoload :Plist,                   'cocoapods/generator/acknowledgements/plist'
     autoload :BridgeSupport,           'cocoapods/generator/bridge_support'
+    autoload :Constant,                'cocoapods/generator/constant'
     autoload :CopyResourcesScript,     'cocoapods/generator/copy_resources_script'
     autoload :DummySource,             'cocoapods/generator/dummy_source'
     autoload :EmbedFrameworksScript,   'cocoapods/generator/embed_frameworks_script'

--- a/lib/cocoapods/generator/constant.rb
+++ b/lib/cocoapods/generator/constant.rb
@@ -1,0 +1,19 @@
+module Pod
+  module Generator
+    # Generates a constant file.
+    #
+    class Constant
+      def initialize(contents)
+        @generate = contents
+      end
+
+      attr_reader :generate
+
+      def save_as(path)
+        path.open('w') do |f|
+          f.write(generate)
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -67,7 +67,7 @@ module Pod
       #
       def generate
         <<-MODULE_MAP.strip_heredoc
-#{module_specificier_prefix}module #{target.product_module_name} {
+#{module_specifier_prefix}module #{target.product_module_name} {
   #{headers.join("\n  ")}
 
   export *
@@ -81,7 +81,7 @@ module Pod
       # The prefix to `module` to prepend in the module map.
       # Ensures that only framework targets have `framework` prepended.
       #
-      def module_specificier_prefix
+      def module_specifier_prefix
         if target.requires_frameworks?
           'framework '
         else

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -41,7 +41,9 @@ module Pod
       #
       def initialize(target)
         @target = target
-        @headers = [Header.new(target.umbrella_header_path.basename, true)]
+        @headers = [
+          Header.new(target.umbrella_header_path.basename, true),
+        ]
       end
 
       # Generates and saves the Info.plist to the given path.
@@ -64,12 +66,12 @@ module Pod
       #
       def generate
         <<-MODULE_MAP.strip_heredoc
-          #{module_specificier_prefix}module #{target.product_module_name} {
-            #{headers.join("\n  ")}
+#{module_specificier_prefix}module #{target.product_module_name} {
+  #{headers.join("\n  ")}
 
-            export *
-            module * { export * }
-          }
+  export *
+  module * { export * }
+}
         MODULE_MAP
       end
 

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -67,7 +67,7 @@ module Pod
       #
       def generate
         <<-MODULE_MAP.strip_heredoc
-#{module_specifier_prefix}module #{target.product_module_name} {
+#{module_specifier_prefix}module #{target.product_module_name}#{module_declaration_attributes} {
   #{headers.join("\n  ")}
 
   export *
@@ -87,6 +87,15 @@ module Pod
         else
           ''
         end
+      end
+
+      # The suffix attributes to `module`.
+      # Ensures that library module maps are treated as `system` modules,
+      # supressing warnings when imported, as is done for header imports given via `-isystem`.
+      #
+      def module_declaration_attributes
+        return '' if target.requires_frameworks?
+        ' [system]'
       end
     end
   end

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -13,7 +13,7 @@ module Pod
       attr_reader :headers
 
       Header = Struct.new(:path, :umbrella, :private, :textual, :size, :mtime) do
-        alias private? private
+        alias_method :private?, :private
         def to_s
           [
             (:private if private?),
@@ -22,14 +22,14 @@ module Pod
             'header',
             %("#{path}"),
             attrs,
-        ].compact.join(' ')
+          ].compact.join(' ')
         end
 
         def attrs
           attrs = {
             'size' => size,
             'mtime' => mtime,
-          }.reject {|k,v| v.nil? }
+          }.reject { |_k, v| v.nil? }
           return nil if attrs.empty?
           attrs.to_s
         end

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -38,13 +38,26 @@ module Pod
       #
       def generate
         <<-MODULE_MAP.strip_heredoc
-          framework module #{target.product_module_name} {
+          #{module_specificier_prefix}module #{target.product_module_name} {
             umbrella header "#{target.umbrella_header_path.basename}"
 
             export *
             module * { export * }
           }
         MODULE_MAP
+      end
+
+      private
+
+      # The prefix to `module` to prepend in the module map.
+      # Ensures that only framework targets have `framework` prepended.
+      #
+      def module_specificier_prefix
+        if target.requires_frameworks?
+          'framework '
+        else
+          ''
+        end
       end
     end
   end

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -12,13 +12,14 @@ module Pod
 
       attr_reader :headers
 
-      Header = Struct.new(:path, :umbrella, :private, :textual, :size, :mtime) do
+      Header = Struct.new(:path, :umbrella, :private, :textual, :exclude, :size, :mtime) do
         alias_method :private?, :private
         def to_s
           [
             (:private if private?),
             (:textual if textual),
             (:umbrella if umbrella),
+            (:exclude if exclude),
             'header',
             %("#{path}"),
             attrs,

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -152,7 +152,9 @@ module Pod
           else
             # Make headers discoverable from $PODS_ROOT/Headers directory
             header_search_paths = target.sandbox.public_headers.search_paths(target.platform)
+            swift_search_paths = pod_targets.select(&:should_build?).select(&:uses_swift?).map(&:configuration_build_dir)
             {
+              'SWIFT_INCLUDE_PATHS' => '$(inherited) ' + XCConfigHelper.quote(swift_search_paths),
               # by `#import "…"`
               'HEADER_SEARCH_PATHS' => '$(inherited) ' + XCConfigHelper.quote(header_search_paths),
               # by `#import <…>`

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -55,7 +55,6 @@ module Pod
             'PODS_ROOT' => '${SRCROOT}',
             'PODS_TARGET_SRCROOT' => target.pod_target_srcroot,
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
-            'PRODUCT_MODULE_NAME' => target.product_module_name,
             'SKIP_INSTALL' => 'YES',
             'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ',
             'SWIFT_INCLUDE_PATHS' => '$(inherited) ',

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -55,6 +55,7 @@ module Pod
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
             'SKIP_INSTALL' => 'YES',
             'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ',
+            'SWIFT_INCLUDE_PATHS' => '$(inherited) ${PODS_CONFIGURATION_BUILD_DIR}/' + target.name,
             # 'USE_HEADERMAP' => 'NO'
           }
 

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -47,17 +47,18 @@ module Pod
           config = {
             'FRAMEWORK_SEARCH_PATHS' => '$(inherited) ',
             'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1',
-            'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(target.header_search_paths(@test_xcconfig)),
+            'HEADER_SEARCH_PATHS' => '$(inherited) ' + XCConfigHelper.quote(target.header_search_paths(@test_xcconfig)),
             'LIBRARY_SEARCH_PATHS' => '$(inherited) ',
+            'OTHER_CFLAGS' => '$(inherited) ',
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target, @test_xcconfig),
+            'OTHER_SWIFT_FLAGS' => '$(inherited) ',
             'PODS_ROOT' => '${SRCROOT}',
             'PODS_TARGET_SRCROOT' => target.pod_target_srcroot,
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
             'PRODUCT_MODULE_NAME' => target.product_module_name,
             'SKIP_INSTALL' => 'YES',
             'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ',
-            'SWIFT_INCLUDE_PATHS' => '$(inherited) ${LIBRARY_SEARCH_PATHS}',
-            # 'USE_HEADERMAP' => 'NO'
+            'SWIFT_INCLUDE_PATHS' => '$(inherited) ',
           }
 
           @xcconfig = Xcodeproj::Config.new(config)

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -55,7 +55,7 @@ module Pod
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
             'SKIP_INSTALL' => 'YES',
             'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ',
-            'SWIFT_INCLUDE_PATHS' => '$(inherited) ${PODS_CONFIGURATION_BUILD_DIR}/' + target.name,
+            'SWIFT_INCLUDE_PATHS' => '$(inherited) ${LIBRARY_SEARCH_PATHS}',
             # 'USE_HEADERMAP' => 'NO'
           }
 

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -53,6 +53,7 @@ module Pod
             'PODS_ROOT' => '${SRCROOT}',
             'PODS_TARGET_SRCROOT' => target.pod_target_srcroot,
             'PRODUCT_BUNDLE_IDENTIFIER' => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
+            'PRODUCT_MODULE_NAME' => target.product_module_name,
             'SKIP_INSTALL' => 'YES',
             'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) ',
             'SWIFT_INCLUDE_PATHS' => '$(inherited) ${LIBRARY_SEARCH_PATHS}',

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -165,8 +165,14 @@ module Pod
 
         def install_libraries
           UI.message '- Installing targets' do
+            umbrella_headers_by_dir = pod_targets.map do |pod_target|
+              next unless pod_target.should_build? && pod_target.defines_module?
+              pod_target.umbrella_header_path
+            end.compact.group_by(&:dirname)
+
             pod_targets.sort_by(&:name).each do |pod_target|
               target_installer = PodTargetInstaller.new(sandbox, pod_target)
+              target_installer.umbrella_headers_by_dir = umbrella_headers_by_dir
               target_installer.install!
             end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -20,6 +20,9 @@ module Pod
                 create_info_plist_file(target.info_plist_path, native_target, target.version, target.platform)
                 create_module_map
                 create_umbrella_header
+              elsif target.uses_swift?
+                create_module_map
+                create_umbrella_header
               end
               # Because embedded targets live in their host target, CocoaPods
               # copies all of the embedded target's pod_targets to its host

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -63,6 +63,8 @@ module Pod
               'PODS_ROOT'                          => '$(SRCROOT)',
               'PRODUCT_BUNDLE_IDENTIFIER'          => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
               'SKIP_INSTALL'                       => 'YES',
+
+              'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => 'NO',
             }
             super.merge(settings)
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -64,6 +64,10 @@ module Pod
               'PRODUCT_BUNDLE_IDENTIFIER'          => 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}',
               'SKIP_INSTALL'                       => 'YES',
 
+              # Needed to ensure that static libraries won't try to embed the swift stdlib,
+              # since there's no where to embed in for a static library.
+              # Not necessary for dynamic frameworks either, since the aggregate targets are never shipped
+              # on their own, and are always further embedded into an app target.
               'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => 'NO',
             }
             super.merge(settings)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -101,7 +101,6 @@ module Pod
               settings['SWIFT_VERSION'] = target.swift_version
             end
 
-
             settings
           end
 
@@ -702,14 +701,14 @@ module Pod
               ditto "${PODS_ROOT}/#{target.module_map_path.relative_path_from(target.sandbox.root)}" "${MODULE_MAP_PATH}"
               printf "\\n\\nmodule ${PRODUCT_MODULE_NAME}.Swift {\\n  header \\"${COMPATIBILITY_HEADER_PATH}\\"\\n  requires objc\\n}\\n" >> "${MODULE_MAP_PATH}"
             SH
-            build_phase.input_paths = %W[
+            build_phase.input_paths = %W(
               ${DERIVED_SOURCES_DIR}/${PRODUCT_MODULE_NAME}-Swift.h
               ${PODS_ROOT}/#{target.module_map_path.relative_path_from(target.sandbox.root)}
-            ]
-            build_phase.output_paths = %W[
+            )
+            build_phase.output_paths = %w(
               ${BUILT_PRODUCTS_DIR}/${PRODUCT_MODULE_NAME}.modulemap
               ${BUILT_PRODUCTS_DIR}/Swift\ Compatibility\ Header/${PRODUCT_MODULE_NAME}-Swift.h
-            ]
+            )
           end
 
           #-----------------------------------------------------------------------#

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -46,6 +46,7 @@ module Pod
                 create_build_phase_to_symlink_header_folders
               else
                 add_copy_module_map_build_phase
+                add_copy_umbrella_header_build_phase
               end
               unless skip_pch?(target.non_test_specs)
                 path = target.prefix_header_path
@@ -684,6 +685,18 @@ module Pod
             if !target.requires_frameworks? && !target.uses_swift?
               file_ref = support_files_group.find_file_by_path(path.to_s)
               copy_phase_name = 'Copy modulemap'
+              copy_phase = native_target.copy_files_build_phases.find { |bp| bp.name == copy_phase_name } ||
+                native_target.new_copy_files_build_phase(copy_phase_name)
+              copy_phase.symbol_dst_subfolder_spec = :products_directory
+              copy_phase.add_file_reference(file_ref, false)
+            end
+          end
+
+          # FIXME: Umbrella header should be copied as part of copy public headers?
+          def add_copy_umbrella_header_build_phase(path = target.umbrella_header_path.relative_path_from(target.support_files_dir))
+            if !target.requires_frameworks? && !target.uses_swift?
+              file_ref = support_files_group.find_file_by_path(path.to_s)
+              copy_phase_name = 'Copy umbrella header'
               copy_phase = native_target.copy_files_build_phases.find { |bp| bp.name == copy_phase_name } ||
                 native_target.new_copy_files_build_phase(copy_phase_name)
               copy_phase.symbol_dst_subfolder_spec = :products_directory

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -606,6 +606,7 @@ module Pod
           def create_module_map
             return super unless custom_module_map
             path = target.module_map_path
+            path.mkpath
             UI.message "- Copying module map file to #{UI.path(path)}" do
               Tempfile.open(path.basename.to_s) do |tmp_module_map|
                 contents = custom_module_map.read

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -622,7 +622,7 @@ module Pod
             UI.message "- Copying module map file to #{UI.path(path)}" do
               contents = custom_module_map.read
               unless target.requires_frameworks?
-                contents.gsub!(/^(\s*)framework\s+module/, '\1module')
+                contents.gsub!(/^(\s*)framework\s+(module [^{}]){/, '\1\2 [system] {')
               end
               generator = Generator::Constant.new(contents)
               update_changed_file(generator, path)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -41,7 +41,7 @@ module Pod
               end
               if target.requires_frameworks?
                 unless target.static_framework?
-                  create_info_plist_file
+                  create_info_plist_file(target.info_plist_path, native_target, target.version, target.platform)
                 end
                 create_build_phase_to_symlink_header_folders
                 if target.static_framework?

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -40,10 +40,13 @@ module Pod
                                      end
               end
               if target.requires_frameworks?
+                unless target.static_framework?
+                  create_info_plist_file
+                end
+                create_build_phase_to_symlink_header_folders
                 if target.static_framework?
                   create_build_phase_to_move_static_framework_archive
                 end
-                create_build_phase_to_symlink_header_folders
               else
                 add_copy_module_map_build_phase
                 add_copy_umbrella_header_build_phase

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -91,6 +91,9 @@ module Pod
               settings['PUBLIC_HEADERS_FOLDER_PATH'] = ''
             end
 
+            settings['PRODUCT_NAME'] = target.product_basename
+            settings['PRODUCT_MODULE_NAME'] = target.product_module_name
+
             settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'] = ''
             settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = ''
             settings['CODE_SIGN_IDENTITY[sdk=watchos*]'] = ''

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -622,7 +622,7 @@ module Pod
             UI.message "- Copying module map file to #{UI.path(path)}" do
               contents = custom_module_map.read
               unless target.requires_frameworks?
-                contents.gsub!(/^(\s*)framework\s+(module [^{}]){/, '\1\2 [system] {')
+                contents.gsub!(/^(\s*)framework\s+(module[^{}]+){/, '\1\2[system] {')
               end
               generator = Generator::Constant.new(contents)
               update_changed_file(generator, path)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -106,6 +106,7 @@ module Pod
           # @return [Void]
           #
           def update_changed_file(generator, path)
+            path.dirname.mkpath
             if path.exist?
               generator.save_as(support_files_temp_dir)
               unless FileUtils.identical?(support_files_temp_dir, path)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -74,9 +74,7 @@ module Pod
           # @return [Hash{String => String}]
           #
           def custom_build_settings
-            settings = {
-              'PRODUCT_NAME' => target.product_module_name,
-            }
+            settings = {}
 
             unless target.archs.empty?
               settings['ARCHS'] = target.archs

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -74,7 +74,9 @@ module Pod
           # @return [Hash{String => String}]
           #
           def custom_build_settings
-            settings = {}
+            settings = {
+              'PRODUCT_NAME' => target.product_module_name
+            }
 
             unless target.archs.empty?
               settings['ARCHS'] = target.archs

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -82,15 +82,11 @@ module Pod
 
             if target.requires_frameworks?
               framework_name = target.product_module_name
-              settings['PRODUCT_NAME'] = framework_name
               if target.static_framework?
                 settings['PUBLIC_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/Headers'
                 settings['PRIVATE_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/PrivateHeaders'
               end
             else
-              # if target.uses_swift?
-              #   settings['PRODUCT_NAME'] = target.product_module_name
-              # end
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -75,7 +75,7 @@ module Pod
           #
           def custom_build_settings
             settings = {
-              'PRODUCT_NAME' => target.product_module_name
+              'PRODUCT_NAME' => target.product_module_name,
             }
 
             unless target.archs.empty?

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -88,6 +88,9 @@ module Pod
                 settings['PRIVATE_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/PrivateHeaders'
               end
             else
+              # if target.uses_swift?
+              #   settings['PRODUCT_NAME'] = target.product_module_name
+              # end
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end
 
@@ -169,16 +172,12 @@ module Pod
           # Creates the module map file which ensures that the umbrella header is
           # recognized with a customized path
           #
-          # @yield_param [Generator::ModuleMap]
-          #              yielded once to configure the private headers
-          #
           # @return [void]
           #
           def create_module_map
             path = target.module_map_path
             UI.message "- Generating module map file at #{UI.path(path)}" do
               generator = Generator::ModuleMap.new(target)
-              yield generator if block_given?
               update_changed_file(generator, path)
               add_file_to_support_group(path)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -176,6 +176,7 @@ module Pod
             path = target.module_map_path
             UI.message "- Generating module map file at #{UI.path(path)}" do
               generator = Generator::ModuleMap.new(target)
+              yield generator if block_given?
               update_changed_file(generator, path)
               add_file_to_support_group(path)
 

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -123,7 +123,7 @@ module Pod
 
             next if non_module_dependencies.empty?
 
-            error_messages << "The swift pod `#{pod_target.name}` depends upon #{non_module_dependencies.to_sentence}, " \
+            error_messages << "The swift pod `#{pod_target.name}` depends upon #{non_module_dependencies.map { |d| "`#{d}`" }.to_sentence}, " \
                               'which do not define modules. ' \
                               'To opt into those targets generating module maps '\
                               '(which is necessary to import them from swift when building as static libraries), ' \

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -35,7 +35,6 @@ module Pod
           verify_no_duplicate_framework_and_library_names
           verify_no_static_framework_transitive_dependencies
           verify_no_pods_used_with_multiple_swift_versions
-          verify_framework_usage
         end
 
         private
@@ -106,25 +105,7 @@ module Pod
 
           unless error_messages.empty?
             raise Informative, 'The following pods are integrated into targets ' \
-            "that do not have the same Swift version:\n\n#{error_messages.join("\n")}"
-          end
-        end
-
-        def verify_framework_usage
-          aggregate_targets.each do |aggregate_target|
-            next if aggregate_target.requires_frameworks?
-
-            aggregate_target.user_build_configurations.keys.each do |config|
-              pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
-
-              swift_pods = pod_targets.select(&:uses_swift?)
-              unless swift_pods.empty?
-                raise Informative, 'Pods written in Swift can only be integrated as frameworks; ' \
-                  'add `use_frameworks!` to your Podfile or target to opt into using it. ' \
-                  "The Swift #{swift_pods.size == 1 ? 'Pod being used is' : 'Pods being used are'}: " +
-                  swift_pods.map(&:name).to_sentence
-              end
-            end
+              "that do not have the same Swift version:\n\n#{error_messages.join("\n")}"
           end
         end
       end

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -127,7 +127,8 @@ module Pod
                               'which do not define modules. ' \
                               'To opt into those targets generating module maps '\
                               '(which is necessary to import them from swift when building as static libraries), ' \
-                              "you may add `'DEFINES_MODULE' => 'YES'` to those pods' `pod_target_xcconfig`."
+                              'you may set `use_modular_header!` globally in your Podfile, '\
+                              'or specify `:modular_headers => true` for particular dependencies.'
           end
           return if error_messages.empty?
 

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -157,7 +157,7 @@ module Pod
     #         defines the module structure for the compiler.
     #
     def module_map_path
-      support_files_dir + 'module.modulemap'
+      support_files_dir + "#{product_module_name}.modulemap"
     end
 
     # @return [Pathname] the absolute path of the bridge support file.

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -157,10 +157,11 @@ module Pod
     #         defines the module structure for the compiler.
     #
     def module_map_path
+      basename = "#{label}.modulemap"
       if requires_frameworks? || !respond_to?(:build_headers)
-        support_files_dir + "#{product_module_name}.modulemap"
+        support_files_dir + basename
       else
-        build_headers.root + product_module_name + "#{label}.modulemap"
+        build_headers.root + product_module_name + basename
       end
     end
 

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -146,14 +146,18 @@ module Pod
     #         module map.
     #
     def umbrella_header_path
-      support_files_dir + "#{label}-umbrella.h"
+      module_map_path.parent + "#{label}-umbrella.h"
     end
 
     # @return [Pathname] the absolute path of the LLVM module map file that
     #         defines the module structure for the compiler.
     #
     def module_map_path
-      support_files_dir + "#{product_module_name}.modulemap"
+      if requires_frameworks? || !respond_to?(:build_headers)
+        support_files_dir + "#{product_module_name}.modulemap"
+      else
+        build_headers.root + product_module_name + "#{label}.modulemap"
+      end
     end
 
     # @return [Pathname] the absolute path of the bridge support file.

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -155,7 +155,7 @@ module Pod
     #         defines the module structure for the compiler.
     #
     def module_map_path
-      support_files_dir + "#{label}.modulemap"
+      support_files_dir + 'module.modulemap'
     end
 
     # @return [Pathname] the absolute path of the bridge support file.

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -95,7 +95,9 @@ module Pod
     # @return [Boolean] Whether the target should build a static framework.
     #
     def static_framework?
-      !is_a?(Pod::AggregateTarget) && specs.any? && specs.flat_map(&:root).all?(&:static_framework)
+      return if is_a?(Pod::AggregateTarget)
+      return if specs.empty?
+      specs.all? { |spec| spec.root.static_framework }
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -158,11 +158,7 @@ module Pod
     #
     def module_map_path
       basename = "#{label}.modulemap"
-      if requires_frameworks? || !respond_to?(:build_headers)
-        support_files_dir + basename
-      else
-        build_headers.root + product_module_name + basename
-      end
+      support_files_dir + basename
     end
 
     # @return [Pathname] the absolute path of the bridge support file.

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -45,11 +45,7 @@ module Pod
     #         and #product_module_name or #label.
     #
     def product_basename
-      if requires_frameworks?
-        product_module_name
-      else
-        label
-      end
+      product_module_name
     end
 
     # @return [String] the name of the framework, depends on #label.
@@ -67,7 +63,7 @@ module Pod
     #       used for migration.
     #
     def static_library_name
-      "lib#{label}.a"
+      "lib#{product_module_name}.a"
     end
 
     # @return [Symbol] either :framework or :static_library, depends on

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -45,7 +45,11 @@ module Pod
     #         and #product_module_name or #label.
     #
     def product_basename
-      product_module_name
+      if requires_frameworks?
+        product_module_name
+      else
+        label
+      end
     end
 
     # @return [String] the name of the framework, depends on #label.
@@ -63,7 +67,7 @@ module Pod
     #       used for migration.
     #
     def static_library_name
-      "lib#{product_module_name}.a"
+      "lib#{label}.a"
     end
 
     # @return [Symbol] either :framework or :static_library, depends on

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -377,6 +377,20 @@ module Pod
       root_spec.name
     end
 
+    # @return [Pathname] the absolute path of the LLVM module map file that
+    #         defines the module structure for the compiler.
+    #
+    def module_map_path
+      basename = "#{label}.modulemap"
+      if requires_frameworks?
+        super
+      elsif file_accessors.any?(&:module_map)
+        build_headers.root + product_module_name + basename
+      else
+        sandbox.public_headers.root + product_module_name + basename
+      end
+    end
+
     # @param  [String] bundle_name
     #         The name of the bundle product, which is given by the +spec+.
     #

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -313,6 +313,11 @@ describe_cli 'pod' do
                             'install --no-repo-update'
     end
 
+    describe 'Integrates a pod with static swift libraries and objective c modules' do
+      behaves_like cli_spec 'install_static_swift_modules',
+                            'install --no-repo-update'
+    end
+
     describe 'Integrates a Pod with circular subspec dependencies' do
       behaves_like cli_spec 'install_circular_subspec_dependency',
                             'install --no-repo-update'

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -27,7 +27,7 @@ module Pod
       @pod_target.stubs(:requires_frameworks?).returns(false)
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
-        module BananaLib {
+        module BananaLib [system] {
           umbrella header "BananaLib-umbrella.h"
 
           export *

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -10,9 +10,24 @@ module Pod
 
     it 'writes the module map to the disk' do
       path = temporary_directory + 'BananaLib.modulemap'
+      @pod_target.stubs(:requires_frameworks?).returns(true)
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
         framework module BananaLib {
+          umbrella header "BananaLib-umbrella.h"
+
+          export *
+          module * { export * }
+        }
+      EOS
+    end
+
+    it 'writes the module map to the disk for a library' do
+      path = temporary_directory + 'BananaLib.modulemap'
+      @pod_target.stubs(:requires_frameworks?).returns(false)
+      @gen.save_as(path)
+      path.read.should == <<-EOS.strip_heredoc
+        module BananaLib {
           umbrella header "BananaLib-umbrella.h"
 
           export *

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -146,7 +146,7 @@ module Pod
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
-            expected = '$(inherited) -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
+            expected = '$(inherited) -fmodule-map-file="${PODS_ROOT}/Target Support Files/BananaLib/BananaLib.modulemap" -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
             @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
           end
 

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -146,6 +146,13 @@ module Pod
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
+            expected = "$(inherited) -isystem \"#{config.sandbox.public_headers.search_paths(Platform.ios).join('" -isystem "')}\""
+            @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
+          end
+
+          it 'adds the dependent pods module map file to OTHER_CFLAGS' do
+            @pod_targets.each { |pt| pt.stubs(:defines_module? => true) }
+            @xcconfig = @generator.generate
             expected = '$(inherited) -fmodule-map-file="${PODS_ROOT}/Headers/Private/BananaLib/BananaLib.modulemap" -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
             @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
           end

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -156,7 +156,7 @@ module Pod
             end
 
             it 'links the pod targets with the aggregate target' do
-              @xcconfig.to_hash['OTHER_LDFLAGS'].should.include '-l"BananaLib"'
+              @xcconfig.to_hash['OTHER_LDFLAGS'].should.include '-l"BananaLib-Pods"'
             end
           end
 

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -146,7 +146,7 @@ module Pod
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
-            expected = '$(inherited) -fmodule-map-file="${PODS_ROOT}/Target Support Files/BananaLib/BananaLib.modulemap" -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
+            expected = '$(inherited) -fmodule-map-file="${PODS_ROOT}/Headers/Private/BananaLib/BananaLib.modulemap" -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
             @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
           end
 
@@ -156,7 +156,7 @@ module Pod
             end
 
             it 'links the pod targets with the aggregate target' do
-              @xcconfig.to_hash['OTHER_LDFLAGS'].should.include '-l"BananaLib-Pods"'
+              @xcconfig.to_hash['OTHER_LDFLAGS'].should.include '-l"BananaLib"'
             end
           end
 

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -138,7 +138,7 @@ module Pod
           end
 
           it 'does not add root public or private header search paths to the xcconfig' do
-            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.be.empty
+            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.be.nil
           end
 
           it 'adds the COCOAPODS macro definition' do

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -270,7 +270,7 @@ module Pod
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Private/CoconutLib"' \
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
               ' "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/BananaLib/BananaLib"' \
               ' "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/CoconutLib/CoconutLib"' \
               ' "${PODS_ROOT}/Headers/Public/monkey" "${PODS_ROOT}/Headers/Public/monkey/monkey"'
@@ -288,7 +288,7 @@ module Pod
             # This is not an test xcconfig so it should exclude header search paths for the 'monkey' pod
             generator = PodXCConfig.new(@coconut_pod_target, false)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Private/CoconutLib"' \
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
               ' "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/BananaLib/BananaLib"' \
               ' "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/CoconutLib/CoconutLib"'
           end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -478,8 +478,8 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject-prefix.pch',
+                  'BananaLib-Pods-SampleProject.modulemap',
                   'BananaLib-Pods-SampleProject.xcconfig',
-                  'BananaLib.modulemap',
                 ]
               end
 
@@ -490,8 +490,8 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject-prefix.pch',
+                  'BananaLib-Pods-SampleProject.modulemap',
                   'BananaLib-Pods-SampleProject.xcconfig',
-                  'BananaLib.modulemap',
                 ]
               end
 
@@ -501,8 +501,8 @@ module Pod
                 group = @project['Pods/BananaLib/Support Files']
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
+                  'BananaLib-Pods-SampleProject.modulemap',
                   'BananaLib-Pods-SampleProject.xcconfig',
-                  'BananaLib.modulemap',
                 ]
               end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -478,7 +478,6 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject-prefix.pch',
-                  'BananaLib-Pods-SampleProject.modulemap',
                   'BananaLib-Pods-SampleProject.xcconfig',
                 ]
               end
@@ -490,7 +489,6 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject-prefix.pch',
-                  'BananaLib-Pods-SampleProject.modulemap',
                   'BananaLib-Pods-SampleProject.xcconfig',
                 ]
               end
@@ -501,6 +499,17 @@ module Pod
                 group = @project['Pods/BananaLib/Support Files']
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
+                  'BananaLib-Pods-SampleProject.xcconfig',
+                ]
+              end
+
+              it 'adds the module map when the target defines a module' do
+                @pod_target.stubs(:defines_module?).returns(true)
+                @installer.install!
+                group = @project['Pods/BananaLib/Support Files']
+                group.children.map(&:display_name).sort.should == [
+                  'BananaLib-Pods-SampleProject-dummy.m',
+                  'BananaLib-Pods-SampleProject-prefix.pch',
                   'BananaLib-Pods-SampleProject.modulemap',
                   'BananaLib-Pods-SampleProject.xcconfig',
                 ]
@@ -570,7 +579,6 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-dummy.m',
                   'BananaLib-prefix.pch',
-                  'BananaLib.modulemap',
                   'BananaLib.xcconfig',
                 ]
               end
@@ -581,6 +589,17 @@ module Pod
                 group = @project['Pods/BananaLib/Support Files']
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-dummy.m',
+                  'BananaLib.xcconfig',
+                ]
+              end
+
+              it 'adds the module map when the target defines a module' do
+                @pod_target.stubs(:defines_module?).returns(true)
+                @installer.install!
+                group = @project['Pods/BananaLib/Support Files']
+                group.children.map(&:display_name).sort.should == [
+                  'BananaLib-dummy.m',
+                  'BananaLib-prefix.pch',
                   'BananaLib.modulemap',
                   'BananaLib.xcconfig',
                 ]

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -479,6 +479,7 @@ module Pod
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject-prefix.pch',
                   'BananaLib-Pods-SampleProject.xcconfig',
+                  'BananaLib.modulemap',
                 ]
               end
 
@@ -490,6 +491,7 @@ module Pod
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject-prefix.pch',
                   'BananaLib-Pods-SampleProject.xcconfig',
+                  'BananaLib.modulemap',
                 ]
               end
 
@@ -500,6 +502,7 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject.xcconfig',
+                  'BananaLib.modulemap',
                 ]
               end
 
@@ -567,6 +570,7 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-dummy.m',
                   'BananaLib-prefix.pch',
+                  'BananaLib.modulemap',
                   'BananaLib.xcconfig',
                 ]
               end
@@ -577,6 +581,7 @@ module Pod
                 group = @project['Pods/BananaLib/Support Files']
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-dummy.m',
+                  'BananaLib.modulemap',
                   'BananaLib.xcconfig',
                 ]
               end

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -383,7 +383,7 @@ module Pod
             e.message.should.include <<-EOS.strip_heredoc.strip
               [!] The following swift pods cannot yet be integrated as static libraries:
 
-              The swift pod `OrangeFramework` depends upon matryoshka, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from swift when building as static libraries), you may add `'DEFINES_MODULE' => 'YES'` to those pods' `pod_target_xcconfig`.
+              The swift pod `OrangeFramework` depends upon `matryoshka`, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from swift when building as static libraries), you may add `'DEFINES_MODULE' => 'YES'` to those pods' `pod_target_xcconfig`.
             EOS
           end
 

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -359,26 +359,6 @@ module Pod
             lambda { @validator.validate! }.should.not.raise
           end
         end
-
-        #-------------------------------------------------------------------------#
-
-        describe '#verify_framework_usage' do
-          it 'raises when Swift pods are used without explicit `use_frameworks!`' do
-            fixture_path = ROOT + 'spec/fixtures'
-            config.repos_dir = fixture_path + 'spec-repos'
-            podfile = Pod::Podfile.new do
-              platform :ios, '8.0'
-              project 'SampleProject/SampleProject'
-              pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
-              pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
-              target 'SampleProject'
-            end
-            lockfile = generate_lockfile
-
-            @validator = create_validator(config.sandbox, podfile, lockfile)
-            should.raise(Informative) { @validator.validate! }.message.should.match /use_frameworks/
-          end
-        end
       end
     end
   end

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -383,7 +383,7 @@ module Pod
             e.message.should.include <<-EOS.strip_heredoc.strip
               [!] The following swift pods cannot yet be integrated as static libraries:
 
-              The swift pod `OrangeFramework` depends upon `matryoshka`, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from swift when building as static libraries), you may add `'DEFINES_MODULE' => 'YES'` to those pods' `pod_target_xcconfig`.
+              The swift pod `OrangeFramework` depends upon `matryoshka`, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from swift when building as static libraries), you may set `use_modular_header!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
             EOS
           end
 

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -433,7 +433,7 @@ module Pod
         end
 
         it 'returns the library name' do
-          @target.static_library_name.should == 'libPods-iOS Example.a'
+          @target.static_library_name.should == 'libPods_iOS_Example.a'
         end
 
         it 'returns :framework as product type' do

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -433,7 +433,7 @@ module Pod
         end
 
         it 'returns the library name' do
-          @target.static_library_name.should == 'libPods_iOS_Example.a'
+          @target.static_library_name.should == 'libPods-iOS Example.a'
         end
 
         it 'returns :framework as product type' do

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -48,7 +48,7 @@ module Pod
 
       it 'returns the name of its product' do
         @pod_target.product_name.should == 'libBananaLib.a'
-        @pod_target.scoped.first.product_name.should == 'libBananaLib-Pods.a'
+        @pod_target.scoped.first.product_name.should == 'libBananaLib.a'
       end
 
       it 'returns the spec consumers for the pod targets' do
@@ -225,9 +225,9 @@ module Pod
 
       it 'returns the path for the CONFIGURATION_BUILD_DIR build setting' do
         @pod_target.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/libBananaLib.a'
-        @pod_target.scoped.first.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-Pods/libBananaLib-Pods.a'
+        @pod_target.scoped.first.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-Pods/libBananaLib.a'
         @pod_target.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib/libBananaLib.a'
-        @pod_target.scoped.first.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib-Pods/libBananaLib-Pods.a'
+        @pod_target.scoped.first.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib-Pods/libBananaLib.a'
       end
 
       it 'returns prefix header path' do
@@ -369,7 +369,7 @@ module Pod
 
           it 'returns the library name' do
             @pod_target.static_library_name.should == 'libBananaLib.a'
-            @pod_target.scoped.first.static_library_name.should == 'libBananaLib-Pods.a'
+            @pod_target.scoped.first.static_library_name.should == 'libBananaLib.a'
           end
 
           it 'returns :framework as product type' do
@@ -388,7 +388,7 @@ module Pod
         describe 'Host does not requires frameworks' do
           it 'returns the product name' do
             @pod_target.product_name.should == 'libBananaLib.a'
-            @pod_target.scoped.first.product_name.should == 'libBananaLib-Pods.a'
+            @pod_target.scoped.first.product_name.should == 'libBananaLib.a'
           end
 
           it 'returns the framework name' do
@@ -397,7 +397,7 @@ module Pod
 
           it 'returns the library name' do
             @pod_target.static_library_name.should == 'libBananaLib.a'
-            @pod_target.scoped.first.static_library_name.should == 'libBananaLib-Pods.a'
+            @pod_target.scoped.first.static_library_name.should == 'libBananaLib.a'
           end
 
           it 'returns :static_library as product type' do
@@ -434,7 +434,7 @@ module Pod
 
         it 'returns the library name' do
           @pod_target.static_library_name.should == 'libOrangeFramework.a'
-          @pod_target.scoped.first.static_library_name.should == 'libOrangeFramework-Pods.a'
+          @pod_target.scoped.first.static_library_name.should == 'libOrangeFramework.a'
         end
 
         it 'returns :framework as product type' do

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -48,7 +48,7 @@ module Pod
 
       it 'returns the name of its product' do
         @pod_target.product_name.should == 'libBananaLib.a'
-        @pod_target.scoped.first.product_name.should == 'libBananaLib.a'
+        @pod_target.scoped.first.product_name.should == 'libBananaLib-Pods.a'
       end
 
       it 'returns the spec consumers for the pod targets' do
@@ -225,9 +225,9 @@ module Pod
 
       it 'returns the path for the CONFIGURATION_BUILD_DIR build setting' do
         @pod_target.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/libBananaLib.a'
-        @pod_target.scoped.first.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-Pods/libBananaLib.a'
+        @pod_target.scoped.first.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-Pods/libBananaLib-Pods.a'
         @pod_target.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib/libBananaLib.a'
-        @pod_target.scoped.first.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib-Pods/libBananaLib.a'
+        @pod_target.scoped.first.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib-Pods/libBananaLib-Pods.a'
       end
 
       it 'returns prefix header path' do
@@ -369,7 +369,7 @@ module Pod
 
           it 'returns the library name' do
             @pod_target.static_library_name.should == 'libBananaLib.a'
-            @pod_target.scoped.first.static_library_name.should == 'libBananaLib.a'
+            @pod_target.scoped.first.static_library_name.should == 'libBananaLib-Pods.a'
           end
 
           it 'returns :framework as product type' do
@@ -388,7 +388,7 @@ module Pod
         describe 'Host does not requires frameworks' do
           it 'returns the product name' do
             @pod_target.product_name.should == 'libBananaLib.a'
-            @pod_target.scoped.first.product_name.should == 'libBananaLib.a'
+            @pod_target.scoped.first.product_name.should == 'libBananaLib-Pods.a'
           end
 
           it 'returns the framework name' do
@@ -397,7 +397,7 @@ module Pod
 
           it 'returns the library name' do
             @pod_target.static_library_name.should == 'libBananaLib.a'
-            @pod_target.scoped.first.static_library_name.should == 'libBananaLib.a'
+            @pod_target.scoped.first.static_library_name.should == 'libBananaLib-Pods.a'
           end
 
           it 'returns :static_library as product type' do
@@ -434,7 +434,7 @@ module Pod
 
         it 'returns the library name' do
           @pod_target.static_library_name.should == 'libOrangeFramework.a'
-          @pod_target.scoped.first.static_library_name.should == 'libOrangeFramework.a'
+          @pod_target.scoped.first.static_library_name.should == 'libOrangeFramework-Pods.a'
         end
 
         it 'returns :framework as product type' do


### PR DESCRIPTION
Closes #6899.

- [x] Examples that build static swift
- [x] New integration specs
- [x] Validator to ensure no swift pod targets depend upon built targets that don't define modules
- [x] CHANGELOG entry
- [x] Allow enabling/disabling module map generation for all pods in a target from the Podfile
- [x] Allow enabling/disabling module map generation for one pod in a target from the Podfile
- [x] Move the generated umbrella header to be in the public headers directory rather than private headers?