### PR TITLE
Set direct and transitive dependency header search paths for pod targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7116](https://github.com/CocoaPods/CocoaPods/pull/7116)
 
+* Log target names missing host for libraries  
+  [Keith Smiley](https://github.com/keith)
+  [#7346](https://github.com/CocoaPods/CocoaPods/pull/7346)
+
 ##### Bug Fixes
 
 * None.  
@@ -20,10 +24,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 ## 1.4.0 (2018-01-18)
 
 ##### Enhancements
-
-* Log target names missing host for libraries  
-  [Keith Smiley](https://github.com/keith)
-  [#7346](https://github.com/CocoaPods/CocoaPods/pull/7346)
 
 * Show warning when Pod source uses unencrypted HTTP  
   [KrauseFx](https://github.com/KrauseFx)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Set direct and transitive dependency header search paths for pod targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7116](https://github.com/CocoaPods/CocoaPods/pull/7116)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -44,14 +44,10 @@ module Pod
         # @return [Xcodeproj::Config]
         #
         def generate
-          target_search_paths = target.build_headers.search_paths(target.platform)
-          sandbox_search_paths = target.sandbox.public_headers.search_paths(target.platform)
-          search_paths = target_search_paths.concat(sandbox_search_paths).uniq
-
           config = {
             'FRAMEWORK_SEARCH_PATHS' => '$(inherited) ',
             'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1',
-            'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(search_paths),
+            'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(target.header_search_paths(@test_xcconfig)),
             'LIBRARY_SEARCH_PATHS' => '$(inherited) ',
             'OTHER_LDFLAGS' => XCConfigHelper.default_ld_flags(target, @test_xcconfig),
             'PODS_ROOT' => '${SRCROOT}',

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -4,6 +4,8 @@ module Pod
     # the header search paths.
     #
     class HeadersStore
+      SEARCH_PATHS_KEY = Struct.new(:platform_name, :target_name)
+
       # @return [Pathname] the absolute path of this header directory.
       #
       def root
@@ -24,21 +26,32 @@ module Pod
         @sandbox       = sandbox
         @relative_path = relative_path
         @search_paths  = []
+        @search_paths_cache = {}
       end
 
       # @param  [Platform] platform
       #         the platform for which the header search paths should be
       #         returned
       #
+      # @param  [String] target_name
+      #         the target for which the header search paths should be
+      #         returned. This will return only header root scope e.g. `${PODS_ROOT}/Headers/Public`
+      #         if the target name specified is `nil`.
+      #
       # @return [Array<String>] All the search paths of the header directory in
       #         xcconfig format. The paths are specified relative to the pods
       #         root with the `${PODS_ROOT}` variable.
       #
-      def search_paths(platform)
-        platform_search_paths = @search_paths.select { |entry| entry[:platform] == platform.name }
-
+      def search_paths(platform, target_name = nil)
+        key = SEARCH_PATHS_KEY.new(platform.name, target_name)
+        return @search_paths_cache[key] if @search_paths_cache.key?(key)
+        platform_search_paths = @search_paths.select do |entry|
+          matches_platform = entry[:platform] == platform.name
+          matches_target = target_name.nil? || (entry[:path].basename.to_s == target_name)
+          matches_platform && matches_target
+        end
         headers_dir = root.relative_path_from(sandbox.root).dirname
-        ["${PODS_ROOT}/#{headers_dir}/#{@relative_path}"] + platform_search_paths.uniq.map { |entry| "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}" }
+        @search_paths_cache[key] = ["${PODS_ROOT}/#{headers_dir}/#{@relative_path}"] + platform_search_paths.uniq.map { |entry| "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}" }
       end
 
       # Removes the directory as it is regenerated from scratch during each

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -567,6 +567,23 @@ module Pod
       [version.major, version.minor, version.patch].join('.')
     end
 
+    # @param [Boolean] include_test_dependent_targets
+    #        whether to include header search paths for test dependent targets
+    #
+    # @return [Array<String>] The set of header search paths this target uses.
+    #
+    def header_search_paths(include_test_dependent_targets = false)
+      header_search_paths = []
+      header_search_paths.concat(build_headers.search_paths(platform))
+      header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name))
+      dependent_targets = recursive_dependent_targets
+      dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets
+      dependent_targets.each do |dependent_target|
+        header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name))
+      end
+      header_search_paths.uniq
+    end
+
     private
 
     # @param  [TargetDefinition] target_definition

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -137,12 +137,12 @@ module Pod
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as header search paths' do
-            expected = "$(inherited) \"#{config.sandbox.public_headers.search_paths(:ios).join('" "')}\""
+            expected = "$(inherited) \"#{config.sandbox.public_headers.search_paths(Platform.ios).join('" "')}\""
             @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == expected
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
-            expected = "$(inherited) -isystem \"#{config.sandbox.public_headers.search_paths(:ios).join('" -isystem "')}\""
+            expected = "$(inherited) -isystem \"#{config.sandbox.public_headers.search_paths(Platform.ios).join('" -isystem "')}\""
             @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
           end
 

--- a/spec/unit/sandbox/headers_store_spec.rb
+++ b/spec/unit/sandbox/headers_store_spec.rb
@@ -38,12 +38,14 @@ module Pod
       relative_header_paths.each do |path|
         File.open(@sandbox.root + path, 'w') { |file| file.write('hello') }
       end
+      fake_platform = mock(:name => 'fake_platform')
       @header_dir.add_files(namespace_path, relative_header_paths)
-      @header_dir.search_paths(:fake_platform).should.not.include('${PODS_ROOT}/Headers/Public/ExampleLib')
+      @header_dir.search_paths(fake_platform).should.not.include('${PODS_ROOT}/Headers/Public/ExampleLib')
     end
 
     it 'always adds the Headers root to the header search paths' do
-      @header_dir.search_paths(:fake_platform).should.include('${PODS_ROOT}/Headers/Public')
+      fake_platform = mock(:name => 'fake_platform')
+      @header_dir.search_paths(fake_platform).should.include('${PODS_ROOT}/Headers/Public')
     end
 
     it 'only exposes header search paths for the given platform' do
@@ -52,6 +54,19 @@ module Pod
       @header_dir.search_paths(Platform.ios).sort.should == [
         '${PODS_ROOT}/Headers/Public',
         '${PODS_ROOT}/Headers/Public/iOS Search Path',
+      ]
+    end
+
+    it 'returns the correct header search paths given platform and target' do
+      @header_dir.add_search_path('ios-target', Platform.ios)
+      @header_dir.add_search_path('osx-target', Platform.osx)
+      @header_dir.search_paths(Platform.ios, 'ios-target').sort.should == [
+        '${PODS_ROOT}/Headers/Public',
+        '${PODS_ROOT}/Headers/Public/ios-target',
+      ]
+      @header_dir.search_paths(Platform.osx, 'osx-target').sort.should == [
+        '${PODS_ROOT}/Headers/Public',
+        '${PODS_ROOT}/Headers/Public/osx-target',
       ]
     end
   end


### PR DESCRIPTION
This is meant to go for 1.5.0. Pod targets will not have access to the full of header search paths in their generated xcconfig, instead only the header search paths for their dependent targets.

This also correctly handles header search paths for test xcconfigs.