### PR TITLE
Do not force include master spec repo if plugin sources are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Do not force include the master spec repo if plugins provide sources  
+  [Eric Amorde](https://github.com/amorde)
+  [#7033](https://github.com/CocoaPods/CocoaPods/pull/7033)
+
 * Add custom shell script integration from Podfile  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#6820](https://github.com/CocoaPods/CocoaPods/pull/6820)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -140,11 +140,11 @@ module Pod
       end
     end
 
+    # @return [Analyzer] The analyzer used to resolve dependencies
+    #
     def resolve_dependencies
-      analyzer = create_analyzer
-
       plugin_sources = run_source_provider_hooks
-      analyzer.sources.insert(0, *plugin_sources)
+      analyzer = create_analyzer(plugin_sources)
 
       UI.section 'Updating local specs repositories' do
         analyzer.update_repositories
@@ -155,6 +155,7 @@ module Pod
         validate_build_configurations
         clean_sandbox
       end
+      analyzer
     end
 
     def download_dependencies
@@ -243,8 +244,8 @@ module Pod
       @aggregate_targets = analyzer.result.targets
     end
 
-    def create_analyzer
-      Analyzer.new(sandbox, podfile, lockfile).tap do |analyzer|
+    def create_analyzer(plugin_sources = nil)
+      Analyzer.new(sandbox, podfile, lockfile, plugin_sources).tap do |analyzer|
         analyzer.installation_options = installation_options
         analyzer.has_dependencies = has_dependencies?
       end


### PR DESCRIPTION
Closes #5306

Noticed this issue still open so thought I'd take a stab at it. I am interested if this is still a desired change, as it could possibly break some projects that were relying on master being included automatically