### PR TITLE
Actually return absolute paths from glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Ruenzuo](https://github.com/Ruenzuo)
   [#6964](https://github.com/CocoaPods/CocoaPods/issues/6964)
 
+* Fix returning absolute paths from glob, fixes issue with static framework and public headers.  
+  [Morgan McKenzie](https://github.com/rmtmckenzie)
+  [#7463](https://github.com/CocoaPods/CocoaPods/issues/7463)
+
 ## 1.4.0 (2018-01-18)
 
 ##### Enhancements

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -88,7 +88,7 @@ module Pod
       # @return [Array<Pathname>]
       #
       def glob(patterns, options = {})
-        relative_glob(patterns, options).map { |p| root + p }
+        relative_glob(patterns, options).map { |p| (root + p).realpath }
       end
 
       # The list of relative paths that are case insensitively matched by a


### PR DESCRIPTION
Currently, symlinks are not followed when creating the absolute path in PathList.glob. This means that when an actually absolute path is compared with the symlinked path, it might not compare as equal even it if should. This changes that so that glob actually returns the absolute path (following symlinks).

Fixes #7463.

FYI - I ran spec in CocoaPods and fixed the errors that caused, but since I was not able to build in Rainforest (I opened a couple bugs and a thread in the mailing list about that), I am not able to run rake spec there as the development guidelines ask. I'd be open to doing that if I can get some guidance on how to actually get the rainforest to work.