### PR TITLE
Fix xcconfig boolean merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Danielle Tomlinson](https://github.com/dantoml)
   [#6971](https://github.com/CocoaPods/CocoaPods/issue/6971)
 
+* Fix xcconfig boolean merging when substrings include yes or no  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#6997](https://github.com/CocoaPods/CocoaPods/pull/6997)
 
 ## 1.3.1 (2017-08-02)
 

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -218,7 +218,7 @@ module Pod
           settings = user_target_xcconfig_values_by_consumer_by_key
           settings.each_with_object({}) do |(key, values_by_consumer), xcconfig|
             uniq_values = values_by_consumer.values.uniq
-            values_are_bools = uniq_values.all? { |v| v =~ /(yes|no)/i }
+            values_are_bools = uniq_values.all? { |v| v =~ /^(yes|no)$/i }
             if values_are_bools
               # Boolean build settings
               if uniq_values.count > 1

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -412,6 +412,13 @@ module Pod
                 '["BananaLib", "OrangeFramework"]. Boolean build setting '\
                 'ENABLE_HEADER_DEPENDENCIES has different values.'
             end
+
+            it 'make sure "no" or "yes" substring doesnt get treated as boolean' do
+              @consumer_a.stubs(:user_target_xcconfig).returns('GCC_PREPROCESSOR_DEFINITIONS' => '-DNOWAY')
+              @consumer_b.stubs(:user_target_xcconfig).returns('GCC_PREPROCESSOR_DEFINITIONS' => '-DYESWAY')
+              @xcconfig = @generator.generate
+              @xcconfig.to_hash['GCC_PREPROCESSOR_DEFINITIONS'].should == '$(inherited) COCOAPODS=1 -DNOWAY -DYESWAY'
+            end
           end
 
           describe 'with list build settings' do


### PR DESCRIPTION
The xcconfig merge boolean checking wasn't tight enough and causing two _GCC_PREPROCESSOR_DEFINITIONS_ that both had a substring "NO" to cause it to be treated as a boolean and failing to do the merge after generating the warning. 

See the new unit test for an example.