### PR TITLE
Add set -u to frameworks and resources copy scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Keith Smiley](https://github.com/keith)
   [#7180](https://github.com/CocoaPods/CocoaPods/pull/7180)
 
+* Allow integrating into static library targets without attempting to copy 
+  resources or embed frameworks unless `UNLOCALIZED_RESOURCES_FOLDER_PATH` 
+  or `FRAMEWORKS_FOLDER_PATH` is set.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Clear input/output paths if they exceed an arbitrary limit  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Store which specs repo a pod comes from in the lockfile.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Add `set -u` to the copy frameworks and copy resources scripts.  
+  [Keith Smiley](https://github.com/keith)
+  [#7180](https://github.com/CocoaPods/CocoaPods/pull/7180)
+
 ##### Bug Fixes
 
 * Clear input/output paths if they exceed an arbitrary limit  
@@ -367,9 +371,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* Add `set -u` to the copy frameworks and copy resources scripts  
-  [Keith Smiley](https://github.com/keith)
-  [#7180](https://github.com/CocoaPods/CocoaPods/pull/7180)
+* None.  
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,7 +367,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add `set -u` to the copy frameworks and copy resources scripts  
+  [Keith Smiley](https://github.com/keith)
+  [#7180](https://github.com/CocoaPods/CocoaPods/pull/7180)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -97,6 +97,7 @@ module Pod
 #!/bin/sh
 set -e
 set -u
+set -o pipefail
 
 mkdir -p "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -109,7 +109,7 @@ XCASSET_FILES=()
 # was originally proposed here: https://lists.samba.org/archive/rsync/2008-February/020158.html
 RSYNC_PROTECT_TMP_FILES=(--filter "P .*.??????")
 
-case "${TARGETED_DEVICE_FAMILY}" in
+case "${TARGETED_DEVICE_FAMILY:-}" in
   1,2)
     TARGET_DEVICE_ARGS="--target-device ipad --target-device iphone"
     ;;

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -99,6 +99,12 @@ set -e
 set -u
 set -o pipefail
 
+if [ -z ${UNLOCALIZED_RESOURCES_FOLDER_PATH+x} ]; then
+    # If UNLOCALIZED_RESOURCES_FOLDER_PATH is not set, then there's no where for us to copy
+    # resources to, so exit 0 (signalling the script phase was successful).
+    exit 0
+fi
+
 mkdir -p "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
 RESOURCES_TO_COPY=${PODS_ROOT}/resources-to-copy-${TARGETNAME}.txt

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -96,6 +96,7 @@ module Pod
       INSTALL_RESOURCES_FUNCTION = <<EOS
 #!/bin/sh
 set -e
+set -u
 
 mkdir -p "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -195,7 +195,7 @@ EOS
 
       XCASSETS_COMPILE = <<EOS
 
-if [[ -n "${WRAPPER_EXTENSION}" ]] && [ "`xcrun --find actool`" ] && [ -n "$XCASSET_FILES" ]
+if [[ -n "${WRAPPER_EXTENSION}" ]] && [ "`xcrun --find actool`" ] && [ -n "${XCASSET_FILES:-}" ]
 then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
   OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -37,6 +37,7 @@ module Pod
         script = <<-SH.strip_heredoc
           #!/bin/sh
           set -e
+          set -u
 
           echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
           mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -131,7 +131,7 @@ module Pod
 
           # Signs a framework with the provided identity
           code_sign_if_enabled() {
-            if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
+            if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
               local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements '$1'"

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -38,6 +38,7 @@ module Pod
           #!/bin/sh
           set -e
           set -u
+          set -o pipefail
 
           echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
           mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -134,7 +134,7 @@ module Pod
             if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
-              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS} --preserve-metadata=identifier,entitlements '$1'"
+              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements '$1'"
 
               if [ "${COCOAPODS_PARALLEL_CODE_SIGN}" == "true" ]; then
                 code_sign_cmd="$code_sign_cmd &"

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -40,6 +40,12 @@ module Pod
           set -u
           set -o pipefail
 
+          if [ -z ${FRAMEWORKS_FOLDER_PATH+x} ]; then
+              # If FRAMEWORKS_FOLDER_PATH is not set, then there's no where for us to copy
+              # frameworks to, so exit 0 (signalling the script phase was successful).
+              exit 0
+          fi
+
           echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
           mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -42,6 +42,7 @@ module Pod
           echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
           mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 
+          COCOAPODS_PARALLEL_CODE_SIGN="${COCOAPODS_PARALLEL_CODE_SIGN:-false}"
           SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
 
           # Used as a return value for each invocation of `strip_invalid_archs` function.


### PR DESCRIPTION
This adds `set -u` to both the frameworks and resources copy shell
scripts. This means that if the scripts attempt to reference any
variable that is undefined, they will fail.