### PR TITLE
Set language to Swift for test native targets if any dependencies use Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Set language to Swift for test native targets if any dependencies use Swift  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7170](https://github.com/CocoaPods/CocoaPods/issues/7170)
+  
 * Prevent multiple script phases from stripping vendored dSYM  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7166](https://github.com/CocoaPods/CocoaPods/pull/7166)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -242,7 +242,7 @@ module Pod
               product_type = target.product_type_for_test_type(test_type)
               name = target.test_target_label(test_type)
               platform_name = target.platform.name
-              language = target.uses_swift? ? :swift : :objc
+              language = target.all_test_dependent_targets.any?(&:uses_swift?) ? :swift : :objc
               native_test_target = project.new_target(product_type, name, platform_name, deployment_target, nil, language)
               native_test_target.product_reference.name = name
 
@@ -431,7 +431,7 @@ module Pod
           #
           def test_target_swift_debug_hack(test_target_bc)
             return unless test_target_bc.debug?
-            return unless [target, *target.recursive_dependent_targets].any?(&:uses_swift?)
+            return unless target.all_test_dependent_targets.any?(&:uses_swift?)
             ldflags = test_target_bc.build_settings['OTHER_LDFLAGS'] ||= '$(inherited)'
             ldflags << ' -lswiftSwiftOnoneSupport'
           end


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7170

Test native targets actually build and link multiple dependencies. If any of these dependencies require Swift, we should be setting the test native target language to Swift.