### PR TITLE
Better warning message for which Swift version was used during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Better warning message for which Swift version was used during validation  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7121](https://github.com/CocoaPods/CocoaPods/issues/7121)
+
 * Strip vendored dSYMs during embed script phase  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7111](https://github.com/CocoaPods/CocoaPods/issues/7111)
@@ -139,7 +143,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Fix validation warnings when using --swift-version  
   [Danielle Tomlinson](https://github.com/dantoml)
-  [#6971](https://github.com/CocoaPods/CocoaPods/issue/6971)
+  [#6971](https://github.com/CocoaPods/CocoaPods/pull/6971)
 
 * Fix xcconfig boolean merging when substrings include yes or no  
   [Paul Beusterien](https://github.com/paulb777)

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -99,6 +99,7 @@ module Pod
       # @return [void]
       #
       def self.add_swift_version(target, swift_version)
+        raise 'Cannot set empty Swift version to target.' if swift_version.blank?
         target.build_configurations.each do |configuration|
           configuration.build_settings['SWIFT_VERSION'] = swift_version
         end


### PR DESCRIPTION
closes #7121, fixes regression from https://github.com/CocoaPods/CocoaPods/pull/6971 in CocoaPods 1.4.0.beta.1

/cc @thomasvl The validator will only output this message if the user has not provided a swift version via a parameter or via a `.swift-version` file. 

This is how it looks now:

```
 -> CannonPodder (1.0.5)
    - WARN  | [iOS] swift_version: The validator for Swift projects used Swift 3.0 by default 
because no Swift version was specified. If you want to use a different version of Swift during 
validation, then either use the `--swift-version` parameter or use a `.swift-version` 
file to set the version of Swift to use for your Pod. For example to use Swift 2.3, run: 
`echo "2.3" > .swift-version`
    - ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code.
```