### PR TITLE
Set `SWIFT_VERSION` to test native targets during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Set `SWIFT_VERSION` to test native targets during validation  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7216](https://github.com/CocoaPods/CocoaPods/pull/7216)
+
 * Add copied resources' paths to "Copy Pods Resources" output file list  
   [igor-makarov](https://github.com/igor-makarov)
   [#6936](https://github.com/CocoaPods/CocoaPods/issues/6936)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -478,6 +478,13 @@ module Pod
             (build_configuration.build_settings['OTHER_CFLAGS'] ||= '$(inherited)') << ' -Wincomplete-umbrella'
             build_configuration.build_settings['SWIFT_VERSION'] = swift_version if pod_target.uses_swift?
           end
+          if pod_target.uses_swift?
+            pod_target.test_native_targets.each do |test_native_target|
+              test_native_target.build_configuration_list.build_configurations.each do |build_configuration|
+                build_configuration.build_settings['SWIFT_VERSION'] = swift_version
+              end
+            end
+          end
         end
         if target.pod_targets.any?(&:uses_swift?) && consumer.platform_name == :ios &&
             (deployment_target.nil? || Version.new(deployment_target).major < 8)


### PR DESCRIPTION
/cc @emuller

![screen_shot_2017-11-10_at_3_59_30_pm](https://user-images.githubusercontent.com/310370/32683466-3aa273ac-c630-11e7-84e9-2edc69cdeef9.png)

Under normal circumstances (non lint/validator) the swift version is set for test native targets because the native target of the user often has the Swift version set but during validation the target definition and targets are generated.

To test use CocoaPods 1.4.0.beta.2 on https://github.com/square/Valet project on branch `emuller+dnkoutso/test_specs`. This came up when we were adding support for test specs into that project.