### PR TITLE
Add support for preventing pch file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add support for preventing pch file generation with the skip_pch podspec attribute  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7044](https://github.com/CocoaPods/CocoaPods/pull/7044)
 
 ##### Bug Fixes
 
@@ -42,7 +44,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#6969](https://github.com/CocoaPods/CocoaPods/pull/6969)
 
 * For source static frameworks, include frameworks from dependent targets and libraries in OTHER_LDFLAGS  
-  [paulb777](https://github.com/paulb777)
+  [Paul Beusterien](https://github.com/paulb777)
   [#6988](https://github.com/CocoaPods/CocoaPods/pull/6988)
 
 ##### Bug Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 811811b839932dd5aeb02dc90dfb55db89c6bedd
+  revision: 283ac03a69984faab02c03ad65871966f7581481
   branch: master
   specs:
     cocoapods-core (1.4.0.beta.1)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -45,12 +45,20 @@ module Pod
                   create_build_phase_to_move_static_framework_archive
                 end
               end
-              create_prefix_header
+              unless skip_pch?
+                create_prefix_header
+              end
               create_dummy_source
             end
           end
 
           private
+
+          # @return [Boolean] Whether the target should build a pch file.
+          #
+          def skip_pch?
+            target.specs.any? { |spec| spec.prefix_header_file.is_a?(FalseClass) }
+          end
 
           # Remove the default headers folder path settings for static library pod
           # targets.

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -417,9 +417,6 @@ module Pod
                   'BananaLib-Pods-SampleProject-prefix.pch',
                   'BananaLib-Pods-SampleProject.xcconfig',
                 ]
-                group.children.map(&:display_name).sort.should.not == [
-                  'BananaLib-Pods-SampleProject-prefix.pch',
-                ]
               end
 
               it 'verifies disabling prefix header generation' do
@@ -429,9 +426,6 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-Pods-SampleProject-dummy.m',
                   'BananaLib-Pods-SampleProject.xcconfig',
-                ]
-                group.children.map(&:display_name).sort.should.not == [
-                  'BananaLib-Pods-SampleProject-prefix.pch',
                 ]
               end
 
@@ -510,9 +504,6 @@ module Pod
                 group.children.map(&:display_name).sort.should == [
                   'BananaLib-dummy.m',
                   'BananaLib.xcconfig',
-                ]
-                group.children.map(&:display_name).sort.should.not == [
-                  'BananaLib-prefix.pch',
                 ]
               end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -408,6 +408,33 @@ module Pod
                 ]
               end
 
+              it 'verifies keeping prefix header generation' do
+                @pod_target.specs.first.stubs(:prefix_header_file).returns(true)
+                @installer.install!
+                group = @project['Pods/BananaLib/Support Files']
+                group.children.map(&:display_name).sort.should == [
+                  'BananaLib-Pods-SampleProject-dummy.m',
+                  'BananaLib-Pods-SampleProject-prefix.pch',
+                  'BananaLib-Pods-SampleProject.xcconfig',
+                ]
+                group.children.map(&:display_name).sort.should.not == [
+                  'BananaLib-Pods-SampleProject-prefix.pch',
+                ]
+              end
+
+              it 'verifies disabling prefix header generation' do
+                @pod_target.specs.first.stubs(:prefix_header_file).returns(false)
+                @installer.install!
+                group = @project['Pods/BananaLib/Support Files']
+                group.children.map(&:display_name).sort.should == [
+                  'BananaLib-Pods-SampleProject-dummy.m',
+                  'BananaLib-Pods-SampleProject.xcconfig',
+                ]
+                group.children.map(&:display_name).sort.should.not == [
+                  'BananaLib-Pods-SampleProject-prefix.pch',
+                ]
+              end
+
               it 'adds the target for the static library to the project' do
                 @installer.install!
                 @project.targets.count.should == 1
@@ -473,6 +500,19 @@ module Pod
                   'BananaLib-dummy.m',
                   'BananaLib-prefix.pch',
                   'BananaLib.xcconfig',
+                ]
+              end
+
+              it 'verifies disabling prefix header generation' do
+                @pod_target.specs.first.stubs(:prefix_header_file).returns(false)
+                @installer.install!
+                group = @project['Pods/BananaLib/Support Files']
+                group.children.map(&:display_name).sort.should == [
+                  'BananaLib-dummy.m',
+                  'BananaLib.xcconfig',
+                ]
+                group.children.map(&:display_name).sort.should.not == [
+                  'BananaLib-prefix.pch',
                 ]
               end
 


### PR DESCRIPTION
See also https://github.com/CocoaPods/Core/pull/406.

Prevent pch file generation with the skip_pch podspec attribute.

Address #1691 and #1746. More context at https://stackoverflow.com/questions/44401464/is-there-a-way-to-disable-the-default-pch-file-in-cocoapods