### PR TITLE
Remove automatic script phase re-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Remove automatic script phase re-ordering  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7065](https://github.com/CocoaPods/CocoaPods/issues/7065)
+
 * Build subspecs in static frameworks without error  
   [Paul Beusterien](https://github.com/paulb777)
   [#7058](https://github.com/CocoaPods/CocoaPods/pull/7058)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -287,16 +287,6 @@ module Pod
               phase.output_paths = td_script_phase[:output_files] if td_script_phase.key?(:output_files)
               phase.show_env_vars_in_log = td_script_phase[:show_env_vars_in_log] ? '1' : '0' if td_script_phase.key?(:show_env_vars_in_log)
             end
-
-            # Move script phases to their correct index if the order has changed.
-            offset = native_target.build_phases.count - target_definition_script_phases.count
-            target_definition_script_phases.each_with_index do |td_script_phase, index|
-              current_index = native_target.build_phases.index do |bp|
-                bp.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && bp.name.sub(USER_BUILD_PHASE_PREFIX, '') == td_script_phase[:name]
-              end
-              expected_index = offset + index
-              native_target.build_phases.insert(expected_index, native_target.build_phases.delete_at(current_index)) if current_index != expected_index
-            end
           end
         end
 

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -388,34 +388,6 @@ module Pod
           target.shell_script_build_phases.find { |bp| bp.name == @user_script_phase_name }.should.be.nil
         end
 
-        it 'moves custom shell scripts to their correct index' do
-          shell_script_one = { :name => 'Custom Script', :script => 'echo "Hello World"' }
-          shell_script_two = { :name => 'Custom Script 2', :script => 'echo "Hello Aliens"' }
-          @pod_bundle.target_definition.stubs(:script_phases).returns([shell_script_one, shell_script_two])
-          @target_integrator.integrate!
-          target = @target_integrator.send(:native_targets).first
-          target.shell_script_build_phases.map(&:name).should == [
-            '[CP] Check Pods Manifest.lock',
-            '[CP] Embed Pods Frameworks',
-            '[CP] Copy Pods Resources',
-            '[CP-User] Custom Script',
-            '[CP-User] Custom Script 2',
-          ]
-          shell_script_one_uuid = target.shell_script_build_phases[3].uuid
-          shell_script_two_uuid = target.shell_script_build_phases[4].uuid
-          @pod_bundle.target_definition.stubs(:script_phases).returns([shell_script_two, shell_script_one])
-          @target_integrator.integrate!
-          target.shell_script_build_phases.map(&:name).should == [
-            '[CP] Check Pods Manifest.lock',
-            '[CP] Embed Pods Frameworks',
-            '[CP] Copy Pods Resources',
-            '[CP-User] Custom Script 2',
-            '[CP-User] Custom Script',
-          ]
-          target.shell_script_build_phases[3].uuid.should == shell_script_two_uuid
-          target.shell_script_build_phases[4].uuid.should == shell_script_one_uuid
-        end
-
         it 'adds, removes and moves custom shell script phases' do
           shell_script_one = { :name => 'Custom Script', :script => 'echo "Hello World"' }
           shell_script_two = { :name => 'Custom Script 2', :script => 'echo "Hello Aliens"' }


### PR DESCRIPTION
closes #7065 

Switching the order between two script phases in the Podfile should not matter and ultimately up to the user to decide (by dragging manually) the order in which they want the script phases to run.

CocoaPods will be responsible for adding a new script phase, updating an existing one or deleting the ones that were removed.