### PR TITLE
Build pod targets with script phases and integrate them properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Build pod targets with script phases and integrate them properly  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7104](https://github.com/CocoaPods/CocoaPods/pull/7104)
+
 * Fix framework and resources paths caching  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7068](https://github.com/CocoaPods/CocoaPods/pull/7068)

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -180,10 +180,10 @@ module Pod
         end
 
         def integrate_targets
-          pod_targets_with_test_targets = pod_targets.reject { |pt| pt.test_native_targets.empty? }
-          unless pod_targets_with_test_targets.empty?
+          pod_targets_to_integrate = pod_targets.select { |pt| !pt.test_native_targets.empty? || pt.contains_script_phases? }
+          unless pod_targets_to_integrate.empty?
             UI.message '- Integrating targets' do
-              pod_targets_with_test_targets.each do |pod_target|
+              pod_targets_to_integrate.each do |pod_target|
                 PodTargetIntegrator.new(pod_target).integrate!
               end
             end

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -163,7 +163,7 @@ module Pod
       @should_build = begin
         source_files = file_accessors.flat_map(&:source_files)
         source_files -= file_accessors.flat_map(&:headers)
-        !source_files.empty?
+        !source_files.empty? || contains_script_phases?
       end
     end
 
@@ -183,6 +183,12 @@ module Pod
           file_accessor.source_files.any? { |sf| sf.extname == '.swift' }
         end
       end
+    end
+
+    # @return [Boolean] Whether the target contains any script phases.
+    #
+    def contains_script_phases?
+      !spec_consumers.map(&:script_phases).flatten.empty?
     end
 
     # @return [Hash{Array => Specification}] a hash where the keys are the test native targets and the value

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -109,6 +109,15 @@ module Pod
 
         @pod_target.should_build?.should == false
       end
+
+      it 'builds a pod target if there are no actual source files but there are script phases' do
+        fa = Sandbox::FileAccessor.new(nil, @pod_target)
+        fa.stubs(:source_files).returns([Pathname.new('foo.h')])
+        @pod_target.stubs(:file_accessors).returns([fa])
+        @pod_target.root_spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
+
+        @pod_target.should_build?.should == true
+      end
     end
 
     describe 'target version' do
@@ -330,6 +339,21 @@ module Pod
           it 'resolves the cycle' do
             @pod_target.recursive_dependent_targets.should == [@pod_dependency]
           end
+        end
+      end
+
+      describe 'script phases support' do
+        before do
+          @pod_target = fixture_pod_target('coconut-lib/CoconutLib.podspec')
+        end
+
+        it 'returns false if it does not contain test specifications' do
+          @pod_target.contains_script_phases?.should == false
+        end
+
+        it 'returns true if it contains test specifications' do
+          @pod_target.root_spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
+          @pod_target.contains_script_phases?.should == true
         end
       end
 


### PR DESCRIPTION
Fixes two issues.

1) A podspec without any sources would not even add a target even if it had a script phase or not. Now this is fixed.
2) A pod target integrator was not being created unless the pod target had test specs in it. This is a bug since we still need to integrate targets that have script phases.

Both issues fixed.