### PR TITLE
Fix OTHER_LDFLAGS for projects including source static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,17 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   dependency resolution.  
   [Samuel Giddins](https://github.com/segiddins)
 
-* Add support for source static library frameworks
+* Add support for source static library frameworks  
   [Paul Beusterien](https://github.com/paulb777)
   [#6811](https://github.com/CocoaPods/CocoaPods/pull/6811)
 
-* Add Private Header support to static frameworks
+* Add Private Header support to static frameworks  
   [Paul Beusterien](https://github.com/paulb777)
   [#6969](https://github.com/CocoaPods/CocoaPods/pull/6969)
+
+* For source static frameworks, include frameworks from dependent targets and libraries in OTHER_LDFLAGS  
+  [paulb777](https://github.com/paulb777)
+  [#6988](https://github.com/CocoaPods/CocoaPods/pull/6988)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -170,11 +170,11 @@ module Pod
         #  - `@import …;` / `import …`
         #
         def generate_settings_to_import_pod_targets
-          @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, pod_targets)
+          @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, pod_targets)
           @xcconfig.merge!(settings_to_import_pod_targets)
           target.search_paths_aggregate_targets.each do |search_paths_target|
             generator = AggregateXCConfig.new(search_paths_target, configuration_name)
-            @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(nil, search_paths_target.pod_targets)
+            @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(nil, search_paths_target.pod_targets)
             @xcconfig.merge!(generator.settings_to_import_pod_targets)
           end
         end

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -70,10 +70,10 @@ module Pod
           end
           XCConfigHelper.add_target_specific_settings(target, @xcconfig)
           recursive_dependent_targets = target.recursive_dependent_targets
-          @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, recursive_dependent_targets, @test_xcconfig)
+          @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, recursive_dependent_targets, @test_xcconfig)
           if @test_xcconfig
             test_dependent_targets = [target, *target.recursive_test_dependent_targets].uniq
-            @xcconfig.merge! XCConfigHelper.settings_for_dependent_targets(target, test_dependent_targets - recursive_dependent_targets, @test_xcconfig)
+            @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, test_dependent_targets - recursive_dependent_targets, @test_xcconfig)
             XCConfigHelper.generate_vendored_build_settings(nil, target.all_test_dependent_targets, @xcconfig)
             XCConfigHelper.generate_other_ld_flags(nil, target.all_test_dependent_targets, @xcconfig)
             XCConfigHelper.generate_ld_runpath_search_paths(target, false, true, @xcconfig)


### PR DESCRIPTION
- Include source static framework library dependencies in aggregate target builds
- Set -framework option for dependent targets in aggregate target builds when there are source static frameworks

I suspect that the -framework option change should be made more broadly and that -framework should be set in concert with updating the FRAMEWORK_SEARCH_PATH, but I'm making the conservative change of only impacting projects that include source static frameworks.

In addition to the unit tests, these changes have been tested with [Firebase](https://github.com/firebase/firebase-ios-sdk/tree/pb-future).