### PR TITLE
Add color indication to output of "pod outdated"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add color indication to output of `pod outdated`  
+  [iv-mexx](https://github.com/iv-mexx)
+  [#7204](https://github.com/CocoaPods/CocoaPods/pull/7204)
+
 * Add support for editing the podspec, license, README, license, and docs of local development pods  
   [Eric Amorde](https://github.com/amorde)
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)

--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -22,10 +22,24 @@ module Pod
         if updates.empty?
           UI.puts 'No pod updates are available.'.yellow
         else
+          UI.section 'The color indicates what happens when you run `pod update`' do
+            UI.puts "#{'<green>'.green}\t\t - Will be updated to the newest version"
+            UI.puts "#{'<yellow>'.yellow}\t - Will be updated, but not to the newest version because of specified version in Podfile"
+            UI.puts "#{'<red>'.red}\t\t - Will not be updated because of specified version in Podfile"
+            UI.puts ''
+          end
           UI.section 'The following pod updates are available:' do
             updates.each do |(name, from_version, matching_version, to_version)|
-              UI.puts "- #{name} #{from_version} -> #{matching_version} " \
-                "(latest version #{to_version})"
+              color = :yellow
+              if matching_version == to_version
+                color = :green
+              elsif from_version == matching_version
+                color = :red
+              end
+              # For the specs, its necessary that to_s is called here even though it is redundant
+              # https://github.com/CocoaPods/CocoaPods/pull/7204#issuecomment-342512015
+              UI.puts "- #{name} #{from_version.to_s.send(color)} -> #{matching_version.to_s.send(color)} " \
+              "(latest version #{to_version.to_s})" # rubocop:disable Lint/StringConversionInInterpolation
             end
           end
         end


### PR DESCRIPTION
This adds color to the output of `pod outdated` to make it easier to read. 

The version numbers are highlighted in one of the following colors:
* **green** if the latest available update is compatible with the specified version in the Podfile
* **yellow** if there is an update available and allowed by the specified version in the Podfile, but the latest available update is *not* compatible
* **red** if the update is not compatible with the version specified in the Podfile.

Here is an example how that would look like:
<img width="665" alt="screen shot 2017-11-07 at 00 00 18" src="https://user-images.githubusercontent.com/3407787/32468563-0fac8400-c34f-11e7-882e-2f2479eaffa9.png">
