### PR TITLE
Fix static_framework Swift pod deps and pod access to dep vendored modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7121](https://github.com/CocoaPods/CocoaPods/issues/7121)
 
+* Fix static_framework Swift pod dependencies and implement pod access to dependent vendored_framework modules  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7117](https://github.com/CocoaPods/CocoaPods/issues/7117)
+
 * Strip vendored dSYMs during embed script phase  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7111](https://github.com/CocoaPods/CocoaPods/issues/7111)

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -71,6 +71,7 @@ module Pod
           XCConfigHelper.add_target_specific_settings(target, @xcconfig)
           recursive_dependent_targets = target.recursive_dependent_targets
           @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, recursive_dependent_targets, @test_xcconfig)
+          XCConfigHelper.generate_vendored_build_settings(target, recursive_dependent_targets, @xcconfig, false) if target.requires_frameworks?
           if @test_xcconfig
             test_dependent_targets = [target, *target.recursive_test_dependent_targets].uniq
             @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, test_dependent_targets - recursive_dependent_targets, @test_xcconfig)

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -63,8 +63,8 @@ module Pod
 
         # Configures the given Xcconfig
         #
-        # @param  [AggregateTarget] aggregate_target
-        #         The aggregate target, may be nil.
+        # @param  [Target] target
+        #         The root target, may be nil.
         #
         # @param  [PodTarget] pod_target
         #         The pod target, which holds the list of +Spec::FileAccessor+.
@@ -72,27 +72,30 @@ module Pod
         # @param  [Xcodeproj::Config] xcconfig
         #         The xcconfig to edit.
         #
+        # @param  [Boolean] include_ld_flags
+        #         Indicates whether or not to generate ld flags in addition to compile flags
+        #
         # @return [void]
         #
-        def self.add_settings_for_file_accessors_of_target(aggregate_target, pod_target, xcconfig)
+        def self.add_settings_for_file_accessors_of_target(target, pod_target, xcconfig, include_ld_flags = true)
           pod_target.file_accessors.each do |file_accessor|
-            if aggregate_target.nil? || !file_accessor.spec.test_specification?
-              XCConfigHelper.add_spec_build_settings_to_xcconfig(file_accessor.spec_consumer, xcconfig)
-              XCConfigHelper.add_static_dependency_build_settings(aggregate_target, pod_target, xcconfig, file_accessor)
+            if target.nil? || !file_accessor.spec.test_specification?
+              XCConfigHelper.add_spec_build_settings_to_xcconfig(file_accessor.spec_consumer, xcconfig) if include_ld_flags
+              XCConfigHelper.add_static_dependency_build_settings(target, pod_target, xcconfig, file_accessor, include_ld_flags)
             end
           end
-          XCConfigHelper.add_dynamic_dependency_build_settings(aggregate_target, pod_target, xcconfig)
+          XCConfigHelper.add_dynamic_dependency_build_settings(target, pod_target, xcconfig, include_ld_flags)
           if pod_target.requires_frameworks?
             pod_target.dependent_targets.each do |dependent_target|
-              XCConfigHelper.add_dynamic_dependency_build_settings(aggregate_target, dependent_target, xcconfig)
+              XCConfigHelper.add_dynamic_dependency_build_settings(target, dependent_target, xcconfig, include_ld_flags)
             end
           end
         end
 
         # Adds build settings for static vendored frameworks and libraries.
         #
-        # @param  [AggregateTarget] aggregate_target
-        #         The aggregate target, may be nil.
+        # @param  [Target] target
+        #         The root target, may be nil.
         #
         # @param [PodTarget] pod_target
         #        The pod target, which holds the list of +Spec::FileAccessor+.
@@ -103,16 +106,18 @@ module Pod
         # @param [Spec::FileAccessor] file_accessor
         #        The file accessor, which holds the list of static frameworks.
         #
+        # @param  [Boolean] include_ld_flags
+        #         Indicates whether or not to generate ld flags in addition to compile flags
+        #
         # @return [void]
         #
-        def self.add_static_dependency_build_settings(aggregate_target, pod_target, xcconfig, file_accessor)
-          if aggregate_target.nil? || !file_accessor.spec.test_specification?
+        def self.add_static_dependency_build_settings(target, pod_target, xcconfig, file_accessor, include_ld_flags)
+          if target.nil? || !file_accessor.spec.test_specification?
+            adds_other_ldflags = include_ld_flags && XCConfigHelper.links_dependency?(target, pod_target)
             file_accessor.vendored_static_frameworks.each do |vendored_static_framework|
