### PR TITLE
Set development pods' podspecs syntax to Ruby when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [iv-mexx](https://github.com/iv-mexx)
   [#7204](https://github.com/CocoaPods/CocoaPods/pull/7204)
 
+* Set syntax of podspecs from development pods to Ruby when appropriate  
+  [Eric Amorde](https://github.com/amorde)
+  [#7278](https://github.com/CocoaPods/CocoaPods/pull/7278)
+
 * Add support for editing the podspec, license, README, license, and docs of local development pods  
   [Eric Amorde](https://github.com/amorde)
   [#7093](https://github.com/CocoaPods/CocoaPods/pull/7093)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -119,7 +119,10 @@ module Pod
                 paths = file_accessor.developer_files
                 paths.each do |path|
                   group = pods_project.group_for_spec(root_name, :developer)
-                  pods_project.add_file_reference(path, group, false)
+                  ref = pods_project.add_file_reference(path, group, false)
+                  if path.extname == '.podspec'
+                    pods_project.mark_ruby_file_ref(ref)
+                  end
                 end
               end
             end

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -221,10 +221,20 @@ module Pod
     #
     def add_podfile(podfile_path)
       new_file(podfile_path, :project).tap do |podfile_ref|
-        podfile_ref.xc_language_specification_identifier = 'xcode.lang.ruby'
-        podfile_ref.explicit_file_type = 'text.script.ruby'
-        podfile_ref.last_known_file_type = 'text'
+        mark_ruby_file_ref(podfile_ref)
       end
+    end
+
+    # Sets the syntax of the provided file reference to be Ruby, in the case that
+    # the file does not already have a ".rb" file extension (ex. the Podfile)
+    #
+    # @param  [PBXFileReference] file_ref
+    #         The file reference to change
+    #
+    def mark_ruby_file_ref(file_ref)
+      file_ref.xc_language_specification_identifier = 'xcode.lang.ruby'
+      file_ref.explicit_file_type = 'text.script.ruby'
+      file_ref.last_known_file_type = 'text'
     end
 
     # Adds a new build configuration to the project and populates it with

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -246,6 +246,15 @@ module Pod
           ref = @project.add_file_reference(sym_file, @group)
           ref.hierarchy_path.should == '/Pods/BananaLib/file.m'
         end
+
+        it 'sets syntax to ruby when requested' do
+          Pathname.any_instance.stubs(:realpath).returns(@file)
+          ref = @project.add_file_reference(@file, @group)
+          @project.mark_ruby_file_ref(ref)
+          ref.xc_language_specification_identifier.should == 'xcode.lang.ruby'
+          ref.explicit_file_type.should == 'text.script.ruby'
+          ref.last_known_file_type.should == 'text'
+        end
       end
 
       #----------------------------------------#


### PR DESCRIPTION
This will set the syntax to ruby only when the file extension is `.podspec`, not `.podspec.json` or `.json`

Refer to #7093 