### PR TITLE
Fix common paths sometimes calculating incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix common paths sometimes calculating incorrectly  
+  [amorde](https://github.com/amorde)
+  [#7028](https://github.com/CocoaPods/CocoaPods/pull/7028)
+
 * Do not code sign OSX targets for testing bundles  
   [Justin Martin](https://github.com/justinseanmartin)
   [#7027](https://github.com/CocoaPods/CocoaPods/pull/7027)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -242,7 +242,7 @@ module Pod
           end
 
           # Returns a Pathname of the nearest parent from which all the given paths descend.
-          # Converts each Pathname to a string and finds the longest common prefix
+          # Converts each Pathname to a list of path components and finds the longest common prefix
           #
           # @param  [Array<Pathname>] paths
           #         The paths to files or directories on disk. Must be absolute paths
@@ -258,10 +258,12 @@ module Pod
               path.dirname.to_s
             end
             min, max = strs.minmax
+            min = min.split('/')
+            max = max.split('/')
             idx = min.size.times { |i| break i if min[i] != max[i] }
-            result = Pathname.new(min[0...idx])
+            result = Pathname.new(min[0...idx].join('/'))
             # Don't consider "/" a common path
-            return result unless result.to_s == '/'
+            return result unless result.to_s == '' || result.to_s == '/'
           end
 
           # Computes the destination sub-directory in the sandbox

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -252,6 +252,18 @@ module Pod
                 result.should == Pathname.new('/Base/Sub/A')
               end
 
+              it 'compares path components instead of string prefixes' do
+                paths = [
+                  '/Base/Sub/A/1.txt',
+                  '/Base/Sub/AA/2.txt',
+                  '/Base/Sub/AAA/B/1.txt',
+                  '/Base/Sub/AAAA/B/2.txt',
+                  '/Base/Sub/AAAAA/D/E/1.txt',
+                ].map { |p| Pathname.new(p) }
+                result = @installer.send(:common_path, paths)
+                result.should == Pathname.new('/Base/Sub')
+              end
+
               it 'should not consider root \'/\' a common path' do
                 paths = [
                   '/A/B/C',


### PR DESCRIPTION
Closes #6979

I was only able to test with my own project which reproduced the issue, but am unsure about the originally submitted bug.

I was comparing the entire path as a string instead of the components, which was what was originally intended. I added a test case for it to (hopefully) prevent a future regression.