### PR TITLE
Copy .swiftmodule to enable access to Swift static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Copy .swiftmodule into static_frameworks to enable access to Swift static frameworks  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7140](https://github.com/CocoaPods/CocoaPods/issues/7140)
+
 * Fix docs for prefix header paths  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7149](https://github.com/CocoaPods/CocoaPods/pull/7149)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -469,6 +469,8 @@ module Pod
           mkdir -p "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Modules"
           cp "${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/${PRODUCT_NAME}"
           cp "${MODULEMAP_FILE}" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Modules/module.modulemap"
+          # If there's a .swiftmodule, copy it into the framework's Modules folder
+          cp -r "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}".swiftmodule "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Modules/" 2>/dev/null || :
             eos
           end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -715,6 +715,7 @@ module Pod
                 build_phase = target.shell_script_build_phases.find do |bp|
                   bp.name == 'Setup Static Framework Archive'
                 end
+                build_phase.shell_script.should.include?('swiftmodule')
                 build_phase.should.not.be.nil
               end
             end


### PR DESCRIPTION
Fix #7140

To access public classes from Swift-built static frameworks, the .swiftmodule must be included into the constructed framework. This PR adds a copy command (modified to be silent when there is no swiftmodule) to the Setup Static Framework build phase.