### PR TITLE
Fix `PRODUCT_MODULE_NAME` for test generated targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7511](https://github.com/CocoaPods/CocoaPods/issues/7511)
 
+* Fix `PRODUCT_MODULE_NAME` for generated test targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7507](https://github.com/CocoaPods/CocoaPods/issues/7507)
+
 * Ensure `SWIFT_VERSION` is set for test only pod targets during validation  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7498](https://github.com/CocoaPods/CocoaPods/issues/7498)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -277,6 +277,7 @@ module Pod
                 # requires frameworks. For tests we always use the test target name as the product name
                 # irrelevant to whether we use frameworks or not.
                 configuration.build_settings['PRODUCT_NAME'] = name
+                configuration.build_settings['PRODUCT_MODULE_NAME'] = name
                 # We must codesign iOS XCTest bundles that contain binary frameworks to allow them to be launchable in the simulator
                 unless target.platform == :osx
                   configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'YES'

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -199,6 +199,7 @@ module Pod
                 native_test_target.product_reference.name.should == 'CoconutLib-Unit-Tests'
                 native_test_target.build_configurations.each do |bc|
                   bc.build_settings['PRODUCT_NAME'].should == 'CoconutLib-Unit-Tests'
+                  bc.build_settings['PRODUCT_MODULE_NAME'].should == 'CoconutLib-Unit-Tests'
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should == 'YES'
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should == 'YES'
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
@@ -216,6 +217,7 @@ module Pod
                 native_test_target.product_reference.name.should == 'CoconutLib-Unit-Tests'
                 native_test_target.build_configurations.each do |bc|
                   bc.build_settings['PRODUCT_NAME'].should == 'CoconutLib-Unit-Tests'
+                  bc.build_settings['PRODUCT_MODULE_NAME'].should == 'CoconutLib-Unit-Tests'
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should.be.nil
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should.be.nil
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == ''


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7507

This regressed from one of the commits in 1.5.0, it is working in 1.4.0.