### PR TITLE
Avoid 'Unspecified' value for SWIFT_VERSION build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7081](https://github.com/CocoaPods/CocoaPods/issues/7081)
 
+* Avoid 'Unspecificed' value for SWIFT_VERSION build settings and make 'Swift 3.2' the default value
+  [Victor Hugo Barros](https://github.com/heyzooi)
+  [#7109](https://github.com/CocoaPods/CocoaPods/issues/7109)
+
 ## 1.4.0.beta.1 (2017-09-24)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7081](https://github.com/CocoaPods/CocoaPods/issues/7081)
 
-* Avoid 'Unspecificed' value for SWIFT_VERSION build settings and make 'Swift 3.2' the default value
+* Avoid 'Unspecified' value for SWIFT_VERSION build settings and make 'Swift 3.2' the default value
   [Victor Hugo Barros](https://github.com/heyzooi)
   [#7109](https://github.com/CocoaPods/CocoaPods/issues/7109)
 

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -312,7 +312,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
+++ b/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
@@ -344,7 +344,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.Resource-Bundle-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.2;
 			};
 			name = Debug;
 		};
@@ -358,7 +358,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.Resource-Bundle-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.2;
 			};
 			name = Release;
 		};

--- a/examples/TestInclusions/Podfile
+++ b/examples/TestInclusions/Podfile
@@ -3,7 +3,7 @@ project 'TestInclusions.xcodeproj'
 platform :ios, '6.0'
 
 abstract_target 'TestInclusionsPods' do
-    pod 'SwrveConversationSDK', '~> 4.3.0'
+    pod 'SwrveConversationSDK', '~> 4.11.4'
 
     target 'TestInclusions'
     target 'TestInclusionsTests'

--- a/examples/TestInclusions/TestInclusions/Base.lproj/Main.storyboard
+++ b/examples/TestInclusions/TestInclusions/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <deployment version="1792" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,9 +18,9 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
+++ b/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
@@ -572,7 +572,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.vu0.watchOSsample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -585,7 +585,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.vu0.watchOSsample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -99,8 +99,9 @@ module Pod
       # @return [void]
       #
       def self.add_swift_version(target, swift_version)
+        version_to_set = !swift_version.nil? ? swift_version : Validator::DEFAULT_SWIFT_VERSION
         target.build_configurations.each do |configuration|
-          configuration.build_settings['SWIFT_VERSION'] = !swift_version.nil? ? swift_version : Validator::DEFAULT_SWIFT_VERSION
+          configuration.build_settings['SWIFT_VERSION'] = version_to_set
         end
       end
 

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -100,7 +100,7 @@ module Pod
       #
       def self.add_swift_version(target, swift_version)
         target.build_configurations.each do |configuration|
-          configuration.build_settings['SWIFT_VERSION'] = swift_version
+          configuration.build_settings['SWIFT_VERSION'] = !swift_version.nil? ? swift_version : Validator::DEFAULT_SWIFT_VERSION
         end
       end
 

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -25,6 +25,9 @@ module Pod
       @pods = new_group('Pods')
       @development_pods = new_group('Development Pods')
       self.symroot = LEGACY_BUILD_ROOT
+      root_object.build_configuration_list.build_configurations.each do |config|
+        config.build_settings['SWIFT_VERSION'] = Validator::DEFAULT_SWIFT_VERSION
+      end
     end
 
     # @return [PBXGroup] The group for the support files of the aggregate

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -16,7 +16,7 @@ module Pod
 
     # The default version of Swift to use when linting pods
     #
-    DEFAULT_SWIFT_VERSION = '3.0'.freeze
+    DEFAULT_SWIFT_VERSION = '3.2'.freeze
 
     # @return [Specification::Linter] the linter instance from CocoaPods
     #         Core.
@@ -470,7 +470,7 @@ module Pod
           next unless (native_target = pod_target.native_target)
           native_target.build_configuration_list.build_configurations.each do |build_configuration|
             (build_configuration.build_settings['OTHER_CFLAGS'] ||= '$(inherited)') << ' -Wincomplete-umbrella'
-            build_configuration.build_settings['SWIFT_VERSION'] = swift_version if pod_target.uses_swift?
+            build_configuration.build_settings['SWIFT_VERSION'] = swift_version if pod_target.uses_swift? && !swift_version.nil?
           end
         end
         if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -398,10 +398,10 @@ module Pod
       if !used_swift_version.nil? && @swift_version.nil?
         warning(:swift_version,
                 'The validator for Swift projects uses ' \
-                'Swift 3.0 by default, if you are using a different version of ' \
+                'Swift 3.2 by default, if you are using a different version of ' \
                 'swift you can use a `.swift-version` file to set the version for ' \
-                "your Pod. For example to use Swift 2.3, run: \n" \
-                '    `echo "2.3" > .swift-version`')
+                "your Pod. For example to use Swift 4.0, run: \n" \
+                '    `echo "4.0" > .swift-version`')
       end
     end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -886,10 +886,10 @@ module Pod
           result = validator.results.first
           result.type.should == :warning
           result.message.should == 'The validator for ' \
-            'Swift projects uses Swift 3.0 by default, if you are using a ' \
+            'Swift projects uses Swift 3.2 by default, if you are using a ' \
             'different version of swift you can use a `.swift-version` file ' \
-            'to set the version for your Pod. For example to use Swift 2.3, ' \
-            "run: \n    `echo \"2.3\" > .swift-version`"
+            'to set the version for your Pod. For example to use Swift 4.0, ' \
+            "run: \n    `echo \"4.0\" > .swift-version`"
         end
       end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -894,10 +894,10 @@ module Pod
       end
 
       describe '#swift_version' do
-        it 'defaults to Swift 3.0' do
+        it 'defaults to Swift 3.2' do
           validator = test_swiftpod
           validator.stubs(:dot_swift_version).returns(nil)
-          validator.swift_version.should == '3.0'
+          validator.swift_version.should == '3.2'
         end
 
         it 'allows the user to set the version' do


### PR DESCRIPTION
* Avoid 'Unspecificed' value for SWIFT_VERSION build settings
* Making Swift 3.2 the default value since this is the minimum version supported by Xcode 9