### PR TITLE
Only add resources and frameworks build phase when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7336](https://github.com/CocoaPods/CocoaPods/issues/7336)
 
+* Avoid adding copy resources and frameworks script phases when those phases
+  would not copy anything.  
+  [Keith Smiley](https://github.com/keith)
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.4.0 (2018-01-18)
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development do
 
   # Integration tests
   gem 'diffy'
-  gem 'clintegracon'
+  gem 'clintegracon', :git => 'https://github.com/segiddins/CLIntegracon.git', :branch => 'segiddins/replacement-pattern-overlapping-replacements'
 
   # Code Quality
   gem 'inch_by_inch'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,15 @@ GIT
     cocoapods-try (1.1.0)
 
 GIT
+  remote: https://github.com/segiddins/CLIntegracon.git
+  revision: 8bb9aa1fecd1731df996bda5cabc53fd746d2577
+  branch: segiddins/replacement-pattern-overlapping-replacements
+  specs:
+    clintegracon (0.8.1)
+      colored2 (~> 3.1)
+      diffy
+
+GIT
   remote: https://github.com/segiddins/json.git
   revision: a9588bc4334c2f5bf985f255b61c05eafdcd8907
   branch: seg-1.7.7-ruby-2.2
@@ -142,15 +151,11 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    clintegracon (0.8.1)
-      colored (~> 1.2)
-      diffy
     cocoapods-dependencies (1.0.0.beta.1)
       ruby-graphviz (~> 1.2)
     cocoapods_debug (0.1.0)
       pry (= 0.10.3)
     coderay (1.1.0)
-    colored (1.2)
     colored2 (3.1.2)
     concurrent-ruby (1.0.5)
     cork (0.3.0)
@@ -267,7 +272,7 @@ DEPENDENCIES
   bacon
   bundler (~> 1.3)
   claide!
-  clintegracon
+  clintegracon!
   cocoapods!
   cocoapods-core!
   cocoapods-deintegrate!

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -303,9 +303,9 @@ module Pod
                 output_extension = TargetIntegrator.output_extension_for_resource(File.extname(input_path))
                 File.join(base_path, File.basename(input_path, File.extname(input_path)) + output_extension)
               end.uniq
+              TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
+              TargetIntegrator.create_or_update_copy_resources_script_phase_to_target(native_target, script_path, input_paths, output_paths)
             end
-            TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
-            TargetIntegrator.create_or_update_copy_resources_script_phase_to_target(native_target, script_path, input_paths, output_paths)
           end
         end
 
@@ -337,9 +337,9 @@ module Pod
             unless framework_paths_by_config.all?(&:empty?)
               input_paths = [target.embed_frameworks_script_relative_path, *framework_paths_by_config.map { |fw| [fw[:input_path], fw[:dsym_input_path]] }.flatten.compact]
               output_paths = framework_paths_by_config.map { |fw| [fw[:output_path], fw[:dsym_output_path]] }.flatten.compact.uniq
+              TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
+              TargetIntegrator.create_or_update_embed_frameworks_script_phase_to_target(native_target, script_path, input_paths, output_paths)
             end
-            TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
-            TargetIntegrator.create_or_update_embed_frameworks_script_phase_to_target(native_target, script_path, input_paths, output_paths)
           end
         end
 

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -149,6 +149,7 @@ describe_cli 'pod' do
 
     # This was changed in a very recent git version
     s.replace_pattern /git checkout -b <new-branch-name>/, 'git checkout -b new_branch_name'
+    s.replace_pattern /[ \t]+(\r?$)/, '\1'
 
     # git sometimes prints this, but not always ¯\_(ツ)_/¯
     s.replace_pattern /^\s*Checking out files.*done\./, ''


### PR DESCRIPTION
This changes the project integrator to only add build phases to the
user's project if there are resources of frameworks that will be copied
in that phase.