### PR TITLE
Ensure `SYMROOT` is properly set for all user configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#7058](https://github.com/CocoaPods/CocoaPods/pull/7058)
 
+* Ensure `SYMROOT` is properly set for all user configurations  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7081](https://github.com/CocoaPods/CocoaPods/issues/7081)
 
 ## 1.4.0.beta.1 (2017-09-24)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -124,6 +124,8 @@ module Pod
             analysis_result.all_user_build_configurations.each do |name, type|
               @project.add_build_configuration(name, type)
             end
+            # Reset symroot just in case the user has added a new build configuration other than 'Debug' or 'Release'.
+            @project.symroot = Pod::Project::LEGACY_BUILD_ROOT
 
             pod_names = pod_targets.map(&:pod_name).uniq
             pod_names.each do |pod_name|

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -55,7 +55,7 @@ module Pod
             @generator = @installer.send(:create_generator)
           end
 
-          describe 'Preparing' do
+          describe '#prepare' do
             before do
               @generator.send(:prepare)
             end
@@ -69,6 +69,13 @@ module Pod
               @generator.project.build_settings('Test')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
               @generator.project.build_settings('Release')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
               @generator.project.build_settings('App Store')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
+            end
+
+            it 'sets the SYMROOT to the default value for all configurations for the whole project' do
+              @generator.project.build_settings('Debug')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+              @generator.project.build_settings('Test')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+              @generator.project.build_settings('Release')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+              @generator.project.build_settings('App Store')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
             end
 
             it 'creates the Pods project' do


### PR DESCRIPTION
closes #7081, #7047, #7084 

When `pods_project_generator.rb` calls for `prepare` and initializes a new `project.rb` we set the `SYMROOT` automatically to all build configurations. However, at that time the user specified configs have not been set and miss this setting.

We now re-apply the `SYMROOT` setting after we've added all build configurations (including the user ones).