### PR TITLE
Use FRAMEWORK_SEARCH_PATHS to discover headers of vendored frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Avoid dependency resolution conflicts when a pod depends upon a local pod.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* When integrating a vendored framework while building pods as static 
+  libraries, public headers will be found via `FRAMEWORK_SEARCH_PATHS` 
+  instead of via the sandbox headers store.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.4.0 (2018-01-18)
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -90,9 +90,11 @@ module Pod
             end
           end
           XCConfigHelper.add_dynamic_dependency_build_settings(target, pod_target, xcconfig, include_ld_flags, test_xcconfig)
-          if pod_target.requires_frameworks?
-            pod_target.dependent_targets.each do |dependent_target|
-              XCConfigHelper.add_dynamic_dependency_build_settings(target, dependent_target, xcconfig, include_ld_flags, test_xcconfig)
+
+          pod_target.dependent_targets.each do |dependent_target|
+            XCConfigHelper.add_dynamic_dependency_build_settings(target, dependent_target, xcconfig, include_ld_flags, test_xcconfig)
+            dependent_target.file_accessors.each do |file_accessor|
+              XCConfigHelper.add_static_dependency_build_settings(target, dependent_target, xcconfig, file_accessor, false)
             end
           end
         end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -136,34 +136,27 @@ module Pod
             UI.message '- Linking headers' do
               pod_targets.each do |pod_target|
                 pod_target.file_accessors.each do |file_accessor|
-                  framework_exp = /\.framework\//
-                  headers_sandbox = Pathname.new(file_accessor.spec.root.name)
-
                   # When integrating Pod as frameworks, built Pods are built into
                   # frameworks, whose headers are included inside the built
                   # framework. Those headers do not need to be linked from the
                   # sandbox.
-                  unless pod_target.requires_frameworks? && pod_target.should_build?
-                    pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform)
-                    sandbox.public_headers.add_search_path(headers_sandbox, pod_target.platform)
+                  next if pod_target.requires_frameworks? || !pod_target.should_build?
 
-                    # Private headers will always end up in Pods/Headers/Private/PodA/*.h
-                    # This will allow for `""` imports to work.
-                    header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
-                      pod_target.build_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
-                    end
+                  headers_sandbox = Pathname.new(file_accessor.spec.root.name)
 
-                    # Public headers on the other hand will be added in Pods/Headers/Public/PodA/PodA/*.h
-                    # The extra folder is intentional in order for `<>` imports to work.
-                    header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers, :public).each do |namespaced_path, files|
-                      sandbox.public_headers.add_files(namespaced_path, files.reject { |f| f.to_path =~ framework_exp })
-                    end
+                  pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform)
+                  sandbox.public_headers.add_search_path(headers_sandbox, pod_target.platform)
+
+                  # Private headers will always end up in Pods/Headers/Private/PodA/*.h
+                  # This will allow for `""` imports to work.
+                  header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
+                    pod_target.build_headers.add_files(namespaced_path, files)
                   end
 
-                  unless pod_target.requires_frameworks?
-                    vendored_frameworks_header_mappings(headers_sandbox, file_accessor).each do |namespaced_path, files|
-                      sandbox.public_headers.add_files(namespaced_path, files)
-                    end
+                  # Public headers on the other hand will be added in Pods/Headers/Public/PodA/PodA/*.h
+                  # The extra folder is intentional in order for `<>` imports to work.
+                  header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers, :public).each do |namespaced_path, files|
+                    sandbox.public_headers.add_files(namespaced_path, files)
                   end
                 end
               end
@@ -319,6 +312,8 @@ module Pod
 
             mappings = {}
             headers.each do |header|
+              next if header.to_s.include?('.framework/')
+
               sub_dir = dir
               if header_mappings_dir
                 relative_path = header.relative_path_from(file_accessor.path_list.root + header_mappings_dir)
@@ -326,36 +321,6 @@ module Pod
               end
               mappings[sub_dir] ||= []
               mappings[sub_dir] << header
