### PR TITLE
Do not set a `CODE_SIGN_IDENTITY` for macOS app hosts or xctest bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7104](https://github.com/CocoaPods/CocoaPods/pull/7104)
 
+* Do not set a `CODE_SIGN_IDENTITY` for macOS app hosts or xctest bundles
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7103](https://github.com/CocoaPods/CocoaPods/pull/7103)
+
 * Fix framework and resources paths caching  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7068](https://github.com/CocoaPods/CocoaPods/pull/7068)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -200,6 +200,7 @@ module Pod
                   configuration.build_settings.merge!(custom_build_settings)
                   configuration.build_settings['PRODUCT_NAME'] = name
                   configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+                  configuration.build_settings['CODE_SIGN_IDENTITY'] = '' if target.platform == :osx
                 end
                 Pod::Generator::AppTargetHelper.add_app_host_main_file(project, app_host_target, platform_name, name)
                 app_host_info_plist_path = project.path.dirname.+("#{name}/Info.plist")
@@ -248,6 +249,8 @@ module Pod
                 configuration.build_settings['PRODUCT_NAME'] = name
                 # We must codesign iOS XCTest bundles that contain binary frameworks to allow them to be launchable in the simulator
                 configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'YES' unless target.platform == :osx
+                # For macOS we do not code sign the XCTest bundle because we do not code sign the frameworks either.
+                configuration.build_settings['CODE_SIGN_IDENTITY'] = '' if target.platform == :osx
               end
 
               # Test native targets also need frameworks and resources to be copied over to their xctest bundle.

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -200,6 +200,7 @@ module Pod
                 native_test_target.build_configurations.each do |bc|
                   bc.build_settings['PRODUCT_NAME'].should == 'CoconutLib-Unit-Tests'
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should == 'YES'
+                  bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
                 end
                 native_test_target.symbol_type.should == :unit_test_bundle
                 @coconut_pod_target.test_native_targets.count.should == 1
@@ -215,6 +216,7 @@ module Pod
                 native_test_target.build_configurations.each do |bc|
                   bc.build_settings['PRODUCT_NAME'].should == 'CoconutLib-Unit-Tests'
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should.be.nil
+                  bc.build_settings['CODE_SIGN_IDENTITY'].should == ''
                 end
                 native_test_target.symbol_type.should == :unit_test_bundle
                 @coconut_pod_target2.test_native_targets.count.should == 1


### PR DESCRIPTION
`validator.rb` sets `CODE_SIGN_IDENTITY` to nothing when lint occurs. This matches this case and fixes issues with code signing app hosts or macOS bundles.