### PR TITLE
Fix script phase output path for `.xcasset` resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix script phase output path for `.xcasset` resources  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7511](https://github.com/CocoaPods/CocoaPods/issues/7511)
+
 * Ensure `SWIFT_VERSION` is set for test only pod targets during validation  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7498](https://github.com/CocoaPods/CocoaPods/issues/7498)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -230,6 +230,7 @@ module Pod
             when '.xcdatamodel'       then '.mom'
             when '.xcdatamodeld'      then '.momd'
             when '.xcmappingmodel'    then '.cdm'
+            when '.xcassets'          then '.car'
             else                      input_extension
             end
           end
@@ -311,8 +312,10 @@ module Pod
               # convert input paths to output paths according to extensions
               output_paths = resource_paths_flattened.map do |input_path|
                 base_path = '${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}'
-                output_extension = TargetIntegrator.output_extension_for_resource(File.extname(input_path))
-                File.join(base_path, File.basename(input_path, File.extname(input_path)) + output_extension)
+                extname = File.extname(input_path)
+                basename = extname == '.xcassets' ? 'Assets' : File.basename(input_path)
+                output_extension = TargetIntegrator.output_extension_for_resource(extname)
+                File.join(base_path, File.basename(basename, extname) + output_extension)
               end.uniq
               TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
               TargetIntegrator.create_or_update_copy_resources_script_phase_to_target(native_target, script_path, input_paths, output_paths)

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -336,6 +336,7 @@ module Pod
         it 'adds copy pods resources input and output paths' do
           resource_paths_by_config = {
             'Debug' => [
+              '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugAssets.xcassets',
               '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodeld',
               '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodel',
               '${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugMappingModel.xcmappingmodel',
@@ -352,6 +353,7 @@ module Pod
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @copy_pods_resources_phase_name }
           phase.input_paths.sort.should == %w(
+            ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugAssets.xcassets
             ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodel
             ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugDataModel.xcdatamodeld
             ${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLib.bundle
@@ -362,6 +364,7 @@ module Pod
             ${SRCROOT}/../Pods/Target\ Support\ Files/Pods/Pods-resources.sh
           )
           phase.output_paths.sort.should == %w(
+            ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Assets.car
             ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugDataModel.mom
             ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugDataModel.momd
             ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DebugLib.bundle


### PR DESCRIPTION
When using `resources` DSL (note: *not* `resource_bundle`) then all `.xcassets` end up within `Assets.car` file.

This was causing re-builds of a project with many resources like the one in https://github.com/CocoaPods/CocoaPods/issues/7511 to re-compile very slow.

This makes re-compilation instant.