### PR TITLE
App Icons not included in build from Xcode 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Filter out subset dependent targets from FRAMEWORK_SEARCH_PATHS  
   [Paul Beusterien](https://github.com/paulb777)
   [#7002](https://github.com/CocoaPods/CocoaPods/pull/7002)
+  
+* Fix App Icons compilation in build from Xcode 9  
+  [Timofey Khomutnikov](https://github.com/khomTima)
+  [#7003](https://github.com/CocoaPods/CocoaPods/issues/7003)
 
 * Propagate HEADER_SEARCH_PATHS settings from search paths  
   [Paul Beusterien](https://github.com/paulb777)

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -204,7 +204,7 @@ then
     fi
   done <<<"$OTHER_XCASSETS"
 
-  printf "%s\\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+  printf "%s\\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}" --app-icon "${ASSETCATALOG_COMPILER_APPICON_NAME}" --output-partial-info-plist "${TARGET_BUILD_DIR}/assetcatalog_generated_info.plist"
 fi
 EOS
     end


### PR DESCRIPTION
Fix #7003
A little research has shown a possible problem:
At first xcode compiles assets in the "Copy Bundle Resources" build step using --app-icon argument.
After that, in step "[CP] Copy Pods Resources" Pods-your_project_name-resources.sh compiles assets from dependencies without --app-icon argument and overwrites Assets.car
Fix: Add --app-icon argument to the assets compilation command in Pods-your_project_name-resources.sh with the appropriate catalog and plist file.