### PR TITLE
[Resolver] Sort external source dependencies first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#7031](https://github.com/CococaPods/CocoaPods/issues/7031)
 
+* Ensure that externally-sourced (e.g. local & git) pods are allowed to resolve
+  to prerelease versions.  
+  [segiddins](https://github.com/segiddins)
+
 ## 1.4.0.rc.1 (2017-12-16)
 
 ##### Enhancements

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -261,6 +261,7 @@ module Pod
         name = name_for(dependency)
         [
           activated.vertex_named(name).payload ? 0 : 1,
+          dependency.external_source ? 0 : 1,
           dependency.prerelease? ? 0 : 1,
           conflicts[name] ? 0 : 1,
           search_for(dependency).count,


### PR DESCRIPTION
This resolves a (potential) ordering bug due to pre-releases.

In #possibility_versions_for_root_name, we check whether dependencies on a pod are pre-release or external source, and if so allow pre-releases. It is crucial, therefore, that any external source dependencies have been addressed before any transitive source without the external source, so that pre-releases are (properly) allowed.