### PR TITLE
Revert part of legacy header search path changes to include root 'Public' and 'Private' folders again

### DIFF
--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -143,12 +143,14 @@ module Pod
               "#{target.build_product_path}/Headers"
             end
             build_settings = {
+              # TODO: remove quote imports in CocoaPods 2.0
               # Make framework headers discoverable by `import "…"`
               'OTHER_CFLAGS' => XCConfigHelper.quote(framework_header_search_paths, '-iquote'),
             }
             if pod_targets.any? { |t| !t.should_build? }
               # Make library headers discoverable by `#import "…"`
               library_header_search_paths = target.sandbox.public_headers.search_paths(target.platform)
+              # TODO: remove quote imports in CocoaPods 2.0
               build_settings['HEADER_SEARCH_PATHS'] = XCConfigHelper.quote(library_header_search_paths)
               build_settings['OTHER_CFLAGS'] += ' ' + XCConfigHelper.quote(library_header_search_paths, '-isystem')
             end
@@ -157,6 +159,7 @@ module Pod
             # Make headers discoverable from $PODS_ROOT/Headers directory
             header_search_paths = target.sandbox.public_headers.search_paths(target.platform)
             {
+              # TODO: remove quote imports in CocoaPods 2.0
               # by `#import "…"`
               'HEADER_SEARCH_PATHS' => XCConfigHelper.quote(header_search_paths),
               # by `#import <…>`

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -153,7 +153,7 @@ module Pod
 
                   # Public headers on the other hand will be added in Pods/Headers/Public/PodA/PodA/*.h
                   # The extra folder is intentional in order for `<>` imports to work.
-                  header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers, :public).each do |namespaced_path, files|
+                  header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
                     added_public_headers = true
                     sandbox.public_headers.add_files(namespaced_path, files)
                   end
@@ -301,10 +301,6 @@ module Pod
           #         The consumer file accessor for which the headers need to be
           #         linked.
           #
-          # @param  [Symbol] visibility_scope
-          #         The visibility scope to produce header mappings for. If set to :public then the headers
-          #         are nested an additional level deep. For example, 'Pods/Headers/Public/PodA/PodA'.
-          #
           # @param  [Array<Pathname>] headers
           #         The absolute paths of the headers which need to be mapped.
           #
@@ -312,11 +308,10 @@ module Pod
           #         headers folders as the keys and the absolute paths of the
           #         header files as the values.
           #
-          def header_mappings(headers_sandbox, file_accessor, headers, visibility_scope = :private)
+          def header_mappings(headers_sandbox, file_accessor, headers)
             consumer = file_accessor.spec_consumer
             header_mappings_dir = consumer.header_mappings_dir
             dir = headers_sandbox
-            dir += headers_sandbox if visibility_scope == :public
             dir += consumer.header_dir if consumer.header_dir
 
             mappings = {}

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -59,9 +59,9 @@ module Pod
         end
         headers_dir = root.relative_path_from(sandbox.root).dirname
         @search_paths_cache[key] = search_paths.uniq.flat_map do |entry|
-          path = "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}"
-          paths = [path]
-          paths.push("#{path}/#{entry[:path].basename}") if !use_modular_headers && @visibility_scope == :public
+          paths = []
+          paths << "${PODS_ROOT}/#{headers_dir}/#{@relative_path}" if !use_modular_headers || @visibility_scope == :public
+          paths << "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}" if !use_modular_headers || @visibility_scope == :private
           paths
         end
       end

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -58,12 +58,12 @@ module Pod
           matches_platform && matches_target
         end
         headers_dir = root.relative_path_from(sandbox.root).dirname
-        @search_paths_cache[key] = search_paths.uniq.flat_map do |entry|
+        @search_paths_cache[key] = search_paths.flat_map do |entry|
           paths = []
           paths << "${PODS_ROOT}/#{headers_dir}/#{@relative_path}" if !use_modular_headers || @visibility_scope == :public
           paths << "${PODS_ROOT}/#{headers_dir}/#{entry[:path]}" if !use_modular_headers || @visibility_scope == :private
           paths
