### PR TITLE
Log target names missing host for libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Log target names missing host for libraries  
+  [Keith Smiley](https://github.com/keith)
+  [#7346](https://github.com/CocoaPods/CocoaPods/pull/7346)
+
 * Show warning when Pod source uses unencrypted HTTP  
   [KrauseFx](https://github.com/KrauseFx)
   [#7293](https://github.com/CocoaPods/CocoaPods/issues/7293)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -336,17 +336,17 @@ module Pod
 
         unless embedded_targets_missing_hosts.empty?
           embedded_targets_missing_hosts_product_types = Set.new embedded_targets_missing_hosts.map(&:user_targets).flatten.map(&:symbol_type)
+          target_names = embedded_targets_missing_hosts.map do |target|
+            target.name.sub('Pods-', '') # Make the target names more recognizable to the user
+          end.join ', '
           #  If the targets missing hosts are only frameworks, then this is likely
           #  a project for doing framework development. In that case, just warn that
           #  the frameworks that these targets depend on won't be integrated anywhere
           if embedded_targets_missing_hosts_product_types.subset?(Set.new([:framework, :static_library]))
-            UI.warn 'The Podfile contains framework or static library targets, for which the Podfile does not contain host targets (targets which embed the framework).' \
+            UI.warn "The Podfile contains framework or static library targets (#{target_names}), for which the Podfile does not contain host targets (targets which embed the framework)." \
               "\n" \
               'If this project is for doing framework development, you can ignore this message. Otherwise, add a target to the Podfile that embeds these frameworks to make this message go away (e.g. a test target).'
           else
-            target_names = embedded_targets_missing_hosts.map do |target|
-              target.name.sub('Pods-', '') # Make the target names more recognizable to the user
-            end.join ', '
             raise Informative, "Unable to find host target(s) for #{target_names}. Please add the host targets for the embedded targets to the Podfile." \
                                 "\n" \
                                 'Certain kinds of targets require a host target. A host target is a "parent" target which embeds a "child" target. These are example types of targets that need a host target:' \

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -841,7 +841,7 @@ module Pod
           end
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           analyzer.analyze
-          UI.warnings.should.match /The Podfile contains framework or static library targets, for which the Podfile does not contain host targets \(targets which embed the framework\)\./
+          UI.warnings.should.match /The Podfile contains framework or static library targets \(SampleLib\), for which the Podfile does not contain host targets \(targets which embed the framework\)\./
         end
 
         it 'warns when using a Podfile for framework-only projects' do
@@ -856,7 +856,7 @@ module Pod
           end
           analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
           analyzer.analyze
-          UI.warnings.should.match /The Podfile contains framework or static library targets, for which the Podfile does not contain host targets \(targets which embed the framework\)\./
+          UI.warnings.should.match /The Podfile contains framework or static library targets \(SampleFramework\), for which the Podfile does not contain host targets \(targets which embed the framework\)\./
         end
 
         it 'raises when the extension calls use_frameworks!, but the host target does not' do


### PR DESCRIPTION
Previously we only logged the target name if the target missing a host
wasn't a framework target. Logging it for framework targets as well can
be useful for debugging Podfile configuration issues.