### PR TITLE
Deduplicate test specs correctly from pod variants and targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Deduplicate test specs correctly from pod variants and targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7036](https://github.com/CocoaPods/CocoaPods/pull/7036)
+
 * Fix common paths sometimes calculating incorrectly  
   [amorde](https://github.com/amorde)
   [#7028](https://github.com/CocoaPods/CocoaPods/pull/7028)

--- a/lib/cocoapods/installer/analyzer/pod_variant.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant.rb
@@ -7,6 +7,10 @@ module Pod
         #
         attr_accessor :specs
 
+        # @return [Array<Specification>] the test specs for the target
+        #
+        attr_accessor :test_specs
+
         # @return [Platform] the platform
         #
         attr_accessor :platform
@@ -24,16 +28,21 @@ module Pod
 
         # Initialize a new instance from its attributes.
         #
-        # @param [Array<String>] specs       @see #specs
-        # @param [Platform] platform         @see #platform
-        # @param [Bool] requires_frameworks  @see #requires_frameworks?
+        # @param [Array<Specification>] specs      @see #specs
+        # @param [Array<Specification>] test_specs @see #test_specs
+        # @param [Platform] platform               @see #platform
+        # @param [Bool] requires_frameworks        @see #requires_frameworks?
         #
-        def initialize(specs, platform, requires_frameworks = false)
+        def initialize(specs, test_specs, platform, requires_frameworks = false)
           self.specs = specs
+          self.test_specs = test_specs
           self.platform = platform
           self.requires_frameworks = requires_frameworks
         end
 
+        # @note Test specs are intentionally not included as part of the equality for pod variants since a
+        #       pod variant should not be affected by the number of test specs included.
+        #
         # @return [Bool] whether the {PodVariant} is equal to another taking all
         #         all their attributes into account
         #

--- a/spec/unit/installer/analyzer/pod_variant_set_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_set_spec.rb
@@ -14,46 +14,46 @@ module Pod
       PodVariant = Pod::Installer::Analyzer::PodVariant.freeze
 
       it 'returns an empty scope if there is only one variant' do
-        variants = PodVariantSet.new([PodVariant.new([@root_spec], Platform.ios)])
+        variants = PodVariantSet.new([PodVariant.new([@root_spec], [], Platform.ios)])
         variants.scope_suffixes.values.should == [nil]
       end
 
       it 'returns scopes by built types if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec], Platform.ios, true),
-          PodVariant.new([@root_spec], Platform.ios, false),
+          PodVariant.new([@root_spec], [], Platform.ios, true),
+          PodVariant.new([@root_spec], [], Platform.ios, false),
         ])
         variants.scope_suffixes.values.should == %w(framework library)
       end
 
       it 'returns scopes by platform names if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec], Platform.ios),
-          PodVariant.new([@root_spec], Platform.osx),
+          PodVariant.new([@root_spec], [], Platform.ios),
+          PodVariant.new([@root_spec], [], Platform.osx),
         ])
         variants.scope_suffixes.values.should == %w(iOS macOS)
       end
 
       it 'returns scopes by versioned platform names if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec], Platform.ios),
-          PodVariant.new([@root_spec], Platform.new(:ios, '7.0')),
+          PodVariant.new([@root_spec], [], Platform.ios),
+          PodVariant.new([@root_spec], [], Platform.new(:ios, '7.0')),
         ])
         variants.scope_suffixes.values.should == %w(iOS iOS7.0)
       end
 
       it 'returns scopes by subspec names if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@foo_subspec], Platform.ios),
-          PodVariant.new([@bar_subspec], Platform.ios),
+          PodVariant.new([@foo_subspec], [], Platform.ios),
+          PodVariant.new([@bar_subspec], [], Platform.ios),
         ])
         variants.scope_suffixes.values.should == %w(Foo Bar)
       end
 
       it 'returns scopes by subspec names if they qualify and handle partial root spec presence well' do
         variants = PodVariantSet.new([
-          PodVariant.new([@foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @bar_subspec], Platform.ios),
+          PodVariant.new([@foo_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @bar_subspec], [], Platform.ios),
         ])
         variants.scope_suffixes.values.should == %w(Foo .root-Bar)
       end
@@ -61,36 +61,36 @@ module Pod
       it 'allows to differentiate between an exclusive variant with a specific subspec and ' \
         'an inclusive variant with the default subspecs plus a non-default subspec' do
         variants = PodVariantSet.new([
-          PodVariant.new([@foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
+          PodVariant.new([@foo_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], Platform.ios),
         ])
         variants.scope_suffixes.values.should == %w(Foo .default-Foo)
       end
 
       it 'omits default specs' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], [], Platform.ios),
         ])
         variants.scope_suffixes.values.should == [nil, '.default-Foo', '.default-Bar']
       end
 
       it 'omits common specs' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec, @inner_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @inner_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @inner_subspec, @bar_subspec], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @inner_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @inner_subspec, @foo_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @inner_subspec, @bar_subspec], [], Platform.ios),
         ])
         variants.scope_suffixes.values.should == %w(.common .common-Foo .common-Bar)
       end
 
       it 'returns scopes by platform names and subspec names if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], [], Platform.osx),
         ])
         variants.scope_suffixes.values.should == %w(
           iOS
@@ -103,10 +103,10 @@ module Pod
       it 'hashes scopes that are longer than 50 characters' do
         @bar_subspec.name = 'matryoshka/ThisIsAReallyLongSubspecName'
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec, @bar_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec, @bar_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], [], Platform.osx),
         ])
         variants.scope_suffixes.values.should == %w(
           iOS
@@ -118,12 +118,12 @@ module Pod
 
       it 'returns scopes by versioned platform names and subspec names if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec], Platform.new(:ios, '7.0')),
-          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], Platform.osx),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.osx),
-          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.new(:ios, '7.0')),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], Platform.osx),
+          PodVariant.new([@root_spec, @default_subspec, @bar_subspec], [], Platform.osx),
         ])
         variants.scope_suffixes.values.should == %w(
           iOS7.0
@@ -137,10 +137,10 @@ module Pod
 
       it 'returns scopes by built types, versioned platform names and subspec names' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec, @default_subspec], Platform.new(:ios, '7.0')),
