### PR TITLE
Display a message when a pods source has changed during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#7473](https://github.com/CocoaPods/CocoaPods/pull/7473)
 
+* Display a message when a pods source has changed during installation  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7464](https://github.com/CocoaPods/CocoaPods/pull/7464)
+
 * Add support for modular header search paths, include "legacy" support.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7412](https://github.com/CocoaPods/CocoaPods/pull/7412)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: e0c6884b37ab6a44095a2bbdbfe9032627a90388
+  revision: 1a92ff1b5aa2bd21b9694d0941406aff328fdd2a
   branch: master
   specs:
     cocoapods-core (1.4.0)


### PR DESCRIPTION
Depends on https://github.com/CocoaPods/Core/pull/434

Sample output for when a source changes:

```
Fetching podspec for `CannonPodder` from `/Users/dimitris/Development/ios/cannonpodder/CannonPodder.podspec`
Downloading dependencies
Using CannonPodder (1.0.6)
Installing SamplePod 2.0.0 (source changed to `some-other-repo`)
Generating Pods project
Integrating client project
Pod installation complete! There are 4 dependencies from the Podfile and 4 total pods installed.
```