### PR TITLE
Prevent multiple script phases from stripping vendored dSYM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Prevent multiple script phases from stripping vendored dSYM  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7166](https://github.com/CocoaPods/CocoaPods/pull/7166)
+
 * Fix archiving apps with static frameworks  
   [Paul Beusterien](https://github.com/paulb777)
   [#7158](https://github.com/CocoaPods/CocoaPods/issues/7158)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -99,17 +99,22 @@ module Pod
           install_dsym() {
             local source="$1"
             if [ -r "$source" ]; then
-              echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${DWARF_DSYM_FOLDER_PATH}\\""
-              rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${DWARF_DSYM_FOLDER_PATH}"
-            fi
+              # Copy the dSYM into a the targets temp dir.
+              echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${DERIVED_FILES_DIR}\\""
+              rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${DERIVED_FILES_DIR}"
 
-            local basename
-            basename="$(basename -s .framework.dSYM "$source")"
-            binary="${DWARF_DSYM_FOLDER_PATH}/${basename}.framework.dSYM/Contents/Resources/DWARF/${basename}"
+              local basename
+              basename="$(basename -s .framework.dSYM "$source")"
+              binary="${DERIVED_FILES_DIR}/${basename}.framework.dSYM/Contents/Resources/DWARF/${basename}"
 
-            # Strip invalid architectures so "fat" simulator / device frameworks work on device
-            if [[ "$(file "$binary")" == *"Mach-O dSYM companion"* ]]; then
-              strip_invalid_archs "$binary"
+              # Strip invalid architectures so "fat" simulator / device frameworks work on device
+              if [[ "$(file "$binary")" == *"Mach-O dSYM companion"* ]]; then
+               strip_invalid_archs "$binary"
+              fi
+
+              # Move the stripped file into its final destination.
+              echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${DERIVED_FILES_DIR}/${basename}.framework.dSYM\\" \\"${DWARF_DSYM_FOLDER_PATH}\\""
+              rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${DERIVED_FILES_DIR}/${basename}.framework.dSYM" "${DWARF_DSYM_FOLDER_PATH}"
             fi
           }
 


### PR DESCRIPTION
After upgrading to 1.4.0.beta.2 we noticed a race condition regarding dSYM architecture stripping. This is because multiple targets can execute the "Embed Pods Framework" script phase in parallel and strip the same dSYM file which can yield to a race and error.

This prevents that by moving the file into the intermediates folder of the scoped target, stripping it and then moving it to the final destination.