### PR TITLE
Don't codesign :osx test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Ensure a unique ID is generated for each resource bundle
+* Do not code sign OSX targets for testing bundles  
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#7027](https://github.com/CocoaPods/CocoaPods/pull/7027)
+
+* Ensure a unique ID is generated for each resource bundle  
   [Justin Martin](https://github.com/justinseanmartin)
   [#7015](https://github.com/CocoaPods/CocoaPods/pull/7015)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -199,8 +199,8 @@ module Pod
                 # requires frameworks. For tests we always use the test target name as the product name
                 # irrelevant to whether we use frameworks or not.
                 configuration.build_settings['PRODUCT_NAME'] = name
-                # We need to codesign the contents of xctest bundles for Xcode to allow them to be launchable
-                configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'YES'
+                # We must codesign iOS XCTest bundles that contain binary frameworks to allow them to be launchable in the simulator
+                configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'YES' unless target.platform == :osx
               end
 
               # Test native targets also need frameworks and resources to be copied over to their xctest bundle.


### PR DESCRIPTION
🌈

It turns out that we need to only sign iOS XCTest bundles for them to be launched within the simulator, but not OSX ones being run on the local machine. I've verified now that both iOS and OSX test bundles appear to work correctly in the same conditions.

This regression was introduced by #7013.