### PR TITLE
Build subspecs in static frameworks without error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Build subspecs in static frameworks without error  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7058](https://github.com/CocoaPods/CocoaPods/pull/7058)
 
 
 ## 1.4.0.beta.1 (2017-09-24)

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -93,7 +93,7 @@ module Pod
     # @return [Boolean] Whether the target should build a static framework.
     #
     def static_framework?
-      !is_a?(Pod::AggregateTarget) && specs.any? && specs.all?(&:static_framework)
+      !is_a?(Pod::AggregateTarget) && specs.any? && specs.flat_map(&:root).all?(&:static_framework)
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/fixtures/matryoshka/matryoshka.podspec
+++ b/spec/fixtures/matryoshka/matryoshka.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.homepage         = "http://httpbin.org/html"
   s.source           = { :git => "http://malyutin.local/matryoshka.git", :tag => s.version.to_s }
   s.license          = 'MIT'
+  s.static_framework = true
 
   s.source_files = 'Outmost.{h,m}'
 
@@ -26,5 +27,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'Bar' do |ss|
     ss.source_files = 'Bar/Bar.{h,m}'
+    ss.dependency 'monkey'
   end
 end

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -181,6 +181,31 @@ module Pod
           end
         end
 
+        describe '#verify_no_static_framework_transitive_dependencies_with_static_framework' do
+          before do
+            fixture_path = ROOT + 'spec/fixtures'
+            config.repos_dir = fixture_path + 'spec-repos'
+            @podfile = Pod::Podfile.new do
+              install! 'cocoapods', 'integrate_targets' => false
+              platform :ios, '8.0'
+              project 'SampleProject/SampleProject'
+              use_frameworks!
+              pod 'matryoshka/Bar',  :path => (fixture_path + 'matryoshka').to_s
+              pod 'monkey',          :path => (fixture_path + 'monkey').to_s
+              target 'SampleProject'
+            end
+            @lockfile = generate_lockfile
+
+            @file = Pathname('/yolo.m')
+            @file.stubs(:realpath).returns(@file)
+          end
+
+          it 'allows transitive static dependencies when building a static framework' do
+            @validator = create_validator(config.sandbox, @podfile, @lockfile)
+            should.not.raise(Informative) { @validator.send :verify_no_static_framework_transitive_dependencies }
+          end
+        end
+
         #-------------------------------------------------------------------------#
 
         describe '#verify_no_pods_used_with_multiple_swift_versions' do


### PR DESCRIPTION
podspecs with subspecs that included the `static_framework` attribute were generating transitive errors even though they would build correctly.

This PR fixes that issue by checking the static_framework attribute from the outermost spec instead of the subspec itself.

The issue was reported at https://github.com/CocoaPods/CocoaPods/pull/6811#issuecomment-331628583.
