### PR TITLE
Show warning when SDK provider tries to push a version with an unencrypted HTTP source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)
 
+* Prohibit SDK providers to use non-encrypted HTTP links for SDKs  
+  [KrauseFx](https://github.com/KrauseFx)
+  [#7250](https://github.com/CocoaPods/CocoaPods/pull/7250)
+
 ##### Bug Fixes
 
 * Quote framework names in OTHER_LDFLAGS  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)
 
-* Show warning when SDK provider tries to push a version with an unencrypted HTTP source
+* Show warning when SDK provider tries to push a version with an unencrypted HTTP source  
   [KrauseFx](https://github.com/KrauseFx)
   [#7250](https://github.com/CocoaPods/CocoaPods/pull/7250)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)
 
-* Prohibit SDK providers to use non-encrypted HTTP links for SDKs  
+* Show warning when SDK provider tries to push a version with an unencrypted HTTP source
   [KrauseFx](https://github.com/KrauseFx)
   [#7250](https://github.com/CocoaPods/CocoaPods/pull/7250)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -400,7 +400,7 @@ module Pod
       return if spec.source.nil? || spec.source[:http].nil?
       url = spec.source[:http]
       return if url.downcase.start_with?('https://')
-      warning('http', "The URL (#{url}) doesn't use the encrypted HTTPs protocol. " \
+      warning('http', "The URL (`#{url}`) doesn't use the encrypted HTTPs protocol. " \
               'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
               'This will be an error in future releases. Please update the URL to use https.')
     end

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -402,7 +402,7 @@ module Pod
       return if url.downcase.start_with?('https://')
       warning('http', "The URL (#{url}) doesn't use the encrypted HTTPs protocol. " \
               'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
-              'Please update the URL to use https and try again.')
+              'This will be an error in future releases. Please update the URL to use https.')
     end
 
     # Performs validation for which version of Swift is used during validation.

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -307,6 +307,7 @@ module Pod
       validate_screenshots(spec)
       validate_social_media_url(spec)
       validate_documentation_url(spec)
+      validate_source_url(spec)
 
       valid = spec.available_platforms.send(fail_fast ? :all? : :each) do |platform|
         UI.message "\n\n#{spec} - Analyzing on #{platform} platform.".green.reversed
@@ -391,6 +392,17 @@ module Pod
     #
     def validate_documentation_url(spec)
       validate_url(spec.documentation_url) if spec.documentation_url
+    end
+
+    # Performs validations related to the `source` -> `http` attribute (if exists)
+    #
+    def validate_source_url(spec)
+      return if spec.source.nil? || spec.source[:http].nil?
+      url = spec.source[:http]
+      return if url.downcase.start_with?("https://")
+      error('http', "The URL (#{url}) doesn't use the encrypted HTTPs protocol. " \
+            'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
+            'Please update the URL to use https and try again.')
     end
 
     # Performs validation for which version of Swift is used during validation.

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -400,9 +400,9 @@ module Pod
       return if spec.source.nil? || spec.source[:http].nil?
       url = spec.source[:http]
       return if url.downcase.start_with?('https://')
-      error('http', "The URL (#{url}) doesn't use the encrypted HTTPs protocol. " \
-            'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
-            'Please update the URL to use https and try again.')
+      warning('http', "The URL (#{url}) doesn't use the encrypted HTTPs protocol. " \
+              'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
+              'Please update the URL to use https and try again.')
     end
 
     # Performs validation for which version of Swift is used during validation.

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -399,7 +399,7 @@ module Pod
     def validate_source_url(spec)
       return if spec.source.nil? || spec.source[:http].nil?
       url = spec.source[:http]
-      return if url.downcase.start_with?("https://")
+      return if url.downcase.start_with?('https://')
       error('http', "The URL (#{url}) doesn't use the encrypted HTTPs protocol. " \
             'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
             'Please update the URL to use https and try again.')

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -265,13 +265,13 @@ module Pod
           end
 
           it 'checks if the source URL is valid' do
-            Specification.any_instance.stubs(:source).returns({ :http => 'https://orta.io/package.zip' })
+            Specification.any_instance.stubs(:source).returns(:http => 'https://orta.io/package.zip')
             @validator.validate
             @validator.results.should.be.empty?
           end
 
-          it "should fail validation if the source URL is not HTTPs encrypted" do
-            Specification.any_instance.stubs(:source).returns({ :http => 'http://orta.io/package.zip' })
+          it 'should fail validation if the source URL is not HTTPs encrypted' do
+            Specification.any_instance.stubs(:source).returns(:http => 'http://orta.io/package.zip')
             @validator.validate
             @validator.results.map(&:to_s).first.should.match /use the encrypted HTTPs protocol./
           end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -139,6 +139,7 @@ module Pod
           @validator.stubs(:validate_screenshots)
           @validator.stubs(:validate_social_media_url)
           @validator.stubs(:validate_documentation_url)
+          @validator.stubs(:validate_source_url)
           @validator.stubs(:perform_extensive_subspec_analysis)
           Specification.any_instance.stubs(:available_platforms).returns([])
 
@@ -259,6 +260,24 @@ module Pod
         end
 
         describe 'documentation URL validation' do
+          before do
+            @validator.unstub(:validate_source_url)
+          end
+
+          it 'checks if the source URL is valid' do
+            Specification.any_instance.stubs(:source).returns({ :http => 'https://orta.io/package.zip' })
+            @validator.validate
+            @validator.results.should.be.empty?
+          end
+
+          it "should fail validation if the source URL is not HTTPs encrypted" do
+            Specification.any_instance.stubs(:source).returns({ :http => 'http://orta.io/package.zip' })
+            @validator.validate
+            @validator.results.map(&:to_s).first.should.match /use the encrypted HTTPs protocol./
+          end
+        end
+
+        describe 'source URL validation' do
           before do
             @validator.unstub(:validate_documentation_url)
           end


### PR DESCRIPTION
Related to https://github.com/CocoaPods/CocoaPods/pull/7249, fixes https://github.com/CocoaPods/CocoaPods/issues/7238

I'll add tests, once I get the ok that this is the right location and the right approach. For now I used the `error` method to fail the validation. I believe that it's the right thing to do, there is no good excuse to transfer executable over non-encrypted protocols, however I do understand that this might throw off some SDK providers, and them being overwhelmed when they quickly need to push an update.

You all have more context around what the users are like, and if they have a way to work around this, just let me know what you're deciding on :+1: