### PR TITLE
Skip updating master repo when running `pod repo update --sources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)
 
 ##### Bug Fixes
+
 * Skip updating master repo when running `pod repo update --sources` without including master repo  as source
   [Nikita Ivanchikov](https://github.com/nivanchikov)
   [#6976](https://github.com/CocoaPods/CocoaPods/issues/6976)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)
 
 ##### Bug Fixes
+* Skip updating master repo when running `pod repo update --sources` without including master repo  as source
+  [Nikita Ivanchikov](https://github.com/nivanchikov)
+  [#6976](https://github.com/CocoaPods/CocoaPods/issues/6976)
 
 * Prevent passing empty string to git when running `pod repo update --silent`
   [Jon Sorrells](https://github.com/jonsorrells)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -239,7 +239,6 @@ module Pod
     # @return [void]
     #
     def analyze(analyzer = create_analyzer)
-      analyzer.update = update
       @analysis_result = analyzer.analyze
       @aggregate_targets = analyzer.result.targets
     end
@@ -248,6 +247,7 @@ module Pod
       Analyzer.new(sandbox, podfile, lockfile, plugin_sources).tap do |analyzer|
         analyzer.installation_options = installation_options
         analyzer.has_dependencies = has_dependencies?
+        analyzer.update = update
       end
     end
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -245,9 +245,9 @@ module Pod
         repo_sources = sources
 
         if update_mode == :selected
-          repo_sources = repo_sources.select { |source| 
+          repo_sources = repo_sources.select do |source|
             !(config.sources_manager.source_with_name_or_url(source.name).pods & update[:pods]).empty?
-          }
+          end
         end
 
         repo_sources.each do |source|

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -242,7 +242,17 @@ module Pod
       # Updates the git source repositories.
       #
       def update_repositories
-        sources.each do |source|
+        repo_sources = sources
+
+        if update_mode == :selected
+          repo_sources = repo_sources.select { |source| 
+            !(config.sources_manager.source_with_name_or_url(source.name).pods & update[:pods]).empty?
+          }
+        end
+		
+		UI.message "REPOS #{repo_sources}"
+
+        repo_sources.each do |source|
           if source.git?
             config.sources_manager.update(source.name, true)
           else

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -249,8 +249,6 @@ module Pod
             !(config.sources_manager.source_with_name_or_url(source.name).pods & update[:pods]).empty?
           }
         end
-		
-		UI.message "REPOS #{repo_sources}"
 
         repo_sources.each do |source|
           if source.git?


### PR DESCRIPTION
Fixes #6976, #5807

Behavior is as following:
- if a podfile contains several sources (e.g. private / master) which share the same pod library name - update all sources containing the same pod library
- if only one source contains the specified pod library name - update only that single pod repo.

Would be glad to hear the feedback on my first PR.