### PR TITLE
Add support for modular header search paths, include "legacy" support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add support for modular header search paths, include "legacy" support.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7412](https://github.com/CocoaPods/CocoaPods/pull/7412)
+
 * Set direct and transitive dependency header search paths for pod targets  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7116](https://github.com/CocoaPods/CocoaPods/pull/7116)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 1f8ced657a224eabeba6958d130ee04058d91f60
+  revision: e0c6884b37ab6a44095a2bbdbfe9032627a90388
   branch: master
   specs:
     cocoapods-core (1.4.0)

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -163,11 +163,11 @@ module Pod
 
         private
 
-        # Add build settings, which ensure that the pod targets can be imported
-        # from the integrating target by all sort of imports, which are:
-        #  - `#import <…>`
-        #  - `#import "…"`
-        #  - `@import …;` / `import …`
+        # Add build settings, which ensure that the pod targets can be imported from the integrating target.
+        # For >= 1.5.0 we use modular (stricter) header search paths this means that the integrated target will only be
+        # able to import public headers using `<>` or `@import` notation, but never import any private headers.
+        #
+        # For < 1.5.0 legacy header search paths the same rules apply: It's the wild west.
         #
         def generate_settings_to_import_pod_targets
           @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, pod_targets)
@@ -176,7 +176,6 @@ module Pod
             generator = AggregateXCConfig.new(search_paths_target, configuration_name)
             @xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(nil, search_paths_target.pod_targets)
             @xcconfig.merge!(generator.settings_to_import_pod_targets)
-
             # Propagate any HEADER_SEARCH_PATHS settings from the search paths.
             XCConfigHelper.propagate_header_search_paths_from_search_paths(search_paths_target, @xcconfig)
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -312,6 +312,7 @@ module Pod
           #
           def header_mappings(headers_sandbox, file_accessor, headers, visibility_scope = :private)
             consumer = file_accessor.spec_consumer
+            header_mappings_dir = consumer.header_mappings_dir
             dir = headers_sandbox
             dir += headers_sandbox if visibility_scope == :public
             dir += consumer.header_dir if consumer.header_dir
@@ -319,9 +320,8 @@ module Pod
             mappings = {}
             headers.each do |header|
               sub_dir = dir
-              if consumer.header_mappings_dir
-                header_mappings_dir = file_accessor.path_list.root + consumer.header_mappings_dir
-                relative_path = header.relative_path_from(header_mappings_dir)
+              if header_mappings_dir
+                relative_path = header.relative_path_from(file_accessor.path_list.root + header_mappings_dir)
                 sub_dir += relative_path.dirname
               end
               mappings[sub_dir] ||= []

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -57,7 +57,7 @@ module Pod
     def initialize(root)
       FileUtils.mkdir_p(root)
       @root = Pathname.new(root).realpath
-      @public_headers = HeadersStore.new(self, 'Public')
+      @public_headers = HeadersStore.new(self, 'Public', :public)
       @predownloaded_pods = []
       @checkout_sources = {}
       @development_pods = {}

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -585,14 +585,31 @@ module Pod
     #
     def header_search_paths(include_test_dependent_targets = false)
       header_search_paths = []
-      header_search_paths.concat(build_headers.search_paths(platform, nil, defines_module?))
-      header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name, defines_module?))
+      header_search_paths.concat(build_headers.search_paths(platform, nil, uses_modular_headers?))
+      header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name, uses_modular_headers?))
       dependent_targets = recursive_dependent_targets
       dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets
       dependent_targets.each do |dependent_target|
-        header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name, defines_module?))
+        header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name, defines_module? && dependent_target.uses_modular_headers?(false)))
       end
       header_search_paths.uniq
+    end
+
+    protected
+
+    # Returns whether the pod target should use modular headers.
+    #
+    # @param  [Boolean] only_if_defines_modules
+    #         whether the use of modular headers should require the target to define a module
+    #
+    # @note  This must return false when a pod has a `header_mappings_dir`,
+    #        as that allows the spec to completely customize the header structure, and
+    #        therefore it might not be expecting the module name to be prepended
+    #        to imports at all.
+    #
+    def uses_modular_headers?(only_if_defines_modules = true)
+      return false if only_if_defines_modules && !defines_module?
+      spec_consumers.none?(&:header_mappings_dir)
     end
 
     private

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -204,6 +204,7 @@ module Pod
     def defines_module?
       return @defines_module if defined?(@defines_module)
       return @defines_module = true if uses_swift? || requires_frameworks?
