### PR TITLE
Add copied resources' paths to "Copy Pods Resources" output file list 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Add copied resources' paths to "Copy Pods Resources" output file list  
+  [igor-makarov](https://github.com/igor-makarov)
+  [#6936](https://github.com/CocoaPods/CocoaPods/issues/6936)
+
 * Do not link system frameworks of test specs to library targets  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7205](https://github.com/CocoaPods/CocoaPods/pull/7205)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
@@ -56,8 +56,13 @@ module Pod
             input_paths = []
             output_paths = []
             unless resource_paths.empty?
-              input_paths = [script_path, *resource_paths.flatten.uniq]
-              output_paths = ['${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}']
+              resource_paths_flattened = resource_paths.flatten.uniq
+              input_paths = [script_path, *resource_paths_flattened]
+              output_paths = resource_paths_flattened.map do |input_path|
+                base_path = '${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}'
+                output_extension = UserProjectIntegrator::TargetIntegrator.output_extension_for_resource(File.extname(input_path))
+                File.join(base_path, File.basename(input_path, File.extname(input_path)) + output_extension)
+              end
             end
             UserProjectIntegrator::TargetIntegrator.add_copy_resources_script_phase_to_target(native_target, script_path, input_paths, output_paths)
           end

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -301,19 +301,41 @@ module Pod
 
         it 'adds copy pods resources input and output paths' do
           resource_paths_by_config = {
-            'Debug' => ['${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLib.bundle'],
-            'Release' => ['${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.bundle'],
+            'Debug' => [
+              '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodeld',
+              '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodel',
+              '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugMappingModel.xcmappingmodel',
+              '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLib.bundle',
+            ],
+            'Release' => [
+              '${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.bundle',
+              '${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.storyboard',
+              '${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLibXIB.xib',
+            ],
           }
           @pod_bundle.stubs(:resource_paths_by_config => resource_paths_by_config)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @copy_pods_resources_phase_name }
           phase.input_paths.sort.should == %w(
+            ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodel
+            ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodeld
             ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLib.bundle
+            ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugMappingModel.xcmappingmodel
             ${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.bundle
+            ${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLib.storyboard
+            ${PODS_CONFIGURATION_BUILD_DIR}/ReleaseLib/ReleaseLibXIB.xib
             ${SRCROOT}/../Pods/Target\ Support\ Files/Pods/Pods-resources.sh
           )
-          phase.output_paths.sort.should == %w(${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH})
+          phase.output_paths.sort.should == %w(
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugDataModel.mom
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugDataModel.momd
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugLib.bundle
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugMappingModel.cdm
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReleaseLib.bundle
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReleaseLib.storyboardc
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReleaseLibXIB.nib
+          )
         end
 
         it 'does not add embed frameworks build phase input output paths with no frameworks' do

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
@@ -53,7 +53,7 @@ module Pod
                   '${PODS_CONFIGURATION_BUILD_DIR}/TestResourceBundle.bundle',
                 ]
                 @test_native_target.build_phases[1].output_paths.should == [
-                  '${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}',
+                  '${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TestResourceBundle.bundle',
                 ]
               end
 


### PR DESCRIPTION
This resolves [#6936](https://github.com/CocoaPods/CocoaPods/issues/6936) by listing all the bundles being copied as output paths, per suggestion from @bjhomer.

@bjhomer's suggestion is [here](https://github.com/CocoaPods/CocoaPods/issues/6936#issuecomment-341922431).