### PR TITLE
Show warning when Pod source uses unencrypted HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Show warning when Pod source uses unencrypted HTTP  
+  [KrauseFx](https://github.com/KrauseFx)
+  [#7238](https://github.com/CocoaPods/CocoaPods/issues/7238)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Show warning when Pod source uses unencrypted HTTP  
   [KrauseFx](https://github.com/KrauseFx)
-  [#7238](https://github.com/CocoaPods/CocoaPods/issues/7238)
+  [#7293](https://github.com/CocoaPods/CocoaPods/issues/7293)
 
 ##### Bug Fixes
 

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -32,6 +32,22 @@ module Pod
         end
       end
 
+      it 'does not show warning if the source is encrypted using https' do
+        @spec.source = { :http => 'https://orta.io/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @installer.install!
+        UI.warnings.length.should.equal(0)
+      end
+
+      it 'shows a warning if the source is unencrypted (e.g. http)' do
+        @spec.source = { :http => 'http://orta.io/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @installer.install!
+        UI.warnings.should.include 'Please reach out to the library author to notify them of this security issue'
+      end
+
       #--------------------------------------#
 
       describe 'Prepare command' do


### PR DESCRIPTION
This PR addresses the first half of #7238, related to #7250 

Via https://github.com/CocoaPods/CocoaPods/pull/7249