-              adds_other_ldflags = XCConfigHelper.links_dependency?(aggregate_target, pod_target)
               XCConfigHelper.add_framework_build_settings(vendored_static_framework, xcconfig, pod_target.sandbox.root, adds_other_ldflags)
             end
             file_accessor.vendored_static_libraries.each do |vendored_static_library|
-              adds_other_ldflags = XCConfigHelper.links_dependency?(aggregate_target, pod_target)
               XCConfigHelper.add_library_build_settings(vendored_static_library, xcconfig, pod_target.sandbox.root, adds_other_ldflags)
             end
           end
@@ -136,8 +141,8 @@ module Pod
 
         # Adds build settings for dynamic vendored frameworks and libraries.
         #
-        # @param  [AggregateTarget] aggregate_target
-        #         The aggregate target, may be nil.
+        # @param  [Target] target
+        #         The root target, may be nil.
         #
         # @param [PodTarget] pod_target
         #        The pod target, which holds the list of +Spec::FileAccessor+.
@@ -145,16 +150,19 @@ module Pod
         # @param [Xcodeproj::Config] xcconfig
         #        The xcconfig to edit.
         #
+        # @param  [Boolean] include_ld_flags
+        #         Indicates whether or not to generate ld flags in addition to compile flags
+        #
         # @return [void]
         #
-        def self.add_dynamic_dependency_build_settings(aggregate_target, pod_target, xcconfig)
+        def self.add_dynamic_dependency_build_settings(target, pod_target, xcconfig, include_ld_flags)
           pod_target.file_accessors.each do |file_accessor|
-            if aggregate_target.nil? || !file_accessor.spec.test_specification?
+            if target.nil? || !file_accessor.spec.test_specification?
               file_accessor.vendored_dynamic_frameworks.each do |vendored_dynamic_framework|
-                XCConfigHelper.add_framework_build_settings(vendored_dynamic_framework, xcconfig, pod_target.sandbox.root)
+                XCConfigHelper.add_framework_build_settings(vendored_dynamic_framework, xcconfig, pod_target.sandbox.root, include_ld_flags)
               end
               file_accessor.vendored_dynamic_libraries.each do |vendored_dynamic_library|
-                XCConfigHelper.add_library_build_settings(vendored_dynamic_library, xcconfig, pod_target.sandbox.root)
+                XCConfigHelper.add_library_build_settings(vendored_dynamic_library, xcconfig, pod_target.sandbox.root, include_ld_flags)
               end
             end
           end
@@ -190,15 +198,18 @@ module Pod
         # @param  [Pathname] sandbox_root
         #         The path retrieved from Sandbox#root.
         #
+        # @param  [Boolean] include_ld_flags
+        #         Indicates whether or not to generate ld flags in addition to compile flags
+        #
         # @return [void]
         #
-        def self.add_framework_build_settings(framework_path, xcconfig, sandbox_root, include_other_ldflags = true)
+        def self.add_framework_build_settings(framework_path, xcconfig, sandbox_root, include_ld_flags = true)
           name = File.basename(framework_path, '.framework')
           dirname = '${PODS_ROOT}/' + framework_path.dirname.relative_path_from(sandbox_root).to_s
           build_settings = {
             'FRAMEWORK_SEARCH_PATHS' => quote([dirname]),
           }
-          build_settings['OTHER_LDFLAGS'] = "-framework #{name}" if include_other_ldflags
+          build_settings['OTHER_LDFLAGS'] = "-framework #{name}" if include_ld_flags
           xcconfig.merge!(build_settings)
         end
 
@@ -214,16 +225,19 @@ module Pod
         # @param  [Pathname] sandbox_root
         #         The path retrieved from Sandbox#root.
         #
+        # @param  [Boolean] include_ld_flags
+        #         Indicates whether or not to generate ld flags in addition to compile flags
+        #
         # @return [void]
         #
-        def self.add_library_build_settings(library_path, xcconfig, sandbox_root, include_other_ldflags = true)
+        def self.add_library_build_settings(library_path, xcconfig, sandbox_root, include_ld_flags = true)
           extension = File.extname(library_path)
           name = File.basename(library_path, extension).sub(/\Alib/, '')
           dirname = '${PODS_ROOT}/' + library_path.dirname.relative_path_from(sandbox_root).to_s
           build_settings = {
             'LIBRARY_SEARCH_PATHS' => quote([dirname]),
           }
-          build_settings['OTHER_LDFLAGS'] = "-l#{name}" if include_other_ldflags
+          build_settings['OTHER_LDFLAGS'] = "-l#{name}" if include_ld_flags
           xcconfig.merge!(build_settings)
         end
 
@@ -350,14 +364,17 @@ module Pod
         # Add custom build settings and required build settings to link to
         # vendored libraries and frameworks.
         #