+      return @defines_module = true if target_definitions.any? { |td| td.build_pod_as_module?(pod_name) }
 
       @defines_module = non_test_specs.any? { |s| s.consumer(platform).pod_target_xcconfig['DEFINES_MODULE'] == 'YES' }
     end

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -279,6 +279,11 @@ describe_cli 'pod' do
                             'install --no-repo-update'
     end
 
+    describe 'Integrates a Pod with a header mappings directory' do
+      behaves_like cli_spec 'install_header_mappings_dir',
+                            'install --no-repo-update'
+    end
+
     describe 'Integrates a Pod using non Objective-C source files' do
       behaves_like cli_spec 'install_non_objective_c_files',
                             'install --no-repo-update'

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -126,6 +126,10 @@ module Pod
         #-----------------------------------------------------------------------#
 
         describe 'with library' do
+          before do
+            config.sandbox.public_headers.stubs(:search_paths).returns(['${PODS_ROOT}/Headers/Public/BananaLib'])
+          end
+
           def specs
             [fixture_spec('banana-lib/BananaLib.podspec')]
           end
@@ -137,12 +141,12 @@ module Pod
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as header search paths' do
-            expected = "$(inherited) \"#{config.sandbox.public_headers.search_paths(Platform.ios).join('" "')}\""
+            expected = '$(inherited) "${PODS_ROOT}/Headers/Public/BananaLib"'
             @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == expected
           end
 
           it 'adds the sandbox public headers search paths to the xcconfig, with quotes, as system headers' do
-            expected = "$(inherited) -isystem \"#{config.sandbox.public_headers.search_paths(Platform.ios).join('" -isystem "')}\""
+            expected = '$(inherited) -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
             @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
           end
 
@@ -185,6 +189,10 @@ module Pod
           end
 
           describe 'with a vendored-library pod' do
+            before do
+              config.sandbox.public_headers.stubs(:search_paths).returns(['${PODS_ROOT}/Headers/Public/monkey'])
+            end
+
             def specs
               [fixture_spec('monkey/monkey.podspec')]
             end
@@ -199,23 +207,26 @@ module Pod
 
             it 'does not include framework header paths as local headers for pods that are linked statically' do
               monkey_headers = '-iquote "${PODS_CONFIGURATION_BUILD_DIR}/monkey.framework/Headers"'
+              @xcconfig = @generator.generate
               @xcconfig.to_hash['OTHER_CFLAGS'].should.not.include monkey_headers
             end
 
             it 'includes the public header paths as system headers' do
-              expected = '$(inherited) -iquote "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework/OrangeFramework.framework/Headers" -isystem "${PODS_ROOT}/Headers/Public"'
+              expected = '$(inherited) -iquote "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework/OrangeFramework.framework/Headers" -isystem "${PODS_ROOT}/Headers/Public/monkey"'
               @generator.stubs(:pod_targets).returns([@pod_targets.first, pod_target(fixture_spec('orange-framework/OrangeFramework.podspec'), @target_definition)])
               @xcconfig = @generator.generate
               @xcconfig.to_hash['OTHER_CFLAGS'].should == expected
             end
 
             it 'includes the public header paths as user headers' do
-              expected = '${PODS_ROOT}/Headers/Public'
+              expected = '${PODS_ROOT}/Headers/Public/monkey'
+              @xcconfig = @generator.generate
               @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include expected
             end
 
             it 'includes $(inherited) in the header search paths' do
               expected = '$(inherited)'
+              @xcconfig = @generator.generate
               @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include expected
             end
 

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -133,11 +133,8 @@ module Pod
             @xcconfig.to_hash['PODS_TARGET_SRCROOT'].should == '${PODS_ROOT}/../../spec/fixtures/banana-lib'
           end
 
