### PR TITLE
Create scripts for every test target's configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Install resource bundles and embed frameworks for every test target's configuration  
+  [Nickolay Tarbayev](https://github.com/tarbayev)
+  [#7012](https://github.com/CocoaPods/CocoaPods/issues/7012)
+
 * Set `SWIFT_VERSION` to test native targets during validation  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7216](https://github.com/CocoaPods/CocoaPods/pull/7216)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -402,7 +402,9 @@ module Pod
           def create_test_target_copy_resources_script(test_type)
             path = target.copy_resources_script_path_for_test_type(test_type)
             pod_targets = target.all_test_dependent_targets
-            resource_paths_by_config = { 'Debug' => pod_targets.flat_map(&:resource_paths) }
+            resource_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
+              resources_by_config[config] = pod_targets.flat_map(&:resource_paths)
+            end
             generator = Generator::CopyResourcesScript.new(resource_paths_by_config, target.platform)
             update_changed_file(generator, path)
             add_file_to_support_group(path)
@@ -418,7 +420,9 @@ module Pod
           def create_test_target_embed_frameworks_script(test_type)
             path = target.embed_frameworks_script_path_for_test_type(test_type)
             pod_targets = target.all_test_dependent_targets
-            framework_paths_by_config = { 'Debug' => pod_targets.flat_map(&:framework_paths) }
+            framework_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, paths_by_config|
+              paths_by_config[config] = pod_targets.flat_map(&:framework_paths)
+            end
             generator = Generator::EmbedFrameworksScript.new(framework_paths_by_config)
             update_changed_file(generator, path)
             add_file_to_support_group(path)


### PR DESCRIPTION
_Copy resource_ and _embed frameworks_ scripts of a test target now contain all the target's configurations instead of just the **Debug** one. 

This resolves #7012