-        # @param  [AggregateTarget] aggregate_target
-        #         The aggregate target, may be nil.
+        # @param  [Target] target
+        #         The root target, may be nil.
         #
-        # @param  [Array<PodTarget] pod_targets
-        #         The pod targets to add the vendored build settings for.
+        # @param  [Array<PodTarget] dep_targets
+        #         The dependency targets to add the vendored build settings for.
         #
         # @param  [Xcodeproj::Config] xcconfig
         #         The xcconfig to edit.
+        #
+        # @param  [Boolean] include_ld_flags
+        #         Indicates whether or not to generate ld flags in addition to compile flags
         #
         # @note
         #   In case of generated pod targets, which require frameworks, the
@@ -365,10 +382,10 @@ module Pod
         #   into the framework binary and must not be linked again to the
         #   user target.
         #
-        def self.generate_vendored_build_settings(aggregate_target, pod_targets, xcconfig)
-          pod_targets.each do |pod_target|
-            unless pod_target.should_build? && pod_target.requires_frameworks? && !pod_target.static_framework?
-              XCConfigHelper.add_settings_for_file_accessors_of_target(aggregate_target, pod_target, xcconfig)
+        def self.generate_vendored_build_settings(target, dep_targets, xcconfig, include_ld_flags = true)
+          dep_targets.each do |dep_target|
+            unless dep_target.should_build? && dep_target.requires_frameworks? && !dep_target.static_framework?
+              XCConfigHelper.add_settings_for_file_accessors_of_target(target, dep_target, xcconfig, include_ld_flags)
             end
           end
         end

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -229,10 +229,11 @@ module Pod
               aggregate_target.native_target.add_dependency(pod_target.native_target)
               configure_app_extension_api_only_for_target(pod_target) if is_app_extension
 
+              add_dependent_targets_to_native_target(pod_target.dependent_targets,
+                                                     pod_target.native_target, is_app_extension,
+                                                     pod_target.requires_frameworks? && !pod_target.static_framework?,
+                                                     frameworks_group)
               unless pod_target.static_framework?
-                add_dependent_targets_to_native_target(pod_target.dependent_targets,
-                                                       pod_target.native_target, is_app_extension,
-                                                       pod_target.requires_frameworks?, frameworks_group)
                 add_pod_target_test_dependencies(pod_target, frameworks_group)
               end
             end

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -298,6 +298,26 @@ module Pod
               @generator.send(:set_target_dependencies)
             end
 
+            it 'adds all test dependent targets to test native targets for static frameworks' do
+              mock_native_target = mock('CoconutLib')
+              dependent_native_target = mock('DependentNativeTarget')
+
+              dependent_target = mock('dependent-target')
+              dependent_target.stubs(:should_build?).returns(true)
+              dependent_target.stubs(:native_target).returns(dependent_native_target)
+
+              @pod_target.stubs(:native_target).returns(mock_native_target)
+              @pod_target.stubs(:dependent_targets).returns([dependent_target])
+              @pod_target.stubs(:should_build? => true)
+              @pod_target.stubs(:static_framework? => true)
+              @mock_target.expects(:add_dependency).with(mock_native_target)
+
+              mock_native_target.expects(:add_dependency).with(dependent_native_target)
+              mock_native_target.expects(:add_dependency).with(mock_native_target).never
+
+              @generator.send(:set_target_dependencies)
+            end
+
             it 'adds dependencies to pod targets that are not part of any aggregate target' do
               @target.stubs(:pod_targets).returns([])
               @generator.expects(:pod_targets).returns([@pod_target])


### PR DESCRIPTION
Fixes #7117 

This PR fixes/implements two issues:

1. When I implemented static frameworks, I made the incorrect assumption that static_frameworks don't need to worry about build dependencies because they don't link. That's not the case when a static_framework depends upon a Swift CocoaPod where it needs its bridging header to be built. This is fixed by the conditional change in `lib/cocoapods/installer/xcode/pods_project_generator.rb`.

2. CocoaPods did not support importing modules from vendored frameworks. While this is annoying for Objective C, it's a show stopper for a Swift CocoaPod depending on a vendored framework.  The vendored framework modules were not being added to FRAMEWORK_SEARCH_PATHS for pod builds that depended upon them. I added a call in `lib/cocoapods/generator/xcconfig/pod_xcconfig.rb` to `generate_vendored_build_settings`. Most of the changes to `lib/cocoapods/generator/xcconfig/xcconfig_helper.rb` are renaming and filtering so that FRAMEWORK_SEARCH_PATHS can be updated with or without updating OTHER_LD_FLAGS.