-          it 'adds the library build headers and public headers search paths to the xcconfig, with quotes' do
-            private_headers = "\"#{@pod_target.build_headers.search_paths(Platform.new(:ios)).join('" "')}\""
-            public_headers = "\"#{config.sandbox.public_headers.search_paths(Platform.new(:ios)).join('" "')}\""
-            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include private_headers
-            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.include public_headers
+          it 'does not add root public or private header search paths to the xcconfig' do
+            @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should.be.empty
           end
 
           it 'adds the COCOAPODS macro definition' do
@@ -269,8 +266,10 @@ module Pod
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/monkey"'
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Private/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/BananaLib/BananaLib"' \
+              ' "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/CoconutLib/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public/monkey" "${PODS_ROOT}/Headers/Public/monkey/monkey"'
           end
 
           it 'adds correct header search paths for dependent and test targets for non test xcconfigs' do
@@ -285,8 +284,9 @@ module Pod
             # This is not an test xcconfig so it should exclude header search paths for the 'monkey' pod
             generator = PodXCConfig.new(@coconut_pod_target, false)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/CoconutLib"'
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Private/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/BananaLib/BananaLib"' \
+              ' "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/CoconutLib/CoconutLib"'
           end
 
           it 'does not include other ld flags for test dependent targets if its not a test xcconfig' do

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -11,6 +11,7 @@ module Pod
 
             vspec = stub(:test_specification? => false)
             consumer = stub(
+              "Spec Consumer (#{vspec} iOS)",
               :pod_target_xcconfig => {},
               :libraries => ['xml2'],
               :frameworks => [],
@@ -18,6 +19,7 @@ module Pod
               :platform_name => :ios,
             )
             file_accessor = stub(
+              'File Accessor',
               :spec => vspec,
               :spec_consumer => consumer,
               :vendored_static_frameworks => [config.sandbox.root + 'AAA/StaticFramework.framework'],
@@ -26,6 +28,7 @@ module Pod
               :vendored_dynamic_libraries => [config.sandbox.root + 'DDD/VendoredDyld.dyld'],
             )
             vendored_dep_target = stub(
+              'Vendored Dependent Target',
               :name => 'BananaLib',
               :pod_name => 'BananaLib',
               :sandbox => config.sandbox,
@@ -34,6 +37,7 @@ module Pod
               :static_framework? => false,
               :dependent_targets => [],
               :file_accessors => [file_accessor],
+              :uses_modular_headers? => false,
             )
 
             @spec = fixture_spec('banana-lib/BananaLib.podspec')

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -84,7 +84,7 @@ module Pod
             it 'links the public headers meant for the user' do
               @installer.install!
               headers_root = config.sandbox.public_headers.root
-              public_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
+              public_headers = [headers_root + 'BananaLib/BananaLib/Banana.h', headers_root + 'BananaLib/BananaLib/MoreBanana.h']
               private_header = headers_root + 'BananaLib/BananaPrivate.h'
               framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
               framework_subdir_header = headers_root + 'BananaLib/Bananalib/SubDir/SubBananalib.h'
@@ -106,7 +106,7 @@ module Pod
               headers_root = config.sandbox.public_headers.root
               banana_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
               banana_headers.each { |banana_header| banana_header.should.not.exist }
-              monkey_header = headers_root + 'monkey/monkey.h'
+              monkey_header = headers_root + 'monkey/monkey/monkey.h'
               monkey_header.should.exist
             end
 
@@ -206,22 +206,32 @@ module Pod
             end
 
             describe '#header_mappings' do
-              it 'returns the header mappings' do
+              it 'returns the correct public header mappings' do
                 headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('BananaLib/Banana.h')]
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
+                headers = [Pathname.new('Banana.h')]
+                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers, :public)
                 mappings.should == {
-                  headers_sandbox => headers,
+                  Pathname.new('BananaLib/BananaLib') => [Pathname.new('Banana.h')],
                 }
               end
 
-              it 'takes into account the header dir specified in the spec' do
+              it 'takes into account the header dir specified in the spec for public headers' do
                 headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('BananaLib/Banana.h')]
