### PR TITLE
Change colorscheme of `pod outdated` from red-yellow-green to red-blue-green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   resources or embed frameworks unless `UNLOCALIZED_RESOURCES_FOLDER_PATH` 
   or `FRAMEWORKS_FOLDER_PATH` is set.  
   [Samuel Giddins](https://github.com/segiddins)
+
 * Change color scheme of `pod outdated` from red-yellow-green to red-blue-green to be more colorblind friendly  
   [iv-mexx](https://github.com/iv-mexx)  
   [#7372](https://github.com/CocoaPods/CocoaPods/issues/7372)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   resources or embed frameworks unless `UNLOCALIZED_RESOURCES_FOLDER_PATH` 
   or `FRAMEWORKS_FOLDER_PATH` is set.  
   [Samuel Giddins](https://github.com/segiddins)
+* Change color scheme of `pod outdated` from red-yellow-green to red-blue-green to be more colorblind friendly  
+  [iv-mexx](https://github.com/iv-mexx)  
+  [#7372](https://github.com/CocoaPods/CocoaPods/issues/7372)  
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/outdated.rb
+++ b/lib/cocoapods/command/outdated.rb
@@ -24,13 +24,13 @@ module Pod
         else
           UI.section 'The color indicates what happens when you run `pod update`' do
             UI.puts "#{'<green>'.green}\t\t - Will be updated to the newest version"
-            UI.puts "#{'<yellow>'.yellow}\t - Will be updated, but not to the newest version because of specified version in Podfile"
+            UI.puts "#{'<blue>'.blue}\t - Will be updated, but not to the newest version because of specified version in Podfile"
             UI.puts "#{'<red>'.red}\t\t - Will not be updated because of specified version in Podfile"
             UI.puts ''
           end
           UI.section 'The following pod updates are available:' do
             updates.each do |(name, from_version, matching_version, to_version)|
-              color = :yellow
+              color = :blue
               if matching_version == to_version
                 color = :green
               elsif from_version == matching_version

--- a/spec/functional/command/outdated_spec.rb
+++ b/spec/functional/command/outdated_spec.rb
@@ -75,16 +75,16 @@ module Pod
       UI.output.should.include('BlocksKit 1.0 -> 1.0 (latest version 2.0)')
     end
 
-    it 'tells the user about outdated pods that can be updated, but not to the latest version in yellow' do
+    it 'tells the user about outdated pods that can be updated, but not to the latest version in blue' do
       pod_name = 'BlocksKit'
 
       current_version_string = mock
-      current_version_string.expects(:yellow).returns('1.0').once
+      current_version_string.expects(:blue).returns('1.0').once
       current_version = mock
       current_version.stubs(:to_s).returns(current_version_string)
 
       next_version_string = mock
-      next_version_string.expects(:yellow).returns('1.1').once
+      next_version_string.expects(:blue).returns('1.1').once
       next_version = mock
       next_version.stubs(:to_s).returns(next_version_string)
 


### PR DESCRIPTION
This is an improvement for colorblind users who can not differentiate between green and yellow.
Refs #7372 

As discussed in #7372 there might be a more comprehensive solution in the future. 

🌈