### PR TITLE
Static library headers should all be Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7166](https://github.com/CocoaPods/CocoaPods/pull/7166)
 
+* Static library headers should all be `Project` in Xcode header build phase  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#4496](https://github.com/CocoaPods/CocoaPods/issues/4496)
+
 * Fix archiving apps with static frameworks  
   [Paul Beusterien](https://github.com/paulb777)
   [#7158](https://github.com/CocoaPods/CocoaPods/issues/7158)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -631,7 +631,9 @@ module Pod
 
           def add_header(build_file, public_headers, private_headers, native_target)
             file_ref = build_file.file_ref
-            acl = if public_headers.include?(file_ref.real_path)
+            acl = if !target.requires_frameworks? # Headers are already rooted at ${PODS_ROOT}/Headers/P*/[pod]/...
+                    'Project'
+                  elsif public_headers.include?(file_ref.real_path)
                     'Public'
                   elsif private_headers.include?(file_ref.real_path)
                     'Private'

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -719,6 +719,16 @@ module Pod
                 build_phase.shell_script.should.include?('PrivateHeaders')
                 build_phase.should.not.be.nil
               end
+
+              it 'verifies that headers in build phase for static libraries are all Project headers' do
+                @pod_target.stubs(:requires_frameworks?).returns(false)
+
+                @installer.install!
+
+                @project.targets.first.headers_build_phase.files.find do |hf|
+                  hf.settings['ATTRIBUTES'].should == ['Project']
+                end
+              end
             end
 
             it "doesn't create a build phase to symlink header folders by default on OS X" do


### PR DESCRIPTION
Fix #4496 and https://github.com/grpc/grpc/issues/12081

For static library pods, Public and Private headers are copied to  `${PODS_ROOT}/Headers/Public/[pod]/` and  `${PODS_ROOT}/Headers/Private/[pod]/` and the dependency search paths set appropriately.

The headers were also being set in an Xcode build phase and marked as `Public` or `Private`. This redundancy is usually harmless since the headers would already be found at previous path. However, if there are multiple same-named at different paths, build warnings will be generated, since the Xcode build phase flattens the path.

This PR addresses that by making all static library pod headers `Project`.

More analysis at #4496 and I've verified this fixes https://github.com/grpc/grpc/issues/12081