+                headers = [Pathname.new('Banana.h')]
+                @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
+                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers, :public)
+                mappings.should == {
+                  Pathname.new('BananaLib/BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
+                }
+              end
+
+              it 'takes into account the header dir specified in the spec for private headers' do
+                headers_sandbox = Pathname.new('BananaLib')
+                headers = [Pathname.new('Banana.h')]
                 @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
                 mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
                 mappings.should == {
-                  (headers_sandbox + 'Sub_dir') => headers,
+                  Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
                 }
               end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -234,52 +234,100 @@ module Pod
         @pod_target.prefix_header_path.to_s.should.include 'Pods/Target Support Files/BananaLib/BananaLib-prefix.pch'
       end
 
-      it 'returns the correct header search paths' do
-        @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
-        @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
-        header_search_paths = @pod_target.header_search_paths
-        header_search_paths.sort.should == [
-          '${PODS_ROOT}/Headers/Private',
-          '${PODS_ROOT}/Headers/Private/BananaLib',
-          '${PODS_ROOT}/Headers/Public',
-          '${PODS_ROOT}/Headers/Public/BananaLib',
-        ]
+      describe 'non modular header search paths' do
+        it 'returns the correct search paths' do
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          header_search_paths = @pod_target.header_search_paths
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
+          ]
+        end
+
+        it 'returns the correct header search paths recursively for dependent targets' do
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.ios)
+          monkey_spec = fixture_spec('monkey/monkey.podspec')
+          monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
+          monkey_pod_target.stubs(:platform).returns(Platform.ios)
+          @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
+          header_search_paths = @pod_target.header_search_paths
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
+            '${PODS_ROOT}/Headers/Public/monkey',
+            '${PODS_ROOT}/Headers/Public/monkey/monkey',
+          ]
+        end
+
+        it 'returns the correct header search paths recursively for dependent targets excluding platform' do
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.osx)
+          monkey_spec = fixture_spec('monkey/monkey.podspec')
+          monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
+          monkey_pod_target.stubs(:platform).returns(Platform.ios)
+          @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
+          header_search_paths = @pod_target.header_search_paths
+          # The monkey lib header search paths should not be present since they are only present in OSX.
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
+          ]
+        end
       end
 
-      it 'returns the correct header search paths recursively for dependent targets' do
-        @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
-        @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
-        @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.ios)
-        monkey_spec = fixture_spec('monkey/monkey.podspec')
-        monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
-        monkey_pod_target.stubs(:platform).returns(Platform.ios)
-        @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
-        header_search_paths = @pod_target.header_search_paths
-        header_search_paths.sort.should == [
-          '${PODS_ROOT}/Headers/Private',
-          '${PODS_ROOT}/Headers/Private/BananaLib',
-          '${PODS_ROOT}/Headers/Public',
-          '${PODS_ROOT}/Headers/Public/BananaLib',
-          '${PODS_ROOT}/Headers/Public/monkey',
-        ]
-      end
+      describe 'modular header search paths' do
+        before do
+          @pod_target.stubs(:defines_module?).returns(true)
+        end
 
-      it 'returns the correct header search paths recursively for dependent targets excluding platform' do
-        @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
-        @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
-        @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.osx)
-        monkey_spec = fixture_spec('monkey/monkey.podspec')
-        monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
-        monkey_pod_target.stubs(:platform).returns(Platform.ios)
-        @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
-        header_search_paths = @pod_target.header_search_paths
-        # The monkey lib header search paths should not be present since they are only present in OSX.
-        header_search_paths.sort.should == [
-          '${PODS_ROOT}/Headers/Private',
-          '${PODS_ROOT}/Headers/Private/BananaLib',
-          '${PODS_ROOT}/Headers/Public',
-          '${PODS_ROOT}/Headers/Public/BananaLib',
-        ]
+        it 'returns the correct header search paths' do
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          header_search_paths = @pod_target.header_search_paths
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+          ]
+        end
+
+        it 'returns the correct header search paths recursively for dependent targets' do
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.ios)
+          monkey_spec = fixture_spec('monkey/monkey.podspec')
+          monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
+          monkey_pod_target.stubs(:platform).returns(Platform.ios)
+          @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
+          header_search_paths = @pod_target.header_search_paths
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public/monkey',
+          ]
+        end
+
+        it 'returns the correct header search paths recursively for dependent targets excluding platform' do
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.osx)
+          monkey_spec = fixture_spec('monkey/monkey.podspec')
+          monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
+          monkey_pod_target.stubs(:platform).returns(Platform.ios)
+          @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
+          header_search_paths = @pod_target.header_search_paths
+          # The monkey lib header search paths should not be present since they are only present in OSX.
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+          ]
+        end
       end
     end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -287,6 +287,19 @@ module Pod
           @pod_target.stubs(:defines_module?).returns(true)
         end
 
