### PR TITLE
Fix framework and resources paths caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix framework and resources paths caching  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7068](https://github.com/CocoaPods/CocoaPods/pull/7068)
+
 * Build subspecs in static frameworks without error  
   [Paul Beusterien](https://github.com/paulb777)
   [#7058](https://github.com/CocoaPods/CocoaPods/pull/7058)


### PR DESCRIPTION
I followed https://www.justinweiss.com/articles/4-simple-memoization-patterns-in-ruby-and-one-gem/ for memoizing with parameters which does not seem to work.

I didn't want to spend enough time so I went back to a more "standard" way. 

No need for specs since this is already covered and the existing tests still pass.