### PR TITLE
Prevent passing empty string to git when running pod repo update --silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Prevent passing empty string to git when running `pod repo update --silent`
+  [Jon Sorrells](https://github.com/jonsorrells)
+  [#7176](https://github.com/CocoaPods/CocoaPods/issues/7176)
+
 * Do not propagate test spec frameworks and libraries into pod target xcconfig  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7172](https://github.com/CocoaPods/CocoaPods/issues/7172)

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -104,7 +104,9 @@ module Pod
 
     def update_git_repo(show_output = false)
       Config.instance.with_changes(:verbose => show_output) do
-        git!(%W(-C #{repo} fetch origin #{show_output ? '--progress' : ''}))
+        args = %W(-C #{repo} fetch origin)
+        args.push('--progress') if show_output
+        git!(args)
         current_branch = git!(%W(-C #{repo} rev-parse --abbrev-ref HEAD)).strip
         git!(%W(-C #{repo} reset --hard origin/#{current_branch}))
       end


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/CocoaPods/issues/7176