+        it 'uses modular header search paths when specified in the podfile' do
+          @pod_target.unstub(:defines_module?)
+          @pod_target.target_definitions.first.stubs(:build_pod_as_module?).with('BananaLib').returns(true)
+
+          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
+          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+          header_search_paths = @pod_target.header_search_paths
+          header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public/BananaLib',
+          ]
+        end
+
         it 'returns the correct header search paths' do
           @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
           @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)


### PR DESCRIPTION
- Assuming `PodA`, `PodB` and `PodC` in a project.
- Assuming `PodA` depends only on `PodB` but **not** on `PodC`

Header search paths for `PodA`:

_before_ (<= 1.4, a.k.a today)
```
${PODS_ROOT}/Headers/Private
${PODS_ROOT}/Headers/Public
${PODS_ROOT}/Headers/Private/PodA
${PODS_ROOT}/Headers/Public/PodA
${PODS_ROOT}/Headers/Public/PodB
${PODS_ROOT}/Headers/Public/PodC
```

Notice that root `Public` folder but also that `PodC` is included in the pod's header search paths despite the fact that `PodA` does not depend on `PodC`.

_after_ (> 1.5)
```
${PODS_ROOT}/Headers/Private/PodA
${PODS_ROOT}/Headers/Public/PodA
${PODS_ROOT}/Headers/Public/PodA/PodA
${PODS_ROOT}/Headers/Public/PodB
${PODS_ROOT}/Headers/Public/PodB/PodB
```

Notice that `PodC` is correctly not included (due to https://github.com/CocoaPods/CocoaPods/pull/7116) but also that the root folder `Public` is no longer present which would have otherwise allowed consumers to include headers of `PodC` without directly depending on it in their podspec.

Instead, the root `Public` folder is "expanded" so users can continue to use `<>` and `""` header imports. Functionally, this is still the same and it shouldn't break anyone upgrading to 1.5.0 but it also makes it more clear by removing the root `Public` folder.

When using/enabling modular headers there is no "before" state because we never had modular header support in CocoaPods, but `PodA` header search paths look like this (using static libraries):

```
${PODS_ROOT}/Headers/Private/PodA
${PODS_ROOT}/Headers/Public/PodA
${PODS_ROOT}/Headers/Public/PodB
```

As for the file system all public headers are now nested an additional folder further so it looks like this:

Public header symlinks on the file system (notice the extra nested folder):
```
Pods/Headers/Public/PodA/PodA/PodA.h
Pods/Headers/Public/PodB/PodB/PodB.h
Pods/Headers/Public/PodC/PodC/PodC.h
```
Private header symlinks on the file system (notice no extra folder as all imports can work with `""`):
```
Pods/Headers/Private/PodA/PodA_Private.h
Pods/Headers/Private/PodB/PodB_Private.h
Pods/Headers/Private/PodC/PodC_Private.h
```

This means that `PodA` can now use `<>` imports of `PodB` but *not* use `""` imports for `PodB` private headers (unless maybe `USE_HEADERMAPS` is set to `YES`?).

The above only applies `HEADER_SEARCH_PATHS` which get populated when static libraries are used. When frameworks are used then `FRAMEWORK_SEARCH_PATHS` are used which continue to work as they are today.

Note that CocoaPods does not also change or interfere with the `USE_HEADERMAPS` flag, which can cause plenty of dark magic to find headers of targets that are otherwise not part of the header search paths.

closes https://github.com/CocoaPods/CocoaPods/issues/7011