### PR TITLE
Added '-verbose' flag to xcodebuild for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [paulb777](https://github.com/paulb777)
   [#6988](https://github.com/CocoaPods/CocoaPods/pull/6988)
 
+* Added '-verbose' flag to xcodebuild for validation  
+  [abbeycode](https://github.com/abbeycode)
+  [#7040](https://github.com/CocoaPods/CocoaPods/issues/7040)
+
 ##### Bug Fixes
 
 * Fix common paths sometimes calculating incorrectly  

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -857,6 +857,10 @@ module Pod
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)
       end
 
+      if config.verbose
+        command += ' -verbose'
+      end
+
       output, status = _xcodebuild(command)
 
       unless status.success?

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -857,7 +857,7 @@ module Pod
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)
       end
 
-      command += ' -verbose' if config.verbose?
+      command += [' -verbose'] if config.verbose?
 
       output, status = _xcodebuild(command)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -857,9 +857,7 @@ module Pod
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)
       end
 
-      if config.verbose
-        command += ' -verbose'
-      end
+      command += ' -verbose' if config.verbose?
 
       output, status = _xcodebuild(command)
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -535,7 +535,7 @@ module Pod
         Executable.stubs(:capture_command).with('git', ['config', '--get', 'remote.origin.url'], :capture => :out).returns(['https://github.com/CocoaPods/Specs.git'])
         Executable.stubs(:which).with(:xcrun)
         config.verbose = true
-        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', 'CODE_SIGN_IDENTITY=']#, '-verbose']
+        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', 'CODE_SIGN_IDENTITY=', '-verbose']
         Executable.expects(:capture_command).with('xcodebuild', command).once
         validator.validate
       end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -536,7 +536,7 @@ module Pod
         Executable.stubs(:which).with(:xcrun)
         config.verbose = true
         command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', 'CODE_SIGN_IDENTITY=', '-verbose']
-        Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
+        Executable.expects(:capture_command).with('xcodebuild', command).once
         validator.validate
       end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -523,6 +523,23 @@ module Pod
         validator.validate
       end
 
+      it 'passes the -verbose flag on to xcodebuild when --verbose passed to validator' do
+        require 'fourflusher'
+        Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
+        Validator.any_instance.unstub(:xcodebuild)
+        validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
+        validator.stubs(:check_file_patterns)
+        validator.stubs(:validate_url)
+        git = Executable.which(:git)
+        Executable.stubs(:which).with('git').returns(git)
+        Executable.stubs(:capture_command).with('git', ['config', '--get', 'remote.origin.url'], :capture => :out).returns(['https://github.com/CocoaPods/Specs.git'])
+        Executable.stubs(:which).with(:xcrun)
+        config.verbose = true
+        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', %w(CODE_SIGN_IDENTITY=), '-verbose']
+        Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
+        validator.validate
+      end
+
       it 'sets the -Wincomplete-umbrella compiler flag for pod targets' do
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.no_clean = true

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -535,7 +535,7 @@ module Pod
         Executable.stubs(:capture_command).with('git', ['config', '--get', 'remote.origin.url'], :capture => :out).returns(['https://github.com/CocoaPods/Specs.git'])
         Executable.stubs(:which).with(:xcrun)
         config.verbose = true
-        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', %w(CODE_SIGN_IDENTITY=), '-verbose']
+        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', 'CODE_SIGN_IDENTITY=', '-verbose']
         Executable.expects(:capture_command).with('xcodebuild', command, :capture => :merge).once.returns(['', stub(:success? => true)])
         validator.validate
       end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -535,7 +535,7 @@ module Pod
         Executable.stubs(:capture_command).with('git', ['config', '--get', 'remote.origin.url'], :capture => :out).returns(['https://github.com/CocoaPods/Specs.git'])
         Executable.stubs(:which).with(:xcrun)
         config.verbose = true
-        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', 'CODE_SIGN_IDENTITY=', '-verbose']
+        command = ['clean', 'build', '-workspace', File.join(validator.validation_dir, 'App.xcworkspace'), '-scheme', 'App', '-configuration', 'Release', 'CODE_SIGN_IDENTITY=']#, '-verbose']
         Executable.expects(:capture_command).with('xcodebuild', command).once
         validator.validate
       end


### PR DESCRIPTION
This will provide more diagnostic output for when validation is failing, or in my case, hopefully prevent the CI build to fail due to no output for a certain interval (Issue #7040).