-        end
+        end.uniq
       end
 
       # Removes the directory as it is regenerated from scratch during each

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -600,16 +600,10 @@ module Pod
       header_search_paths = []
       header_search_paths.concat(build_headers.search_paths(platform, nil, uses_modular_headers?))
       header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name, uses_modular_headers?))
-      # Modular headers will only provide header search paths of the dependencies of the pod target. That is in
-      # contrast to legacy mode, which has always given access to all pods header search paths.
-      if uses_modular_headers?
-        dependent_targets = recursive_dependent_targets
-        dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets
-        dependent_targets.each do |dependent_target|
-          header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name, defines_module? && dependent_target.uses_modular_headers?(false)))
-        end
-      else
-        header_search_paths.concat(sandbox.public_headers.search_paths(platform))
+      dependent_targets = recursive_dependent_targets
+      dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets
+      dependent_targets.each do |dependent_target|
+        header_search_paths.concat(sandbox.public_headers.search_paths(platform, dependent_target.pod_name, defines_module? && dependent_target.uses_modular_headers?(false)))
       end
       header_search_paths.uniq
     end

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -272,10 +272,12 @@ module Pod
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/BananaLib/BananaLib"' \
-              ' "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/CoconutLib/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/monkey" "${PODS_ROOT}/Headers/Public/monkey/monkey"'
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private"' \
+              ' "${PODS_ROOT}/Headers/Private/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public"' \
+              ' "${PODS_ROOT}/Headers/Public/BananaLib"' \
+              ' "${PODS_ROOT}/Headers/Public/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public/monkey"'
           end
 
           it 'adds correct header search paths for dependent and test targets for non test xcconfigs without modular headers' do
@@ -292,10 +294,11 @@ module Pod
             # This is not an test xcconfig so it should exclude header search paths for the 'monkey' pod
             generator = PodXCConfig.new(@coconut_pod_target, false)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/BananaLib" "${PODS_ROOT}/Headers/Public/BananaLib/BananaLib"' \
-              ' "${PODS_ROOT}/Headers/Public/CoconutLib" "${PODS_ROOT}/Headers/Public/CoconutLib/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/monkey" "${PODS_ROOT}/Headers/Public/monkey/monkey"'
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private"' \
+              ' "${PODS_ROOT}/Headers/Private/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public"' \
+              ' "${PODS_ROOT}/Headers/Public/BananaLib"' \
+              ' "${PODS_ROOT}/Headers/Public/CoconutLib"' \
           end
 
           it 'adds correct header search paths for dependent and test targets with modular headers' do
@@ -312,9 +315,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/BananaLib"' \
-              ' "${PODS_ROOT}/Headers/Public/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/monkey"'
+              ' "${PODS_ROOT}/Headers/Public"' \
           end
 
           it 'adds correct header search paths for dependent and test targets for non test xcconfigs with modular headers' do
@@ -331,8 +332,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, false)
             xcconfig = generator.generate
             xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
-              ' "${PODS_ROOT}/Headers/Public/BananaLib"' \
-              ' "${PODS_ROOT}/Headers/Public/CoconutLib"' \
+              ' "${PODS_ROOT}/Headers/Public"' \
           end
 
           it 'does not include other ld flags for test dependent targets if its not a test xcconfig' do

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -84,7 +84,7 @@ module Pod
             it 'links the public headers meant for the user' do
               @installer.install!
               headers_root = config.sandbox.public_headers.root
-              public_headers = [headers_root + 'BananaLib/BananaLib/Banana.h', headers_root + 'BananaLib/BananaLib/MoreBanana.h']
+              public_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
               private_header = headers_root + 'BananaLib/BananaPrivate.h'
               framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
               framework_subdir_header = headers_root + 'BananaLib/Bananalib/SubDir/SubBananalib.h'
@@ -92,10 +92,9 @@ module Pod
               private_header.should.not.exist
               framework_header.should.exist
               framework_subdir_header.should.exist
