### PR TITLE
Revert "Merge pull request #7442 from CocoaPods/seg-vendored-framewor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,11 +82,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Avoid dependency resolution conflicts when a pod depends upon a local pod.  
   [Samuel Giddins](https://github.com/segiddins)
 
-* When integrating a vendored framework while building pods as static 
-  libraries, public headers will be found via `FRAMEWORK_SEARCH_PATHS` 
-  instead of via the sandbox headers store.  
-  [Samuel Giddins](https://github.com/segiddins)
-
 * Fix legacy header search paths that broke due to #7116 and #7412.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7445](https://github.com/CocoaPods/CocoaPods/pull/7445)

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -90,11 +90,9 @@ module Pod
             end
           end
           XCConfigHelper.add_dynamic_dependency_build_settings(target, pod_target, xcconfig, include_ld_flags, test_xcconfig)
-
-          pod_target.dependent_targets.each do |dependent_target|
-            XCConfigHelper.add_dynamic_dependency_build_settings(target, dependent_target, xcconfig, include_ld_flags, test_xcconfig)
-            dependent_target.file_accessors.each do |file_accessor|
-              XCConfigHelper.add_static_dependency_build_settings(target, dependent_target, xcconfig, file_accessor, false)
+          if pod_target.requires_frameworks?
+            pod_target.dependent_targets.each do |dependent_target|
+              XCConfigHelper.add_dynamic_dependency_build_settings(target, dependent_target, xcconfig, include_ld_flags, test_xcconfig)
             end
           end
         end

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -115,12 +115,12 @@ module Pod
             @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/DDD')
           end
 
-          it 'vendored frameworks get added to frameworks paths even if use_frameworks! isnt set' do
+          it 'vendored frameworks dont get added to frameworks paths if use_frameworks! isnt set' do
             @pod_target.stubs(:requires_frameworks?).returns(false)
             @xcconfig = @generator.generate
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('spec/fixtures/monkey')
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/AAA')
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/CCC')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('spec/fixtures/monkey')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/AAA')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/CCC')
           end
 
           it 'sets the PODS_ROOT build variable' do
@@ -256,7 +256,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib" "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
           end
 
           it 'adds correct header search paths for dependent and test targets without modular headers' do

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -90,8 +90,13 @@ module Pod
               framework_subdir_header = headers_root + 'BananaLib/Bananalib/SubDir/SubBananalib.h'
               public_headers.each { |public_header| public_header.should.exist }
               private_header.should.not.exist
-              framework_header.should.not.exist
-              framework_subdir_header.should.not.exist
+              framework_header.should.exist
+              framework_subdir_header.should.exist
+
+              config.sandbox.public_headers.search_paths(@pod_target.platform).should == %w(
+                ${PODS_ROOT}/Headers/Public/BananaLib
+                ${PODS_ROOT}/Headers/Public/BananaLib/BananaLib
+              )
             end
 
             it 'does not link the public headers meant for the user for a vendored framework' do


### PR DESCRIPTION
…ks-no-sandbox-headers"

This reverts commit d16f648e38fe53b7910f6f00c55dd499a2d00999, reversing
changes made to d7c0b2b36e297df9799180fef277878bbe84ca44.

Reverts https://github.com/CocoaPods/CocoaPods/pull/7442

> We might need to revert this, it's absolutely decimated our pod install times (because we're recursing into dependent targets a lot more, merging into xcconfigs more, which calls Shellwords.shellsplit more. Which is very slow)

