### PR TITLE
Ensure a unique ID is generated for each resource bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Ensure a unique ID is generated for each resource bundle
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#7015](https://github.com/CocoaPods/CocoaPods/pull/7015)
+
 * Do not include settings from file accessors of test specs into aggregate xcconfigs  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7019](https://github.com/CocoaPods/CocoaPods/pull/7019)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -226,7 +226,6 @@ module Pod
                 bundle_target.product_reference.tap do |bundle_product|
                   bundle_file_name = "#{bundle_name}.bundle"
                   bundle_product.name = bundle_file_name
-                  bundle_product.path = bundle_file_name
                 end
 
                 filter_resource_file_references(paths) do |resource_phase_refs, compile_phase_refs|

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -400,7 +400,7 @@ module Pod
                 it 'adds the resource bundle targets' do
                   @bundle_target.should.be.an.instance_of Xcodeproj::Project::Object::PBXNativeTarget
                   @bundle_target.product_reference.name.should == 'banana_bundle.bundle'
-                  @bundle_target.product_reference.path.should == 'banana_bundle.bundle'
+                  @bundle_target.product_reference.path.should == 'BananaLib-Pods-SampleProject-banana_bundle.bundle'
                   @bundle_target.platform_name.should == :ios
                   @bundle_target.deployment_target.should == '4.3'
                 end
@@ -468,7 +468,7 @@ module Pod
                 it 'adds the resource bundle targets' do
                   @bundle_target.should.be.an.instance_of Xcodeproj::Project::Object::PBXNativeTarget
                   @bundle_target.product_reference.name.should == 'banana_bundle.bundle'
-                  @bundle_target.product_reference.path.should == 'banana_bundle.bundle'
+                  @bundle_target.product_reference.path.should == 'BananaLib-banana_bundle.bundle'
                 end
 
                 it 'adds the build configurations to the resources bundle targets' do


### PR DESCRIPTION
🌈

Resource bundles can be processed multiple times across different pod targets with the same spec activated, but different subspec dependencies.

Example:
  Spec/Subspec1 has a resource bundle SubspecResources
  Spec/Subspec2 has a dependency on Spec/Subspec1
  Target1 depends on Spec/Subspec1
  Target2 depends on Spec/Subspec2 (which activates Spec/Subspec1 as a dependency)
  Both Target1 & Target2 try to integrate SubspecResources

Tested with and without the change and verified that the count of `FooResources.bundle` was 2 without the fix. This causes warnings to appear when using deterministic UUIDs for duplicate references in a valid scenario.