### PR TITLE
Wrap `$PODS_CONFIGURATION_BUILD_DIR` and `$PODS_BUILD_DIR` with curlies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7037](https://github.com/CocoaPods/CocoaPods/pull/7037)
 
+* Wrap `$PODS_CONFIGURATION_BUILD_DIR` and `$PODS_BUILD_DIR` with curlies  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7048](https://github.com/CocoaPods/CocoaPods/pull/7048)
+
 * Fix common paths sometimes calculating incorrectly  
   [amorde](https://github.com/amorde)
   [#7028](https://github.com/CocoaPods/CocoaPods/pull/7028)

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -11,7 +11,7 @@ module Pod
         #         this variable to point to the standard directory, which
         #         will be used by CocoaPods.
         #
-        BUILD_DIR_VARIABLE = '$PODS_BUILD_DIR'.freeze
+        BUILD_DIR_VARIABLE = '${PODS_BUILD_DIR}'.freeze
 
         # @return [String] Used as alias for CONFIGURATION_BUILD_DIR, so that
         #         when this is overridden per {PodTarget}, it is still possible
@@ -20,7 +20,7 @@ module Pod
         #         the user can override this variable to point to the standard
         #         directory, which will be used by CocoaPods.
         #
-        CONFIGURATION_BUILD_DIR_VARIABLE = '$PODS_CONFIGURATION_BUILD_DIR'.freeze
+        CONFIGURATION_BUILD_DIR_VARIABLE = '${PODS_CONFIGURATION_BUILD_DIR}'.freeze
 
         # Converts an array of strings to a single string where the each string
         # is surrounded by double quotes and separated by a space. Used to
@@ -296,8 +296,8 @@ module Pod
           # Alias build dirs to avoid recursive definitions for pod targets and depending
           # on build settings which could be overwritten in the user target.
           build_settings = {
-            BUILD_DIR_VARIABLE[1..-1] => '$BUILD_DIR',
-            CONFIGURATION_BUILD_DIR_VARIABLE[1..-1] => "#{BUILD_DIR_VARIABLE}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+            BUILD_DIR_VARIABLE[2..-2] => '${BUILD_DIR}',
+            CONFIGURATION_BUILD_DIR_VARIABLE[2..-2] => "#{BUILD_DIR_VARIABLE}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
           }
 
           # Scope pod targets as long as they are not test targets.

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -86,11 +86,11 @@ module Pod
           end
 
           it 'sets the PODS_BUILD_DIR build variable' do
-            @xcconfig.to_hash['PODS_BUILD_DIR'].should == '$BUILD_DIR'
+            @xcconfig.to_hash['PODS_BUILD_DIR'].should == '${BUILD_DIR}'
           end
 
           it 'sets the PODS_CONFIGURATION_BUILD_DIR build variable' do
-            @xcconfig.to_hash['PODS_CONFIGURATION_BUILD_DIR'].should == '$PODS_BUILD_DIR/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)'
+            @xcconfig.to_hash['PODS_CONFIGURATION_BUILD_DIR'].should == '${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)'
           end
 
           it 'adds the COCOAPODS macro definition' do
@@ -198,12 +198,12 @@ module Pod
             end
 
             it 'does not include framework header paths as local headers for pods that are linked statically' do
-              monkey_headers = '-iquote "$PODS_CONFIGURATION_BUILD_DIR/monkey.framework/Headers"'
+              monkey_headers = '-iquote "${PODS_CONFIGURATION_BUILD_DIR}/monkey.framework/Headers"'
               @xcconfig.to_hash['OTHER_CFLAGS'].should.not.include monkey_headers
             end
 
             it 'includes the public header paths as system headers' do
-              expected = '$(inherited) -iquote "$PODS_CONFIGURATION_BUILD_DIR/OrangeFramework/OrangeFramework.framework/Headers" -isystem "${PODS_ROOT}/Headers/Public"'
+              expected = '$(inherited) -iquote "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework/OrangeFramework.framework/Headers" -isystem "${PODS_ROOT}/Headers/Public"'
               @generator.stubs(:pod_targets).returns([@pod_targets.first, pod_target(fixture_spec('orange-framework/OrangeFramework.podspec'), @target_definition)])
               @xcconfig = @generator.generate
               @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
@@ -242,22 +242,22 @@ module Pod
             end
 
             it 'adds the framework build path to the xcconfig, with quotes, as framework search paths' do
-              @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "$PODS_CONFIGURATION_BUILD_DIR/BananaLib-iOS" "$PODS_CONFIGURATION_BUILD_DIR/OrangeFramework-iOS"'
+              @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-iOS" "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework-iOS"'
             end
 
             it 'adds the framework header paths to the xcconfig, with quotes, as local headers' do
-              expected = '$(inherited) -iquote "$PODS_CONFIGURATION_BUILD_DIR/BananaLib-iOS/BananaLib.framework/Headers" -iquote "$PODS_CONFIGURATION_BUILD_DIR/OrangeFramework-iOS/OrangeFramework.framework/Headers"'
+              expected = '$(inherited) -iquote "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-iOS/BananaLib.framework/Headers" -iquote "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework-iOS/OrangeFramework.framework/Headers"'
               @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
             end
           end
 
           describe 'with an unscoped pod target' do
             it 'adds the framework build path to the xcconfig, with quotes, as framework search paths' do
-              @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "$PODS_CONFIGURATION_BUILD_DIR/OrangeFramework"'
+              @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework"'
             end
 
             it 'adds the framework header paths to the xcconfig, with quotes, as local headers' do
-              expected = '$(inherited) -iquote "$PODS_CONFIGURATION_BUILD_DIR/OrangeFramework/OrangeFramework.framework/Headers"'
+              expected = '$(inherited) -iquote "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework/OrangeFramework.framework/Headers"'
               @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
             end
           end

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -106,15 +106,15 @@ module Pod
           end
 
           it 'sets the PODS_BUILD_DIR build variable' do
-            @xcconfig.to_hash['PODS_BUILD_DIR'].should == '$BUILD_DIR'
+            @xcconfig.to_hash['PODS_BUILD_DIR'].should == '${BUILD_DIR}'
           end
 
           it 'sets the PODS_CONFIGURATION_BUILD_DIR build variable' do
-            @xcconfig.to_hash['PODS_CONFIGURATION_BUILD_DIR'].should == '$PODS_BUILD_DIR/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)'
+            @xcconfig.to_hash['PODS_CONFIGURATION_BUILD_DIR'].should == '${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)'
           end
 
           it 'sets the CONFIGURATION_BUILD_DIR build variable' do
-            @xcconfig.to_hash['CONFIGURATION_BUILD_DIR'].should.be == '$PODS_CONFIGURATION_BUILD_DIR/BananaLib'
+            @xcconfig.to_hash['CONFIGURATION_BUILD_DIR'].should.be == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib'
           end
 
           it 'will be skipped when installing' do
@@ -202,7 +202,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "$PODS_CONFIGURATION_BUILD_DIR/BananaLib" "$PODS_CONFIGURATION_BUILD_DIR/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
           end
 
           it 'adds settings for test dependent targets excluding the parents targets' do
@@ -211,7 +211,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "$PODS_CONFIGURATION_BUILD_DIR/BananaLib" "$PODS_CONFIGURATION_BUILD_DIR/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
           end
 
           it 'does not include other ld flags for test dependent targets if its not a test xcconfig' do

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -301,16 +301,16 @@ module Pod
 
         it 'adds copy pods resources input and output paths' do
           resource_paths_by_config = {
-            'Debug' => ['$PODS_CONFIGURATION_BUILD_DIR/DebugLib/DebugLib.bundle'],
-            'Release' => ['$PODS_CONFIGURATION_BUILD_DIR/ReleaseLib/ReleaseLib.bundle'],
+            'Debug' => ['${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLib.bundle'],
+            'Release' => ['${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.bundle'],
           }
           @pod_bundle.stubs(:resource_paths_by_config => resource_paths_by_config)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @copy_pods_resources_phase_name }
           phase.input_paths.sort.should == %w(
-            $PODS_CONFIGURATION_BUILD_DIR/DebugLib/DebugLib.bundle
-            $PODS_CONFIGURATION_BUILD_DIR/ReleaseLib/ReleaseLib.bundle
+            ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLib.bundle
+            ${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.bundle
             ${SRCROOT}/../Pods/Target\ Support\ Files/Pods/Pods-resources.sh
           )
           phase.output_paths.sort.should == %w(${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH})

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -160,8 +160,8 @@ module Pod
               )
               resources_by_config = @target.resource_paths_by_config
               resources_by_config.each_value do |resources|
-                resources.should.include '$PODS_CONFIGURATION_BUILD_DIR/BananaLib/Trees.bundle'
-                resources.should.include '$PODS_CONFIGURATION_BUILD_DIR/BananaLib/Leafs.bundle'
+                resources.should.include '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/Trees.bundle'
+                resources.should.include '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/Leafs.bundle'
               end
             end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -170,15 +170,15 @@ module Pod
       end
 
       it 'returns the path for the CONFIGURATION_BUILD_DIR build setting' do
-        @pod_target.configuration_build_dir.should == '$PODS_CONFIGURATION_BUILD_DIR/BananaLib'
-        @pod_target.scoped.first.configuration_build_dir.should == '$PODS_CONFIGURATION_BUILD_DIR/BananaLib-Pods'
-        @pod_target.configuration_build_dir('$PODS_BUILD_DIR').should == '$PODS_BUILD_DIR/BananaLib'
-        @pod_target.scoped.first.configuration_build_dir('$PODS_BUILD_DIR').should == '$PODS_BUILD_DIR/BananaLib-Pods'
+        @pod_target.configuration_build_dir.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib'
+        @pod_target.scoped.first.configuration_build_dir.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-Pods'
+        @pod_target.configuration_build_dir('${PODS_BUILD_DIR}').should == '${PODS_BUILD_DIR}/BananaLib'
+        @pod_target.scoped.first.configuration_build_dir('${PODS_BUILD_DIR}').should == '${PODS_BUILD_DIR}/BananaLib-Pods'
       end
 
       it 'returns the path for the CONFIGURATION_BUILD_DIR build setting' do
-        @pod_target.build_product_path.should == '$PODS_CONFIGURATION_BUILD_DIR/BananaLib/libBananaLib.a'
-        @pod_target.scoped.first.build_product_path.should == '$PODS_CONFIGURATION_BUILD_DIR/BananaLib-Pods/libBananaLib-Pods.a'
+        @pod_target.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/libBananaLib.a'
+        @pod_target.scoped.first.build_product_path.should == '${PODS_CONFIGURATION_BUILD_DIR}/BananaLib-Pods/libBananaLib-Pods.a'
         @pod_target.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib/libBananaLib.a'
         @pod_target.scoped.first.build_product_path('$BUILT_PRODUCTS_DIR').should == '$BUILT_PRODUCTS_DIR/BananaLib-Pods/libBananaLib-Pods.a'
       end
@@ -373,7 +373,7 @@ module Pod
           fa.stubs(:resources).returns([])
           fa.stubs(:spec).returns(stub(:test_specification? => true))
           @test_pod_target.stubs(:file_accessors).returns([fa])
-          @test_pod_target.resource_paths.should == ['$PODS_CONFIGURATION_BUILD_DIR/TestResourceBundle.bundle']
+          @test_pod_target.resource_paths.should == ['${PODS_CONFIGURATION_BUILD_DIR}/TestResourceBundle.bundle']
         end
 
         it 'includes framework paths from test specifications' do


### PR DESCRIPTION
This is consistent with everything else that uses variables by cocoapods but also fixes an issue where sometimes Xcode stomps the input paths due to the lack of `{}` around the env variable.
