### PR TITLE
Update default Swift version to 3.2 for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Set the default Swift version to 3.2 during validation  
+  [Victor Hugo Barros](https://github.com/heyzooi)
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7136](https://github.com/CocoaPods/CocoaPods/pull/7136)
+
 * Better warning message for which Swift version was used during validation  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7121](https://github.com/CocoaPods/CocoaPods/issues/7121)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -16,7 +16,7 @@ module Pod
 
     # The default version of Swift to use when linting pods
     #
-    DEFAULT_SWIFT_VERSION = '3.0'.freeze
+    DEFAULT_SWIFT_VERSION = '3.2'.freeze
 
     # @return [Specification::Linter] the linter instance from CocoaPods
     #         Core.
@@ -407,7 +407,7 @@ module Pod
                 "Swift #{DEFAULT_SWIFT_VERSION} by default because no Swift version was specified. " \
                 'If you want to use a different version of Swift during validation, then either use the `--swift-version` parameter ' \
                 'or use a `.swift-version` file to set the version of Swift to use for ' \
-                'your Pod. For example to use Swift 2.3, run: `echo "2.3" > .swift-version`.')
+                'your Pod. For example to use Swift 4.0, run: `echo "4.0" > .swift-version`.')
       end
     end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -886,10 +886,10 @@ module Pod
           result = validator.results.first
           result.type.should == :warning
           result.message.should == 'The validator used ' \
-            'Swift 3.0 by default because no Swift version was specified. ' \
+            'Swift 3.2 by default because no Swift version was specified. ' \
             'If you want to use a different version of Swift during validation, then either use the `--swift-version` parameter ' \
             'or use a `.swift-version` file to set the version of Swift to use for ' \
-            'your Pod. For example to use Swift 2.3, run: `echo "2.3" > .swift-version`.'
+            'your Pod. For example to use Swift 4.0, run: `echo "4.0" > .swift-version`.'
         end
 
         it 'does not warn for Swift if version was set by a dot swift version file' do
@@ -912,10 +912,10 @@ module Pod
       end
 
       describe '#swift_version' do
-        it 'defaults to Swift 3.0' do
+        it 'defaults to Swift 3.2' do
           validator = test_swiftpod
           validator.stubs(:dot_swift_version).returns(nil)
-          validator.swift_version.should == '3.0'
+          validator.swift_version.should == '3.2'
         end
 
         it 'allows the user to set the version' do


### PR DESCRIPTION
Supersedes https://github.com/CocoaPods/CocoaPods/pull/7109

![screen_shot_2017-10-13_at_3_52_33_pm](https://user-images.githubusercontent.com/310370/31569288-93a15238-b02e-11e7-9aa5-162053cacd33.png)

On Xcode 9 ^^^
