### PR TITLE
Mixed language static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-
 * Add `--exclude-pods` option to `pod update` to allow excluding specific pods from update  
   [Oleksandr Kruk](https://github.com/0mega)
   [#7334](https://github.com/CocoaPods/CocoaPods/issues/7334)
+
+* Add support for mixed Objective-C and Swift static frameworks  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7213](https://github.com/CocoaPods/CocoaPods/issues/7213)
 
 * Improve `pod install` performance for pods with exact file paths rather than glob patterns  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -81,10 +81,8 @@ module Pod
             end
 
             if target.requires_frameworks?
-              framework_name = target.product_module_name
               if target.static_framework?
-                settings['PUBLIC_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/Headers'
-                settings['PRIVATE_HEADERS_FOLDER_PATH'] = framework_name + '.framework' + '/PrivateHeaders'
+                settings['MACH_O_TYPE'] = 'staticlib'
               end
             else
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -74,7 +74,7 @@ module Pod
     #         #requires_frameworks?.
     #
     def product_type
-      requires_frameworks? && !static_framework? ? :framework : :static_library
+      requires_frameworks? ? :framework : :static_library
     end
 
     # @return [String] A string suitable for debugging.

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -818,20 +818,6 @@ module Pod
                 build_phase.should.not.be.nil
               end
 
-              it 'creates a build phase to set up a static library framework' do
-                @pod_target.stubs(:static_framework?).returns(true)
-
-                @installer.install!
-
-                target = @project.native_targets.first
-                build_phase = target.shell_script_build_phases.find do |bp|
-                  bp.name == 'Setup Static Framework'
-                end
-                build_phase.shell_script.should.include?('swiftmodule')
-                build_phase.shell_script.should.include?('PrivateHeaders')
-                build_phase.should.not.be.nil
-              end
-
               it 'verifies that headers in build phase for static libraries are all Project headers' do
                 @pod_target.stubs(:requires_frameworks?).returns(false)
 

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -61,27 +61,15 @@ module Pod
             }
           end
 
-          it 'verify header path for a static library framework' do
+          it 'verify static framework is building a static library' do
             @pod_target.stubs(:requires_frameworks?).returns(true)
             @pod_target.stubs(:static_framework?).returns(true)
             @installer.send(:add_target)
-            @installer.send(:native_target).resolved_build_setting('PUBLIC_HEADERS_FOLDER_PATH').should == {
-              'Release' => 'BananaLib.framework/Headers',
-              'Debug' => 'BananaLib.framework/Headers',
-              'Test' => 'BananaLib.framework/Headers',
-              'AppStore' => 'BananaLib.framework/Headers',
-            }
-          end
-
-          it 'verify private header path for a static library framework' do
-            @pod_target.stubs(:requires_frameworks?).returns(true)
-            @pod_target.stubs(:static_framework?).returns(true)
-            @installer.send(:add_target)
-            @installer.send(:native_target).resolved_build_setting('PRIVATE_HEADERS_FOLDER_PATH').should == {
-              'Release' => 'BananaLib.framework/PrivateHeaders',
-              'Debug' => 'BananaLib.framework/PrivateHeaders',
-              'Test' => 'BananaLib.framework/PrivateHeaders',
-              'AppStore' => 'BananaLib.framework/PrivateHeaders',
+            @installer.send(:native_target).resolved_build_setting('MACH_O_TYPE').should == {
+              'Release' => 'staticlib',
+              'Debug' => 'staticlib',
+              'Test' => 'staticlib',
+              'AppStore' => 'staticlib',
             }
           end
         end


### PR DESCRIPTION
closes #7213 
closes #7307

Support static frameworks with a mix of Objective C and Swift

It turns out that solving this problem simplifies the static framework implementation.  Instead of building a static library and moving files around to create a static framework, we now build a standard Xcode framework, but just force its library to be static - so Xcode will do all the file organization work.

I've verified that this fixes the mixed language examples from #7213, #7307 and #7413.