-          PodVariant.new([@root_spec, @default_subspec], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], Platform.osx, true),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], Platform.osx, true),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.new(:ios, '7.0')),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], [], Platform.osx, true),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], Platform.osx, true),
         ])
         variants.scope_suffixes.values.should == %w(
           library-iOS7.0

--- a/spec/unit/installer/analyzer/pod_variant_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_spec.rb
@@ -6,18 +6,19 @@ module Pod
       describe PodVariant do
         before do
           @specs = [stub('Spec'), stub('Spec/Foo')]
+          @testspecs = [stub('Spec/Tests')]
           @platform = Platform.ios
         end
 
         it 'can be initialized with specs and platform' do
-          variant = PodVariant.new(@specs, @platform)
+          variant = PodVariant.new(@specs, [], @platform)
           variant.specs.should == @specs
           variant.platform.should == @platform
           variant.requires_frameworks.should == false
         end
 
         it 'can be initialized with specs, platform and whether it requires frameworks' do
-          variant = PodVariant.new(@specs, @platform, true)
+          variant = PodVariant.new(@specs, [], @platform, true)
           variant.specs.should == @specs
           variant.platform.should == @platform
           variant.requires_frameworks.should == true
@@ -25,26 +26,32 @@ module Pod
 
         it 'can return the root spec' do
           spec = fixture_spec('banana-lib/BananaLib.podspec')
-          variant = PodVariant.new([spec], Platform.ios)
+          variant = PodVariant.new([spec], [], Platform.ios)
           variant.root_spec.should == spec
         end
 
         it 'can be compared for equality with another variant with the same specs, platform, and whether it requires frameworks' do
-          spec = PodVariant.new(@specs, @platform, false)
-          spec.should == PodVariant.new(@specs, @platform, false)
-          spec.should.not == PodVariant.new([@specs.first], @platform)
-          spec.should.not == PodVariant.new(@specs, Platform.osx, false)
-          spec.should.not == PodVariant.new(@specs, @platform, true)
+          spec = PodVariant.new(@specs, [], @platform, false)
+          spec.should == PodVariant.new(@specs, [], @platform, false)
+          spec.should.not == PodVariant.new([@specs.first], [], @platform)
+          spec.should.not == PodVariant.new(@specs, [], Platform.osx, false)
+          spec.should.not == PodVariant.new(@specs, [], @platform, true)
         end
 
         it 'can be used as hash keys' do
-          k0 = PodVariant.new(@specs, @platform, false)
+          k0 = PodVariant.new(@specs, [], @platform, false)
           v0 = stub('Value at index 0')
-          k1 = PodVariant.new(@specs, @platform, true)
+          k1 = PodVariant.new(@specs, [], @platform, true)
           v1 = stub('Value at index 1')
           hash = { k0 => v0, k1 => v1 }
           hash[k0].should == v0
           hash[k1].should == v1
+        end
+
+        it 'does not use testspecs for equality' do
+          k0 = PodVariant.new(@specs, @testspecs, @platform, false)
+          k1 = PodVariant.new(@specs, [], @platform, false)
+          k0.should == k1
         end
       end
     end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -245,6 +245,31 @@ module Pod
             matryoshka/Outer/Inner
           )
         end
+
+        it 'does not create multiple variants across different targets that require different set of testspecs' do
+          @podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            platform :ios, '8.0'
+            project 'SampleProject/SampleProject'
+
+            target 'TestRunner' do
+              pod 'CoconutLib', :testspecs => ['Tests']
+            end
+
+            target 'SampleProject' do
+              pod 'CoconutLib'
+            end
+          end
+          @analyzer = Pod::Installer::Analyzer.new(config.sandbox, @podfile, nil)
+          result = @analyzer.analyze
+
+          result.targets.count.should == 2
+          result.targets[0].pod_targets.count == 1
+          result.targets[0].pod_targets[0].name.should == 'CoconutLib'
+          result.targets[1].pod_targets.count == 1
+          result.targets[1].pod_targets[0].name.should == 'CoconutLib'
+          result.targets[0].pod_targets[0].should == result.targets[1].pod_targets[0]
+        end
       end
 
       describe 'deduplication' do


### PR DESCRIPTION
Given the following scenario:

```ruby
target 'MyApp'
  pod 'PodA', :testspecs => ['Tests']
end

target 'MyApp2'
  pod 'PodA'
end
```

This generates two variants of `PodA` one called `PodA` and one more called `PodA.root` but with the exact same sources. This is because testspecs were taken into consideration for the uniqueness of a `pod_variant.rb` within `analyzer.rb`

This is no longer the case. The number of test specs asked should not matter for the generation of a pod variant. Pod variants should vary across platform, subspecs and whether they require frameworks or not.

Tase case and change depends on https://github.com/CocoaPods/cocoapods-test-specs/pull/1