### PR TITLE
Filter out subset dependent targets from FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#6811](https://github.com/CocoaPods/CocoaPods/pull/6811)
 
 * Add Private Header support to static frameworks
-  [paulb777](https://github.com/paulb777)
-  [#6969](https://github.com/CocoaPods/CocoaPods/issues/6969)
+  [Paul Beusterien](https://github.com/paulb777)
+  [#6969](https://github.com/CocoaPods/CocoaPods/pull/6969)
 
 ##### Bug Fixes
 
@@ -41,6 +41,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Fix xcconfig boolean merging when substrings include yes or no  
   [Paul Beusterien](https://github.com/paulb777)
   [#6997](https://github.com/CocoaPods/CocoaPods/pull/6997)
+
+* Filter out subset dependent targets from FRAMEWORK_SEARCH_PATHS  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7002](https://github.com/CocoaPods/CocoaPods/pull/7002)
 
 ## 1.3.1 (2017-08-02)
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -273,6 +273,17 @@ module Pod
         def self.settings_for_dependent_targets(target, dependent_targets, test_xcconfig = false)
           dependent_targets = dependent_targets.select(&:should_build?)
 
+          # Filter out dependent targets that are subsets of another target.
+          subset_targets = []
+          dependent_targets.combination(2) do |a, b|
+            if (a.specs - b.specs).empty?
+              subset_targets << a
+            elsif (b.specs - a.specs).empty?
+              subset_targets << b
+            end
+          end
+          dependent_targets -= subset_targets
+
           # Alias build dirs to avoid recursive definitions for pod targets and depending
           # on build settings which could be overwritten in the user target.
           build_settings = {

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -63,6 +63,24 @@ module Pod
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-l"xml2"'
           end
 
+          it 'check that subspec subsets are removed from frameworks search paths' do
+            target1 = stub(
+              :specs => %w(A, B),
+              :should_build? => true,
+              :requires_frameworks? => true,
+              :configuration_build_dir => 'AB',
+            )
+            target2 = stub(
+              :specs => ['B'],
+              :should_build? => true,
+              :requires_frameworks? => true,
+              :configuration_build_dir => 'B',
+            )
+            dependent_targets = [target1, target2]
+            build_settings = @sut.settings_for_dependent_targets(nil, dependent_targets)
+            build_settings['FRAMEWORK_SEARCH_PATHS'].should == '"AB"'
+          end
+
           it 'adds the frameworks of the xcconfig' do
             xcconfig = Xcodeproj::Config.new
             consumer = stub(


### PR DESCRIPTION
When multiple build targets in a workspace have dependencies on different subspecs of another pod, builds can fail if the subset build has already been done and the framework search path occurs first on the command line.

This PR fixes the issue by removing the redundant subset subspecs from FRAMEWORK_SEARCH_PATHS. See the fixed issue #6967 for more details and a reproducible example.