### PR TITLE
Warn instead of throwing an exception when dev pod's license file is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Warn instead of throwing an exception when a development pod specifies an invalid license file path  
+  [Eric Amorde](https://github.com/amorde)
+  [#7377](https://github.com/CocoaPods/CocoaPods/issues/7377)
+
 * Better static frameworks transitive dependency error checking  
   [Paul Beusterien](https://github.com/paulb777)
   [#7352](https://github.com/CocoaPods/CocoaPods/issues/7352)

--- a/lib/cocoapods/generator/acknowledgements.rb
+++ b/lib/cocoapods/generator/acknowledgements.rb
@@ -73,13 +73,16 @@ module Pod
         return nil unless spec.license
         text = spec.license[:text]
         unless text
-          if license_file = file_accessor(spec).license
-            if license_file.exist?
-              text = IO.read(license_file)
+          if license_file = spec.license[:file]
+            license_path = file_accessor(spec).root + license_file
+            if File.exist?(license_path)
+              text = IO.read(license_path)
             else
               UI.warn "Unable to read the license file `#{license_file}` " \
               "for the spec `#{spec}`"
             end
+          elsif license_file = file_accessor(spec).license
+            text = IO.read(license_file)
           end
         end
         text


### PR DESCRIPTION
Closes #7377 

@dnkoutso I double checked the other files and it seems the license file is the only one with the problem, due to the way it checks the Podspec and falls back to a glob pattern