### PR TITLE
Store the Podfile checksum in a separate file in the sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [iv-mexx](https://github.com/iv-mexx)  
   [#7372](https://github.com/CocoaPods/CocoaPods/issues/7372)  
 
+* The Podfile checksum is stored in a separate file in the Pods directory 
+  instead of in the Podfile.lock, allowing concurrent modification of the
+  Podfile from multiple branches without causing merge conflicts.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Clear input/output paths if they exceed an arbitrary limit  

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core'
+  cp_gem 'cocoapods-core',        'Core', 'seg-remove-lockfile-podfile-checksum'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: b24b82511b8ed5a6f93e2a9f74bbdc9c33da8672
-  branch: master
+  revision: fffb3447abd4979100e490a1dd65bf003dfe1557
+  branch: seg-remove-lockfile-podfile-checksum
   specs:
     cocoapods-core (1.4.0)
       activesupport (>= 4.0.2, < 6)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -187,6 +187,7 @@ module Pod
         generator.write
         generator.share_development_pod_schemes
         write_lockfiles
+        write_podfile_checksum
       end
     end
 
@@ -541,9 +542,7 @@ module Pod
       end
     end
 
-    # Writes the Podfile and the lock files.
-    #
-    # @todo   Pass the checkout options to the Lockfile.
+    # Writes the lockfile and sandbox manifest.
     #
     # @return [void]
     #
@@ -557,9 +556,22 @@ module Pod
       end
 
       UI.message "- Writing Manifest in #{UI.path sandbox.manifest_path}" do
-        sandbox.manifest_path.open('w') do |f|
-          f.write config.lockfile_path.read
-        end
+        FileUtils.cp(config.lockfile_path, sandbox.manifest_path)
+      end
+    end
+
+    # Writes the podfile checksum file into the sandbox,
+    # if the podfile was defined in a file.
+    #
+    # @return [Void]
+    #
+    def write_podfile_checksum
+      return unless checksum = podfile.checksum
+      return unless podfile_path = podfile.defined_in_file
+      checksum_path = sandbox.podfile_checksum_path
+
+      UI.message "- Writing Podfile checksum in #{UI.path checksum_path}" do
+        checksum_path.open('w') { |f| f << checksum << '  ' << podfile_path.basename.to_s << "\n" }
       end
     end
 

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -123,6 +123,12 @@ module Pod
       root + 'Manifest.lock'
     end
 
+    # @return [Pathname] the path of the Podfile checksum file.
+    #
+    def podfile_checksum_path
+      root + 'Podfile.sha1'
+    end
+
     # @return [Pathname] the path of the Pods project.
     #
     def project_path

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -271,6 +271,14 @@ module Pod
       '${PODS_ROOT}/..'
     end
 
+    # @return [Pathname] The basename of the Podfile, if it is defined in a file
+    #
+    def podfile_basename
+      return unless podfile = target_definition.podfile
+      return unless podfile_path = podfile.defined_in_file
+      podfile_path.basename
+    end
+
     # @param  [String] config_name The build configuration name to get the xcconfig for
     # @return [String] The path of the xcconfig file relative to the root of
     #         the user project.

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -83,12 +83,18 @@ CLIntegracon.configure do |c|
 
   # Register special handling for YAML files
   c.transform_produced %r{(^|/)(Podfile|Manifest).lock$} do |path|
-    # Remove CocoaPods version & Podfile checksum
+    # Remove CocoaPods version
     yaml = YAML.load(path.read)
-    deleted_keys = ['COCOAPODS', 'PODFILE CHECKSUM']
+    deleted_keys = ['COCOAPODS']
     deleted_keys.each { |key| yaml.delete(key) }
     keys_hint = Pod::Lockfile::HASH_KEY_ORDER - deleted_keys
     path.open('w') { |f| f << Pod::YAMLHelper.convert_hash(yaml, keys_hint, "\n\n") }
+  end
+
+  c.transform_produced 'Pods/Podfile.sha1' do |path|
+    contents = path.read
+    contents.gsub!(/^\h+/, 'SHA1SUM')
+    path.open('w') { |f| f << contents }
   end
 
   c.preprocess('**/*.xcodeproj', %r{(^|/)(Podfile|Manifest).lock$}) do |path|


### PR DESCRIPTION
* The Podfile checksum is stored in a separate file in the Pods directory
  instead of in the Podfile.lock, allowing concurrent modification of the
  Podfile from multiple branches without causing merge conflicts.

The checksum is still verified in the “Check Manifest.lock” build script phase by running `shasum`.