### PR TITLE
[Sandbox] Clean up usage of #local?

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -651,7 +651,7 @@ module Pod
     #
     def development_pod_targets
       pod_targets.select do |pod_target|
-        sandbox.development_pods.keys.include?(pod_target.pod_name)
+        sandbox.local?(pod_target.pod_name)
       end
     end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -277,7 +277,7 @@ module Pod
         #
         def development_pod_targets
           pod_targets.select do |pod_target|
-            sandbox.development_pods.keys.include?(pod_target.pod_name)
+            sandbox.local?(pod_target.pod_name)
           end
         end
 

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -389,9 +389,7 @@ module Pod
     #
     def local_podspec(name)
       root_name = Specification.root_name(name)
-      if path = development_pods[root_name]
-        Pathname.new(path)
-      end
+      development_pods[root_name]
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -438,7 +438,7 @@ module Pod
                 pod_target = fixture_pod_target(spec)
 
                 @generator.stubs(:pod_targets).returns([pod_target])
-                @generator.sandbox.stubs(:development_pods).returns('BananaLib' => nil)
+                @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
               end
 
               it 'does not share by default' do
@@ -468,7 +468,7 @@ module Pod
                     returns(true)
 
                 @generator.stubs(:pod_targets).returns([pod_target])
-                @generator.sandbox.stubs(:development_pods).returns('CoconutLib' => nil)
+                @generator.sandbox.stubs(:development_pods).returns('CoconutLib' => fixture('CoconutLib'))
 
                 Xcodeproj::XCScheme.expects(:share_scheme).with(
                   @generator.project.path,


### PR DESCRIPTION
Trivial changes, hopefully they'll cut down on some spurious CI failures around null bytes in `Pathname.new`