-            end
-            mappings
-          end
-
-          # Computes the destination sub-directory in the sandbox for headers
-          # from inside vendored frameworks.
-          #
-          # @param  [Pathname] headers_sandbox
-          #         The sandbox where the header links should be stored for this
-          #         Pod.
-          #
-          # @param  [Sandbox::FileAccessor] file_accessor
-          #         The consumer file accessor for which the headers need to be
-          #         linked.
-          #
-          def vendored_frameworks_header_mappings(headers_sandbox, file_accessor)
-            mappings = {}
-            file_accessor.vendored_frameworks.each do |framework|
-              headers_dir = Sandbox::FileAccessor.vendored_frameworks_headers_dir(framework)
-              headers = Sandbox::FileAccessor.vendored_frameworks_headers(framework)
-              framework_name = framework.basename(framework.extname)
-              dir = headers_sandbox + framework_name
-              headers.each do |header|
-                # the relative path of framework headers should be kept,
-                # not flattened like is done for most public headers.
-                relative_path = header.relative_path_from(headers_dir)
-                sub_dir = dir + relative_path.dirname
-                mappings[sub_dir] ||= []
-                mappings[sub_dir] << header
-              end
             end
             mappings
           end

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -115,12 +115,12 @@ module Pod
             @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/DDD')
           end
 
-          it 'vendored frameworks dont get added to frameworks paths if use_frameworks! isnt set' do
+          it 'vendored frameworks get added to frameworks paths even if use_frameworks! isnt set' do
             @pod_target.stubs(:requires_frameworks?).returns(false)
             @xcconfig = @generator.generate
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('spec/fixtures/monkey')
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/AAA')
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/CCC')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('spec/fixtures/monkey')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/AAA')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/CCC')
           end
 
           it 'sets the PODS_ROOT build variable' do
@@ -256,7 +256,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib" "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib"'
           end
 
           it 'adds correct header search paths for dependent and test targets' do

--- a/spec/unit/hooks_manager_spec.rb
+++ b/spec/unit/hooks_manager_spec.rb
@@ -115,7 +115,7 @@ module Pod
         config.verbose = true
         @hooks_manager.register('plugin', :post_install) {}
         @hooks_manager.run(:post_install, Object.new)
-        UI.output.should.match %r{- plugin from `spec/unit/hooks_manager_spec.rb`}
+        UI.output.should.include "- plugin from `#{__FILE__}`"
       end
     end
   end

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -90,11 +90,11 @@ module Pod
               framework_subdir_header = headers_root + 'BananaLib/Bananalib/SubDir/SubBananalib.h'
               public_headers.each { |public_header| public_header.should.exist }
               private_header.should.not.exist
-              framework_header.should.exist
-              framework_subdir_header.should.exist
+              framework_header.should.not.exist
+              framework_subdir_header.should.not.exist
             end
 
-            it 'links the public headers meant for the user, but only for Pods that are not built' do
+            it 'does not link the public headers meant for the user for a vendored framework' do
               Target.any_instance.stubs(:requires_frameworks?).returns(true)
               pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec')
               pod_target_two = fixture_pod_target('monkey/monkey.podspec')
@@ -107,7 +107,7 @@ module Pod
               banana_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
               banana_headers.each { |banana_header| banana_header.should.not.exist }
               monkey_header = headers_root + 'monkey/monkey/monkey.h'
-              monkey_header.should.exist
+              monkey_header.should.not.exist
             end
 
             it "doesn't link public headers from vendored framework, when frameworks required" do
@@ -299,19 +299,6 @@ module Pod
                 paths = []
                 result = @installer.send(:common_path, paths)
                 result.should.be.nil
-              end
-            end
-
-            describe '#vendored_frameworks_header_mappings' do
-              it 'returns the vendored frameworks header mappings' do
-                headers_sandbox = Pathname.new('BananaLib')
-                header = @file_accessor.root + 'Bananalib.framework/Versions/A/Headers/Bananalib.h'
-                header_subdir = @file_accessor.root + 'Bananalib.framework/Versions/A/Headers/SubDir/SubBananalib.h'
-                mappings = @installer.send(:vendored_frameworks_header_mappings, headers_sandbox, @file_accessor)
-                mappings.should == {
-                  (headers_sandbox + 'Bananalib') => [header],
-                  (headers_sandbox + 'Bananalib/SubDir') => [header_subdir],
-                }
               end
             end
           end


### PR DESCRIPTION
This way, vendored frameworks integrated into static library aggregate targets can, e.g., use module maps.