### PR TITLE
Allows to skip update operation for specific pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+
+* Add `--exclude-pods` option to `pod update` to allow excluding specific pods from update  
+  [Oleksandr Kruk](https://github.com/0mega)
+  [#7334](https://github.com/CocoaPods/CocoaPods/issues/7334)
+
 * Improve `pod install` performance for pods with exact file paths rather than glob patterns  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#7473](https://github.com/CocoaPods/CocoaPods/pull/7473)


### PR DESCRIPTION
This PR introduces `--exclude-pods` option to `pod update` command.
It allows to skip the update operation for specific pods.
E.g.: `pod update --exclude-pods=Alamofire` will update all installed pods from the lockfile except Alamofire.

When `--exclude-pods` option is used with non installed pods, an Informative error will be raised.

Resolves #7334 