-
               config.sandbox.public_headers.search_paths(@pod_target.platform).should == %w(
+                ${PODS_ROOT}/Headers/Public
                 ${PODS_ROOT}/Headers/Public/BananaLib
-                ${PODS_ROOT}/Headers/Public/BananaLib/BananaLib
               )
             end
 
@@ -111,12 +110,11 @@ module Pod
               headers_root = config.sandbox.public_headers.root
               banana_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
               banana_headers.each { |banana_header| banana_header.should.not.exist }
-              monkey_header = headers_root + 'monkey/monkey/monkey.h'
+              monkey_header = headers_root + 'monkey/monkey.h'
               monkey_header.should.exist # since it lives outside of the vendored framework
-
               config.sandbox.public_headers.search_paths(pod_target_one.platform).should == %w(
+                ${PODS_ROOT}/Headers/Public
                 ${PODS_ROOT}/Headers/Public/monkey
-                ${PODS_ROOT}/Headers/Public/monkey/monkey
               )
             end
 
@@ -219,9 +217,9 @@ module Pod
               it 'returns the correct public header mappings' do
                 headers_sandbox = Pathname.new('BananaLib')
                 headers = [Pathname.new('Banana.h')]
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers, :public)
+                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
                 mappings.should == {
-                  Pathname.new('BananaLib/BananaLib') => [Pathname.new('Banana.h')],
+                  Pathname.new('BananaLib') => [Pathname.new('Banana.h')],
                 }
               end
 
@@ -229,9 +227,9 @@ module Pod
                 headers_sandbox = Pathname.new('BananaLib')
                 headers = [Pathname.new('Banana.h')]
                 @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers, :public)
+                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
                 mappings.should == {
-                  Pathname.new('BananaLib/BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
+                  Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
                 }
               end
 

--- a/spec/unit/sandbox/headers_store_spec.rb
+++ b/spec/unit/sandbox/headers_store_spec.rb
@@ -49,8 +49,8 @@ module Pod
         @public_header_dir.add_search_path('iOS Search Path', Platform.ios)
         @public_header_dir.add_search_path('OS X Search Path', Platform.osx)
         @public_header_dir.search_paths(Platform.ios).sort.should == [
+          '${PODS_ROOT}/Headers/Public',
           '${PODS_ROOT}/Headers/Public/iOS Search Path',
-          '${PODS_ROOT}/Headers/Public/iOS Search Path/iOS Search Path',
         ]
       end
 
@@ -58,12 +58,12 @@ module Pod
         @public_header_dir.add_search_path('ios-target', Platform.ios)
         @public_header_dir.add_search_path('osx-target', Platform.osx)
         @public_header_dir.search_paths(Platform.ios, 'ios-target').sort.should == [
+          '${PODS_ROOT}/Headers/Public',
           '${PODS_ROOT}/Headers/Public/ios-target',
-          '${PODS_ROOT}/Headers/Public/ios-target/ios-target',
         ]
         @public_header_dir.search_paths(Platform.osx, 'osx-target').sort.should == [
+          '${PODS_ROOT}/Headers/Public',
           '${PODS_ROOT}/Headers/Public/osx-target',
-          '${PODS_ROOT}/Headers/Public/osx-target/osx-target',
         ]
       end
 
@@ -71,9 +71,11 @@ module Pod
         @private_header_dir.add_search_path('ios-target', Platform.ios)
         @private_header_dir.add_search_path('osx-target', Platform.osx)
         @private_header_dir.search_paths(Platform.ios, 'ios-target', false).sort.should == [
+          '${PODS_ROOT}/Headers/Private',
           '${PODS_ROOT}/Headers/Private/ios-target',
         ]
         @private_header_dir.search_paths(Platform.osx, 'osx-target', false).sort.should == [
+          '${PODS_ROOT}/Headers/Private',
           '${PODS_ROOT}/Headers/Private/osx-target',
         ]
       end
@@ -84,7 +86,7 @@ module Pod
         @public_header_dir.add_search_path('iOS Search Path', Platform.ios)
         @public_header_dir.add_search_path('OS X Search Path', Platform.osx)
         @public_header_dir.search_paths(Platform.ios, nil, true).sort.should == [
-          '${PODS_ROOT}/Headers/Public/iOS Search Path',
+          '${PODS_ROOT}/Headers/Public',
         ]
       end
 
@@ -92,10 +94,10 @@ module Pod
         @public_header_dir.add_search_path('ios-target', Platform.ios)
         @public_header_dir.add_search_path('osx-target', Platform.osx)
         @public_header_dir.search_paths(Platform.ios, 'ios-target', true).sort.should == [
-          '${PODS_ROOT}/Headers/Public/ios-target',
+          '${PODS_ROOT}/Headers/Public',
         ]
         @public_header_dir.search_paths(Platform.osx, 'osx-target', true).sort.should == [
-          '${PODS_ROOT}/Headers/Public/osx-target',
+          '${PODS_ROOT}/Headers/Public',
         ]
       end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -240,9 +240,10 @@ module Pod
           @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public',
             '${PODS_ROOT}/Headers/Public/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
           ]
         end
 
