### PR TITLE
Preserve external sources on locked dependencies in the resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Speed up `pod install` times by up to 50% for very large project.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Avoid dependency resolution conflicts when a pod depends upon a local pod.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.4.0 (2018-01-18)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     terminal-table (1.6.0)
     thread_safe (0.3.6)
     tins (1.8.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (0.3.1)
     webmock (2.3.1)

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -163,7 +163,9 @@ module Pod
     def search_for(dependency)
       @search ||= {}
       @search[dependency] ||= begin
-        specifications_for_dependency(dependency, [requirement_for_locked_pod_named(dependency.name)])
+        locked_requirement = requirement_for_locked_pod_named(dependency.name)
+        additional_requirements = Array(locked_requirement)
+        specifications_for_dependency(dependency, additional_requirements)
       end
       @search[dependency].dup
     end
@@ -357,7 +359,7 @@ module Pod
     # @return [Array<Specification>] List of specifications satisfying given requirements.
     #
     def specifications_for_dependency(dependency, additional_requirements = [])
-      requirement = Requirement.new(dependency.requirement.as_list + additional_requirements)
+      requirement = Requirement.new(dependency.requirement.as_list + additional_requirements.flat_map(&:as_list))
       find_cached_set(dependency).
         all_specifications(installation_options.warn_for_multiple_pod_sources).
         select { |s| requirement.satisfied_by? s.version }.


### PR DESCRIPTION
This PR preserves the `external_source` attribute on dependencies generated by the locking dependency analyzer, which ensures the resolver won't complain about pre-release versions for "locked" development pods.

cc @justinseanmartin 