### PR TITLE
Fix legacy header search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   instead of via the sandbox headers store.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Fix legacy header search paths that broke due to #7116 and #7412.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7445](https://github.com/CocoaPods/CocoaPods/pull/7445)
 
 ## 1.4.0 (2018-01-18)
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -602,10 +602,16 @@ module Pod
       header_search_paths = []
       header_search_paths.concat(build_headers.search_paths(platform, nil, uses_modular_headers?))
       header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name, uses_modular_headers?))
-      dependent_targets = recursive_dependent_targets
-      dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets
-      dependent_targets.each do |dependent_target|
-        header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name, defines_module? && dependent_target.uses_modular_headers?(false)))
+      # Modular headers will only provide header search paths of the dependencies of the pod target. That is in
+      # contrast to legacy mode, which has always given access to all pods header search paths.
+      if uses_modular_headers?
+        dependent_targets = recursive_dependent_targets
+        dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets
+        dependent_targets.each do |dependent_target|
+          header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name, defines_module? && dependent_target.uses_modular_headers?(false)))
+        end
+      else
+        header_search_paths.concat(sandbox.public_headers.search_paths(platform))
       end
       header_search_paths.uniq
     end


### PR DESCRIPTION
Turns out that https://github.com/CocoaPods/CocoaPods/pull/7116 and https://github.com/CocoaPods/CocoaPods/pull/7412 together are breaking legacy header search paths.

The first change removed all header search paths for dependent targets *but* kept the root `Public` folder which allowed things to continue to work.

However, with #7412 we removed the `Public` root folder and this will cause crashes to entire world.

This PR fixes this.