### PR TITLE
Propagate HEADER_SEARCH_PATHS settings from search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#7002](https://github.com/CocoaPods/CocoaPods/pull/7002)
 
+* Propagate HEADER_SEARCH_PATHS settings from search paths  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7006](https://github.com/CocoaPods/CocoaPods/pull/7006)
+
 ## 1.3.1 (2017-08-02)
 
 ##### Enhancements

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -176,6 +176,9 @@ module Pod
             generator = AggregateXCConfig.new(search_paths_target, configuration_name)
             @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(nil, search_paths_target.pod_targets)
             @xcconfig.merge!(generator.settings_to_import_pod_targets)
+
+            # Propagate any HEADER_SEARCH_PATHS settings from the search paths.
+            XCConfigHelper.propagate_header_search_paths_from_search_paths(search_paths_target, @xcconfig)
           end
         end
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -321,6 +321,32 @@ module Pod
           build_settings
         end
 
+        # Updates xcconfig with the HEADER_SEARCH_PATHS from the search_paths.
+        #
+        # @param  [Target] search_paths_target
+        #         The target.
+        #
+        # @param  [Xcodeproj::Config] xcconfig
+        #         The xcconfig to edit.
+        #
+        def self.propagate_header_search_paths_from_search_paths(search_paths_target, xcconfig)
+          header_search_paths_list = []
+          search_paths_target.pod_targets.each do |target|
+            target.spec_consumers.each do |spec_consumer|
+              paths = spec_consumer.user_target_xcconfig['HEADER_SEARCH_PATHS']
+              header_search_paths_list <<= paths unless paths.nil?
+            end
+            unless header_search_paths_list == []
+              header_search_paths = header_search_paths_list.join(' ')
+              unless header_search_paths.include? '$(inherited)'
+                header_search_paths = '$(inherited) ' + header_search_paths
+              end
+              build_settings = { 'HEADER_SEARCH_PATHS' => header_search_paths }
+              xcconfig.merge!(build_settings)
+            end
+          end
+        end
+
         # Add custom build settings and required build settings to link to
         # vendored libraries and frameworks.
         #

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -161,6 +161,18 @@ module Pod
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-framework "Foo"'
           end
 
+          it 'includes HEADER_SEARCH_PATHS from search paths' do
+            xcconfig = Xcodeproj::Config.new
+            spec_consumer = stub(:user_target_xcconfig => { 'HEADER_SEARCH_PATHS' => 'my/path' })
+            pod_target = stub(:spec_consumers => [spec_consumer])
+            search_path_target = stub(
+              :pod_targets_for_build_configuration => [pod_target],
+              :pod_targets => [pod_target],
+            )
+            @sut.propagate_header_search_paths_from_search_paths(search_path_target, xcconfig)
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) my/path'
+          end
+
           it 'adds the frameworks of the xcconfig' do
             xcconfig = Xcodeproj::Config.new
             consumer = stub(


### PR DESCRIPTION
For targets that  _inherit! :search_paths_, propagate HEADER_SEARCH_PATHS from _user_target_xcconfig_, in addition to propagating the FRAMEWORK_SEARCH_PATHS.

This fixes #6891 and https://github.com/firebase/firebase-ios-sdk/issues/58