### PR TITLE
Prevent `xcassets` compilation from stomping over the apps `xcassets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Prevent `xcassets` compilation from stomping over the apps `xcassets`  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7003](https://github.com/CocoaPods/CocoaPods/issues/7003)
+
 * Fix script phase output path for `.xcasset` resources  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7511](https://github.com/CocoaPods/CocoaPods/issues/7511)

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -212,7 +212,11 @@ then
     fi
   done <<<"$OTHER_XCASSETS"
 
-  printf "%s\\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+  if [ -z ${ASSETCATALOG_COMPILER_APPICON_NAME+x} ]; then
+    printf "%s\\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+  else
+    printf "%s\\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}" --app-icon "${ASSETCATALOG_COMPILER_APPICON_NAME}" --output-partial-info-plist "${TARGET_BUILD_DIR}/assetcatalog_generated_info.plist"
+  fi
 fi
 EOS
     end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
@@ -58,11 +58,7 @@ module Pod
             unless resource_paths.empty?
               resource_paths_flattened = resource_paths.flatten.uniq
               input_paths = [script_path, *resource_paths_flattened]
-              output_paths = resource_paths_flattened.map do |input_path|
-                base_path = '${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}'
-                output_extension = UserProjectIntegrator::TargetIntegrator.output_extension_for_resource(File.extname(input_path))
-                File.join(base_path, File.basename(input_path, File.extname(input_path)) + output_extension)
-              end
+              output_paths = UserProjectIntegrator::TargetIntegrator.resource_output_paths(resource_paths_flattened)
             end
             UserProjectIntegrator::TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
             UserProjectIntegrator::TargetIntegrator.create_or_update_copy_resources_script_phase_to_target(native_target, script_path, input_paths, output_paths)


### PR DESCRIPTION
closes #7003 supersedes https://github.com/CocoaPods/CocoaPods/pull/7020