### PR TITLE
Remove SWIFT_INCLUDE_PATHS for dependent targets with no swift

### DIFF
--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -346,9 +346,9 @@ module Pod
                                       "${PODS_ROOT}/#{dependent_target.module_map_path.relative_path_from(dependent_target.sandbox.root)}"
                                     end
                   module_map_files << %(-fmodule-map-file="#{module_map_file}")
+                  swift_import_paths << dependent_target.configuration_build_dir(CONFIGURATION_BUILD_DIR_VARIABLE) if dependent_target.uses_swift?
                 end
               end
-              swift_import_paths << dependent_target.configuration_build_dir(CONFIGURATION_BUILD_DIR_VARIABLE)
             end
 
             build_settings['FRAMEWORK_SEARCH_PATHS'] = XCConfigHelper.quote(framework_search_paths.uniq)

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -69,12 +69,14 @@ module Pod
                            :should_build? => true,
                            :requires_frameworks? => true,
                            :configuration_build_dir => 'AB',
+                           :uses_swift? => false,
                           )
             target2 = stub('target2',
                            :specs => ['B'],
                            :should_build? => true,
                            :requires_frameworks? => true,
                            :configuration_build_dir => 'B',
+                           :uses_swift? => false,
                           )
             dependent_targets = [target1, target2]
             build_settings = @sut.search_paths_for_dependent_targets(nil, dependent_targets)


### PR DESCRIPTION
They're unnecessary (since they wont ever point to a swiftmodule file), and make us hit `ARG_MAX` faster