### PR TITLE
fix bug : can’t filter xcassets in pods root dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Build subspecs in static frameworks without error  
   [Paul Beusterien](https://github.com/paulb777)
   [#7058](https://github.com/CocoaPods/CocoaPods/pull/7058)
+  
+* fix bug : can’t filter xcassets in pods root dir  
+  [grittymindy](https://github.com/grittymindy)
+  [#7087](https://github.com/CocoaPods/CocoaPods/issues/7087)
 
 
 ## 1.4.0.beta.1 (2017-09-24)

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -199,7 +199,7 @@ then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
   OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)
   while read line; do
-    if [[ $line != "${PODS_ROOT}*" ]]; then
+    if [[ $line != ${PODS_ROOT}* ]]; then
       XCASSET_FILES+=("$line")
     fi
   done <<<"$OTHER_XCASSETS"


### PR DESCRIPTION
fix issue #7087 