### PR TITLE
[PathList] Wait to resolve symlinks until checking header ACL

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -182,8 +182,8 @@ module Pod
 
               native_target = target.native_target_for_spec(consumer.spec)
               headers = file_accessor.headers
-              public_headers = file_accessor.public_headers
-              private_headers = file_accessor.private_headers
+              public_headers = file_accessor.public_headers.map(&:realpath)
+              private_headers = file_accessor.private_headers.map(&:realpath)
               other_source_files = file_accessor.source_files.reject { |sf| SOURCE_FILE_EXTENSIONS.include?(sf.extname) }
 
               {

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -215,25 +215,6 @@ module Pod
         end
       end
 
-      # Escapes the glob metacharacters from a given path so it can used in
-      # Dir#glob and similar methods.
-      #
-      # @note   See CocoaPods/CocoaPods#862.
-      #
-      # @param  [String, Pathname] path
-      #         The path to escape.
-      #
-      # @return [Pathname] The escaped path.
-      #
-      def escape_path_for_glob(path)
-        result = path.to_s
-        characters_to_escape = ['[', ']', '{', '}', '?', '*']
-        characters_to_escape.each do |character|
-          result.gsub!(character, "\\#{character}")
-        end
-        Pathname.new(result)
-      end
-
       #-----------------------------------------------------------------------#
     end
   end

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -88,7 +88,7 @@ module Pod
       # @return [Array<Pathname>]
       #
       def glob(patterns, options = {})
-        relative_glob(patterns, options).map { |p| (root + p).realpath }
+        relative_glob(patterns, options).map { |p| root.join(p) }
       end
 
       # The list of relative paths that are case insensitively matched by a

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -205,11 +205,11 @@ module Pod
         else
           patterns = [pattern]
           values_by_set.each do |set, values|
-            patterns = patterns.map do |old_pattern|
+            patterns = patterns.flat_map do |old_pattern|
               values.map do |value|
                 old_pattern.gsub(set, value)
               end
-            end.flatten
+            end
           end
           patterns
         end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -364,7 +364,7 @@ module Pod
           @project.add_pod_group('BananaLib', config.sandbox.pod_dir('BananaLib'), false)
           @file = config.sandbox.pod_dir('BananaLib') + 'file.m'
           @group = @project.group_for_spec('BananaLib')
-          Pathname.any_instance.stubs(:realpath).returns(@file)
+          @file.stubs(:realpath).returns(@file)
           @project.add_file_reference(@file, @group)
         end
 
@@ -375,6 +375,7 @@ module Pod
 
         it 'returns nil if no reference for the given path is available' do
           another_file = config.sandbox.pod_dir('BananaLib') + 'another_file.m'
+          another_file.stubs(:realpath).returns(another_file)
           ref = @project.reference_for_path(another_file)
           ref.should.be.nil
         end

--- a/spec/unit/sandbox/path_list_spec.rb
+++ b/spec/unit/sandbox/path_list_spec.rb
@@ -260,15 +260,6 @@ module Pod
       end
 
       #--------------------------------------#
-
-      describe '#escape_path_for_glob' do
-        it 'escapes metacharacters' do
-          escaped = @path_list.send(:escape_path_for_glob, '[]{}?**')
-          escaped.to_s.should == '\[\]\{\}\?\*\*'
-        end
-      end
-
-      #--------------------------------------#
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/sandbox/path_list_spec.rb
+++ b/spec/unit/sandbox/path_list_spec.rb
@@ -192,6 +192,13 @@ module Pod
           Resources/sub_dir
         )
       end
+
+      it 'can glob for exact matches' do
+        paths = @path_list.relative_glob('libBananalib.a').map(&:to_s)
+        paths.sort.should == %w(
+          libBananalib.a
+        )
+      end
     end
 
     describe 'Reading file system' do
@@ -291,14 +298,27 @@ module Pod
         @path_list.instance_variable_set(:@files, nil)
         File.symlink(@tmpfile, @symlink_file)
 
-        @path_list.files.map(&:to_s).include?('Classes/symlinked.h').should == true
+        @path_list.files.map(&:to_s).should.include?('Classes/symlinked.h')
+      end
+
+      it 'includes symlinked file with a different basename' do
+        orange_h = @path_list.root.join('Classes', 'Orange.h')
+        File.symlink('Banana.h', orange_h)
+
+        begin
+          @path_list.glob('Classes/Orange.h').should == [
+            orange_h,
+          ]
+        ensure
+          FileUtils.remove_entry(orange_h)
+        end
       end
 
       it 'includes symlinked dir' do
         @path_list.instance_variable_set(:@dirs, nil)
         File.symlink(@tmpdir, @symlink_dir)
 
-        @path_list.dirs.map(&:to_s).include?('Classes/symlinked').should == true
+        @path_list.dirs.map(&:to_s).should.include?('Classes/symlinked')
       end
 
       it 'doesn\'t include file in symlinked dir' do
@@ -306,7 +326,7 @@ module Pod
         @path_list.instance_variable_set(:@dirs, nil)
         File.symlink(@tmpdir, @symlink_dir)
 
-        @path_list.files.map(&:to_s).include?('Classes/symlinked/someheader.h').should == false
+        @path_list.files.map(&:to_s).should.not.include?('Classes/symlinked/someheader.h')
       end
     end
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/CocoaPods/CocoaPods/pull/7470.

> It turns out this has caused a regression for one of our pods -- it has a vendored_library , libThing.a, that is a symlink to just Thing. With this change, CocoaPods is no longer keeping libThing.a around, so linking is failing.

cc @rmtmckenzie 