### PR TITLE
Allow installation of a pod with its own Swift version on multiple targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Allow installation of a pod with its own Swift version on multiple targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7261](https://github.com/CocoaPods/CocoaPods/pull/7261)
+
 * Quote framework names in OTHER_LDFLAGS  
   [Tyler Stromberg](https://github.com/AquaGeek)
   [#7185](https://github.com/CocoaPods/CocoaPods/issues/7185)

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -91,6 +91,7 @@ module Pod
           end
           swift_pod_targets = pod_targets.select(&:uses_swift?)
           error_messages = swift_pod_targets.map do |pod_target|
+            next unless pod_target.spec_swift_version.nil?
             swift_target_definitions = pod_target.target_definitions.reject { |target| target.swift_version.blank? }
             next if swift_target_definitions.empty? || swift_target_definitions.uniq(&:swift_version).count == 1
             target_errors = swift_target_definitions.map(&error_message_for_target).join(', ')

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -100,7 +100,13 @@ module Pod
     #                  targets that include this pod target.
     #
     def swift_version
-      root_spec.swift_version || target_definitions.map(&:swift_version).compact.uniq.first
+      spec_swift_version || target_definitions.map(&:swift_version).compact.uniq.first
+    end
+
+    # @return [String] the Swift version within the root spec. Might be `nil` if none is set.
+    #
+    def spec_swift_version
+      root_spec.swift_version
     end
 
     # @note   The deployment target for the pod target is the maximum of all

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -225,8 +225,8 @@ module Pod
             podfile.target_definitions['SampleProject'].stubs(:swift_version).returns('3.0')
             podfile.target_definitions['TestRunner'].stubs(:swift_version).returns('2.3')
 
-            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']])
-            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => false, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']])
+            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => nil)
+            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => false, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => nil)
 
             @validator = TargetValidator.new([], [orangeframework_pod_target, matryoshka_pod_target])
             e = should.raise Informative do
@@ -254,8 +254,8 @@ module Pod
             # when the swift version is unset at the project level, but set in one target, swift_version is nil
             podfile.target_definitions['TestRunner'].stubs(:swift_version).returns(nil)
 
-            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']])
-            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']])
+            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => nil)
+            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => nil)
 
             @validator = TargetValidator.new([], [orangeframework_pod_target, matryoshka_pod_target])
             lambda { @validator.validate! }.should.not.raise
@@ -278,8 +278,31 @@ module Pod
             podfile.target_definitions['TestRunner'].stubs(:swift_version).returns('2.3')
 
             # Pretend none of the pod targets use swift, even if the target definitions they are linked with do have different Swift versions.
-            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => false, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']])
-            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => false, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']])
+            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => false, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => nil)
+            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => false, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => nil)
+
+            @validator = TargetValidator.new([], [orangeframework_pod_target, matryoshka_pod_target])
+            lambda { @validator.validate! }.should.not.raise
+          end
+
+          it 'does not raise when targets with different Swift versions integrate the same pod that specifies swift version attribute' do
+            fixture_path = ROOT + 'spec/fixtures'
+            config.repos_dir = fixture_path + 'spec-repos'
+            podfile = Podfile.new do
+              project 'SampleProject/SampleProject'
+              use_frameworks!
+              platform :ios, '8.0'
+              pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
+              pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
+              target 'SampleProject'
+              target 'TestRunner'
+            end
+
+            podfile.target_definitions['SampleProject'].stubs(:swift_version).returns('3.0')
+            podfile.target_definitions['TestRunner'].stubs(:swift_version).returns('2.3')
+
+            orangeframework_pod_target = stub(:name => 'OrangeFramework', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => '4.0')
+            matryoshka_pod_target = stub(:name => 'matryoshka', :uses_swift? => true, :target_definitions => [podfile.target_definitions['SampleProject'], podfile.target_definitions['TestRunner']], :spec_swift_version => '3.2')
 
             @validator = TargetValidator.new([], [orangeframework_pod_target, matryoshka_pod_target])
             lambda { @validator.validate! }.should.not.raise


### PR DESCRIPTION
If a pod specifies `swift_version` we should not error out when it is integrated with 2 different targets that have a different Swift version.