### PR TITLE
Do not display script phases warnings multiple times per platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not display script phases warnings multiple times per platform  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7193](https://github.com/CocoaPods/CocoaPods/pull/7193)
+
 * Prevent passing empty string to git when running `pod repo update --silent`
   [Jon Sorrells](https://github.com/jonsorrells)
   [#7176](https://github.com/CocoaPods/CocoaPods/issues/7176)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -530,12 +530,11 @@ module Pod
     #
     def warn_for_installed_script_phases
       pods_to_install = sandbox_state.added | sandbox_state.changed
-      pod_targets.each do |pod_target|
-        spec = pod_target.root_spec
-        if pods_to_install.include?(spec.name)
-          script_phase_count = pod_target.script_phases.count
+      pod_targets.group_by(&:pod_name).each do |name, pod_targets|
+        if pods_to_install.include?(name)
+          script_phase_count = pod_targets.inject(0) { |sum, target| sum + target.script_phases.count }
           unless script_phase_count.zero?
-            UI.warn "#{spec.name} has added #{pod_target.script_phases.count} #{'script phase'.pluralize(script_phase_count)}. " \
+            UI.warn "#{name} has added #{script_phase_count} #{'script phase'.pluralize(script_phase_count)}. " \
               'Please inspect before executing a build. See `https://guides.cocoapods.org/syntax/podspec.html#script_phases` for more information.'
           end
         end


### PR DESCRIPTION
Given a pod that supports multiple platforms the warning message would appear twice like this:
```
[!] CannonPodder has added 1 script phase. Please inspect before executing a build. See `https://guides.cocoapods.org/syntax/podspec.html#script_phases` for more information.

[!] CannonPodder has added 1 script phase. Please inspect before executing a build. See `https://guides.cocoapods.org/syntax/podspec.html#script_phases` for more information.
```
This change groups the message into a single message:
```
[!] CannonPodder has added 2 script phases. Please inspect before executing a build. See `https://guides.cocoapods.org/syntax/podspec.html#script_phases` for more information.
```