@@ -256,11 +257,11 @@ module Pod
           @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public',
             '${PODS_ROOT}/Headers/Public/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
             '${PODS_ROOT}/Headers/Public/monkey',
-            '${PODS_ROOT}/Headers/Public/monkey/monkey',
           ]
         end
 
@@ -275,34 +276,10 @@ module Pod
           header_search_paths = @pod_target.header_search_paths
           # The monkey lib header search paths should not be present since they are only present in OSX.
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
+            '${PODS_ROOT}/Headers/Public',
             '${PODS_ROOT}/Headers/Public/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
-          ]
-        end
-
-        # This is a legacy header search paths test support that adds header search paths for all dependencies
-        # even the ones that are not part of the podspec. It is how CocoaPods always worked until support for modular
-        # header search paths support was added in > 1.4.0
-        it 'includes header search paths for all dependent targets' do
-          @pod_target.build_headers.add_search_path('BananaLib', Platform.ios)
-          @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
-          @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.ios)
-          @pod_target.sandbox.public_headers.add_search_path('matryoshka', Platform.ios)
-          monkey_spec = fixture_spec('monkey/monkey.podspec')
-          monkey_pod_target = PodTarget.new([monkey_spec], [@target_definition], config.sandbox)
-          monkey_pod_target.stubs(:platform).returns(Platform.ios)
-          # Notice that pod target does not depend on `matryoshka` but it will still include its header search paths
-          @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
-          header_search_paths = @pod_target.header_search_paths
-          header_search_paths.sort.should == [
-            '${PODS_ROOT}/Headers/Private/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib/BananaLib',
-            '${PODS_ROOT}/Headers/Public/matryoshka',
-            '${PODS_ROOT}/Headers/Public/matryoshka/matryoshka',
-            '${PODS_ROOT}/Headers/Public/monkey',
-            '${PODS_ROOT}/Headers/Public/monkey/monkey',
           ]
         end
       end
@@ -321,7 +298,7 @@ module Pod
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
             '${PODS_ROOT}/Headers/Private/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public',
           ]
         end
 
@@ -331,7 +308,7 @@ module Pod
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
             '${PODS_ROOT}/Headers/Private/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public',
           ]
         end
 
@@ -346,8 +323,7 @@ module Pod
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
             '${PODS_ROOT}/Headers/Private/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib',
-            '${PODS_ROOT}/Headers/Public/monkey',
+            '${PODS_ROOT}/Headers/Public',
           ]
         end
 
@@ -363,7 +339,7 @@ module Pod
           # The monkey lib header search paths should not be present since they are only present in OSX.
           header_search_paths.sort.should == [
             '${PODS_ROOT}/Headers/Private/BananaLib',
-            '${PODS_ROOT}/Headers/Public/BananaLib',
+            '${PODS_ROOT}/Headers/Public',
           ]
         end
       end


### PR DESCRIPTION
Needs update on integration specs