### PR TITLE
Store spec repos in the Lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   existing specs that have already been pushed.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Store which specs repo a pod comes from in the lockfile.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Unique all available pre-release versions when displaying  

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core', 'seg-lockfile-spec-repos'
+  cp_gem 'cocoapods-core',        'Core'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core'
+  cp_gem 'cocoapods-core',        'Core', 'seg-lockfile-spec-repos'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: f80744433c6d5d1229d663b289456cc5662d91a9
-  branch: seg-lockfile-spec-repos
+  revision: c67c10dc718bae4c07bdfb78d8917134432aaff4
+  branch: master
   specs:
     cocoapods-core (1.4.0)
       activesupport (>= 4.0.2, < 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: b4fb2f193897c789c094d126ebca91034edc261d
-  branch: master
+  revision: f80744433c6d5d1229d663b289456cc5662d91a9
+  branch: seg-lockfile-spec-repos
   specs:
     cocoapods-core (1.4.0)
       activesupport (>= 4.0.2, < 6)
@@ -180,7 +180,7 @@ GEM
     gh_inspector (1.0.3)
     git (1.3.0)
     hashdiff (0.3.1)
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     inch (0.7.0)
       pry

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -550,7 +550,7 @@ module Pod
     def write_lockfiles
       external_source_pods = podfile.dependencies.select(&:external_source).map(&:root_name).uniq
       checkout_options = sandbox.checkout_sources.select { |root_name, _| external_source_pods.include? root_name }
-      @lockfile = Lockfile.generate(podfile, analysis_result.specifications, checkout_options)
+      @lockfile = Lockfile.generate(podfile, analysis_result.specifications, checkout_options, analysis_result.specs_by_source)
 
       UI.message "- Writing Lockfile in #{UI.path config.lockfile_path}" do
         @lockfile.write_to_disk(config.lockfile_path)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -90,6 +90,8 @@ module Pod
         @result.specs_by_target = resolver_specs_by_target.each_with_object({}) do |rspecs_by_target, hash|
           hash[rspecs_by_target[0]] = rspecs_by_target[1].map(&:spec)
         end
+        @result.specs_by_source = Hash[resolver_specs_by_target.values.flatten(1).group_by(&:source).map { |source, specs| [source, specs.map(&:spec).uniq] }]
+        sources.each { |s| @result.specs_by_source[s] ||= [] }
         @result
       end
 

--- a/lib/cocoapods/installer/analyzer/analysis_result.rb
+++ b/lib/cocoapods/installer/analyzer/analysis_result.rb
@@ -11,6 +11,11 @@ module Pod
         #
         attr_accessor :specs_by_target
 
+        # @return [Hash{Source => Array<Specification>}] the
+        #         specifications grouped by spec repo source.
+        #
+        attr_accessor :specs_by_source
+
         # @return [Array<Specification>] the specifications of the resolved
         #         version of Pods that should be installed.
         #

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -20,14 +20,19 @@ module Pod
       #
       attr_reader :spec
 
+      # @return [Source] the spec repo source the specification came from
+      #
+      attr_reader :source
+
       # @return [Bool] whether this resolved specification is only used by tests.
       #
       attr_reader :used_by_tests_only
       alias used_by_tests_only? used_by_tests_only
 
-      def initialize(spec, used_by_tests_only)
+      def initialize(spec, used_by_tests_only, source)
         @spec = spec
         @used_by_tests_only = used_by_tests_only
+        @source = source
       end
 
       def name
@@ -129,7 +134,7 @@ module Pod
 
           resolver_specs_by_target[target] = specs.
             group_by(&:first).
-            map { |vertex, spec_test_only_tuples| ResolverSpecification.new(vertex.payload, spec_test_only_tuples.map { |tuple| tuple[1] }.all?) }.
+            map { |vertex, spec_test_only_tuples| ResolverSpecification.new(vertex.payload, spec_test_only_tuples.map { |tuple| tuple[1] }.all?, vertex.payload.respond_to?(:spec_source) && vertex.payload.spec_source) }.
             sort_by(&:name)
         end
       end

--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -32,7 +32,7 @@ module Pod
 
 ```
 #{exception.class} - #{exception.message}
-#{exception.backtrace.join("\n")}
+#{exception.backtrace.join("\n") if exception.backtrace}
 ```
 
 #{'――― TEMPLATE END ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――'.reversed}

--- a/spec/functional/command/update_spec.rb
+++ b/spec/functional/command/update_spec.rb
@@ -30,7 +30,11 @@ module Pod
           end,
         ]
         external_sources = {}
-        Lockfile.generate(podfile, specs, external_sources).write_to_disk(temporary_directory + 'Podfile.lock')
+        specs_by_source = {
+          Source.new(fixture('spec-repos/master')) => specs,
+        }
+        Lockfile.generate(podfile, specs, external_sources, specs_by_source).
+          write_to_disk(temporary_directory + 'Podfile.lock')
       end
 
       describe 'updates of the spec repos' do

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -698,8 +698,8 @@ module Pod
       #-------------------------------------------------------------------------#
 
       it 'does include pod target if any spec is not used by tests only and is part of target definition' do
-        spec1 = Resolver::ResolverSpecification.new(stub, false)
-        spec2 = Resolver::ResolverSpecification.new(stub, true)
+        spec1 = Resolver::ResolverSpecification.new(stub, false, nil)
+        spec2 = Resolver::ResolverSpecification.new(stub, true, nil)
         target_definition = stub
         pod_target = stub(:name => 'Pod1', :target_definitions => [target_definition], :specs => [spec1.spec, spec2.spec])
         resolver_specs_by_target = { target_definition => [spec1, spec2] }
@@ -707,8 +707,8 @@ module Pod
       end
 
       it 'does not include pod target if its used by tests only' do
-        spec1 = Resolver::ResolverSpecification.new(stub, true)
-        spec2 = Resolver::ResolverSpecification.new(stub, true)
+        spec1 = Resolver::ResolverSpecification.new(stub, true, nil)
+        spec2 = Resolver::ResolverSpecification.new(stub, true, nil)
         target_definition = stub
         pod_target = stub(:name => 'Pod1', :target_definitions => [target_definition], :specs => [spec1.spec, spec2.spec])
         resolver_specs_by_target = { target_definition => [spec1, spec2] }
@@ -716,7 +716,7 @@ module Pod
       end
 
       it 'does not include pod target if its not part of the target definition' do
-        spec = Resolver::ResolverSpecification.new(stub, false)
+        spec = Resolver::ResolverSpecification.new(stub, false, nil)
         target_definition = stub
         pod_target = stub(:name => 'Pod1', :target_definitions => [], :specs => [spec.spec])
         resolver_specs_by_target = { target_definition => [spec] }

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -564,6 +564,7 @@ module Pod
         before do
           @analysis_result = Installer::Analyzer::AnalysisResult.new
           @analysis_result.specifications = [fixture_spec('banana-lib/BananaLib.podspec')]
+          @analysis_result.specs_by_source = {}
           @installer.stubs(:analysis_result).returns(@analysis_result)
         end
 


### PR DESCRIPTION
Needs some polish & docs & CHANGELOG, but I think this is a good start!

Depends upon https://github.com/CocoaPods/Core/pull/421

This way, we can let users know when a pod has changed sources (and inspecting the lockfile will tell you which source every spec is coming from!)