### PR TITLE
Add Private Header support to static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#6811](https://github.com/CocoaPods/CocoaPods/pull/6811)
 
+* Add Private Header support to static frameworks
+  [paulb777](https://github.com/paulb777)
+  [#6969](https://github.com/CocoaPods/CocoaPods/issues/6969)
+
 ##### Bug Fixes
 
 * Wrap platform warning message with quotes  

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -85,6 +85,7 @@ module Pod
               settings['PRODUCT_NAME'] = framework_name
               if target.static_framework?
                 settings['PUBLIC_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/Headers'
+                settings['PRIVATE_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/PrivateHeaders'
               end
             else
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -72,6 +72,18 @@ module Pod
               'AppStore' => 'BananaLib.framework/Headers',
             }
           end
+
+          it 'verify private header path for a static library framework' do
+            @pod_target.stubs(:requires_frameworks?).returns(true)
+            @pod_target.stubs(:static_framework?).returns(true)
+            @installer.send(:add_target)
+            @installer.send(:native_target).resolved_build_setting('PRIVATE_HEADERS_FOLDER_PATH').should == {
+              'Release' => 'BananaLib.framework/PrivateHeaders',
+              'Debug' => 'BananaLib.framework/PrivateHeaders',
+              'Test' => 'BananaLib.framework/PrivateHeaders',
+              'AppStore' => 'BananaLib.framework/PrivateHeaders',
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
While working on migrating Firebase to static frameworks, I discovered that I didn't set up Private Header support correctly for static frameworks.  Here it is.