### PR TITLE
Improve `pod install` performance for pods with exact file paths rather than glob patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Improve `pod install` performance for pods with exact file paths rather than glob patterns  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#7473](https://github.com/CocoaPods/CocoaPods/pull/7473)
+
 * Add support for modular header search paths, include "legacy" support.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7412](https://github.com/CocoaPods/CocoaPods/pull/7412)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -58,9 +58,7 @@ module Pod
           # @return [void]
           #
           def refresh_file_accessors
-            file_accessors.each do |fa|
-              fa.path_list.read_file_system
-            end
+            file_accessors.map(&:path_list).uniq.each(&:read_file_system)
           end
 
           # Adds the source files of the Pods to the Pods project.

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -128,19 +128,21 @@ module Pod
         else
           full_list = files
         end
-
-        list = Array(patterns).map do |pattern|
+        patterns_array = Array(patterns)
+        exact_matches = full_list & patterns_array
+        patterns_array -= exact_matches
+        all_patterns = patterns_array.map do |pattern|
           if directory?(pattern) && dir_pattern
             pattern += '/' unless pattern.end_with?('/')
             pattern += dir_pattern
           end
-          expanded_patterns = dir_glob_equivalent_patterns(pattern)
-          full_list.select do |path|
-            expanded_patterns.any? do |p|
-              File.fnmatch(p, path, File::FNM_CASEFOLD | File::FNM_PATHNAME)
-            end
-          end
+          dir_glob_equivalent_patterns(pattern)
         end.flatten
+        list = exact_matches + full_list.select do |path|
+          all_patterns.any? do |p|
+            File.fnmatch(p, path, File::FNM_CASEFOLD | File::FNM_PATHNAME)
+          end
+        end
 
         list = list.map { |path| Pathname.new(path) }
         if exclude_patterns

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -131,6 +131,7 @@ module Pod
         patterns_array = Array(patterns)
         exact_matches = full_list & patterns_array
         patterns_array -= exact_matches
+
         all_patterns = patterns_array.map do |pattern|
           if directory?(pattern) && dir_pattern
             pattern += '/' unless pattern.end_with?('/')
@@ -138,9 +139,12 @@ module Pod
           end
           dir_glob_equivalent_patterns(pattern)
         end.flatten
-        list = exact_matches + full_list.select do |path|
-          all_patterns.any? do |p|
-            File.fnmatch(p, path, File::FNM_CASEFOLD | File::FNM_PATHNAME)
+        list = exact_matches
+        unless all_patterns.empty?
+          list += full_list.select do |path|
+            all_patterns.any? do |p|
+              File.fnmatch(p, path, File::FNM_CASEFOLD | File::FNM_PATHNAME)
+            end
           end
         end
 


### PR DESCRIPTION
This PR dramatically improves `pod install` performance for pod specs using exact file path lists for file attributes rather than glob patterns.

## Changes

- `FileReferencesInstaller` was reading file system from scratch using `read_file_system` multiple times for a `PathList` object if multiple file accessors are using that same `PathList` object. This is a common case for development pods having several subspecs which are independently added into a `Podfile`.
Now, file system will be read only once for each `PathList` object in `refresh_file_accessors` method.

- When `PathList.relative_glob` method runs, all string objects in `patterns` argument are regarded as glob patterns and `File.fnmatch` runs for each `(path_list_file, pattern)` pairs, which has complexity O(m*n). 
Now, we calculate the set intersection of list of all files exist under `PathList` and list of patterns, to find exact file path matches much faster. Then, we run `File.fnmatch` for remaining glob patterns.

Here is `time` output of my `pod install` run before and after changes:

*Before :* `bundle exec pod install  51.63s user 4.46s system 99% cpu 56.524 total`
*After :* `bundle exec pod install  7.08s user 1.97s system 98% cpu 9.176 total`