### PR TITLE
fix pod lib lint errors for pod with test_spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Create a generic Info.plist file for test targets  
   Use xcode default `PRODUCT_MODULE_NAME` for generated test targets  
   [Paul Zabelin](https://github.com/paulz)
   [#7506](https://github.com/CocoaPods/CocoaPods/issues/7506)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+  Use xcode default `PRODUCT_MODULE_NAME` for generated test targets  
+  [Paul Zabelin](https://github.com/paulz)
+  [#7506](https://github.com/CocoaPods/CocoaPods/issues/7506)
+  
 * Prevent `xcassets` compilation from stomping over the apps `xcassets`  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7003](https://github.com/CocoaPods/CocoaPods/issues/7003)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -294,6 +294,11 @@ module Pod
               create_test_target_embed_frameworks_script(test_type)
               create_test_target_copy_resources_script(test_type)
 
+              # Generate vanila Info.plist for test target similar to the one xcode gererates for new test target.
+              # This creates valid test bundle accessible at the runtime, allowing tests to load bundle resources
+              # defined in podspec.
+              create_info_plist_file(target.info_plist_path_for_test_type(test_type), native_test_target, '1.0', target.platform, :bndl)
+
               target.test_native_targets << native_test_target
             end
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -277,7 +277,10 @@ module Pod
                 # requires frameworks. For tests we always use the test target name as the product name
                 # irrelevant to whether we use frameworks or not.
                 configuration.build_settings['PRODUCT_NAME'] = name
-                configuration.build_settings['PRODUCT_MODULE_NAME'] = name
+                # Use xcode default product module name, which is $(PRODUCT_NAME:c99extidentifier)
+                # this gives us always valid name that is distinct from the parent spec module name
+                # which allow tests to use either import or @testable import to access the parent framework
+                configuration.build_settings.delete('PRODUCT_MODULE_NAME')
                 # We must codesign iOS XCTest bundles that contain binary frameworks to allow them to be launchable in the simulator
                 unless target.platform == :osx
                   configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'YES'

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -436,6 +436,15 @@ module Pod
       support_files_dir + "#{test_target_label(test_type)}-frameworks.sh"
     end
 
+    # @param  [Symbol] test_type
+    #         The test type this Info.plist path is for.
+    #
+    # @return [Pathname] The absolute path of the Info.plist for the given test type.
+    #
+    def info_plist_path_for_test_type(test_type)
+      support_files_dir + "#{test_target_label(test_type)}-Info.plist"
+    end
+
     # @return [Pathname] the absolute path of the prefix header file.
     #
     def prefix_header_path

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -199,7 +199,7 @@ module Pod
                 native_test_target.product_reference.name.should == 'CoconutLib-Unit-Tests'
                 native_test_target.build_configurations.each do |bc|
                   bc.build_settings['PRODUCT_NAME'].should == 'CoconutLib-Unit-Tests'
-                  bc.build_settings['PRODUCT_MODULE_NAME'].should == 'CoconutLib-Unit-Tests'
+                  bc.build_settings['PRODUCT_MODULE_NAME'].should.be.nil
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should == 'YES'
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should == 'YES'
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
@@ -217,7 +217,7 @@ module Pod
                 native_test_target.product_reference.name.should == 'CoconutLib-Unit-Tests'
                 native_test_target.build_configurations.each do |bc|
                   bc.build_settings['PRODUCT_NAME'].should == 'CoconutLib-Unit-Tests'
-                  bc.build_settings['PRODUCT_MODULE_NAME'].should == 'CoconutLib-Unit-Tests'
+                  bc.build_settings['PRODUCT_MODULE_NAME'].should.be.nil
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should.be.nil
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should.be.nil
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == ''

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -203,6 +203,7 @@ module Pod
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should == 'YES'
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should == 'YES'
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
+                  bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/CoconutLib/CoconutLib-Unit-Tests-Info.plist'
                 end
                 native_test_target.symbol_type.should == :unit_test_bundle
                 @coconut_pod_target.test_native_targets.count.should == 1
@@ -221,6 +222,7 @@ module Pod
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should.be.nil
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should.be.nil
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == ''
+                  bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/CoconutLib/CoconutLib-Unit-Tests-Info.plist'
                 end
                 native_test_target.symbol_type.should == :unit_test_bundle
                 @coconut_pod_target2.test_native_targets.count.should == 1

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -551,6 +551,10 @@ module Pod
           @test_pod_target.prefix_header_path_for_test_type(:unit).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-prefix.pch'
         end
 
+        it 'returns correct path for info plist for unit test type' do
+          @test_pod_target.info_plist_path_for_test_type(:unit).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-Info.plist'
+        end
+
         it 'returns the correct resource path for test resource bundles' do
           fa = Sandbox::FileAccessor.new(nil, @test_pod_target)
           fa.stubs(:resource_bundles).returns('TestResourceBundle' => [Pathname.new('Model.xcdatamodeld')])


### PR DESCRIPTION
1. Generate info plist file for test spec target to create valid test bundle, allowing tests to load bundle resources fixes https://github.com/CocoaPods/CocoaPods/issues/7506
2. Clear product module name to inherit Xcode default value, which is `$(PRODUCT_NAME:c99extidentifier)`, see https://github.com/CocoaPods/CocoaPods/pull/7510#discussion_r174983832. This always creates valid identifier different from the parent spec module name. 

closes https://github.com/CocoaPods/CocoaPods/issues/7506