### PR TITLE
Specs submodule should be shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "spec/fixtures/spec-repos/master"]
 	path = spec/fixtures/spec-repos/master
 	url = https://github.com/CocoaPods/Specs.git
+	shallow = true
 [submodule "spec/fixtures/integration/Reachability"]
 	path = spec/fixtures/integration/Reachability
 	url = https://github.com/tonymillion/Reachability.git


### PR DESCRIPTION
https://git-scm.com/docs/gitmodules#gitmodules-submoduleltnamegtshallow
https://stackoverflow.com/a/17692710/3343740

A user's first time `pod install` is extremely slow due to the number of objects to download from the Specs repo submodule. This looked like it would take about 2 hours for me to do on my 100 Mbps internet:

```
$ pod install
Analyzing dependencies
Pre-downloading: `PSPDFTextView` from `https://github.com/steipete/PSPDFTextView.git`
Pre-downloading: `RSTWebViewController` from `https://github.com/rileytestut/RSTWebViewController-Legacy.git`
Setting up CocoaPods master repo
  $ /usr/local/bin/git clone https://github.com/CocoaPods/Specs.git master --progress
  Cloning into 'master'...
  remote: Counting objects: 2005760, done.
  remote: Compressing objects: 100% (703/703), done.
^C[!] Cancelledects:   4% (92988/2005760), 18.50 MiB | 414.00 KiB/s
```

I dont know anything about cocoapods, but I assume it will still work if the submodule is cloned shallow - it worked for me by manually cloning the repo shallow this way:

```
~ $ cd /Users/austinheiman/.cocoapods/repos/
repos $ /usr/local/bin/git clone https://github.com/CocoaPods/Specs.git master --progress --depth 1
Cloning into 'master'...
remote: Counting objects: 494900, done.
remote: Compressing objects: 100% (316652/316652), done.
remote: Total 494900 (delta 106801), reused 479247 (delta 106252), pack-reused 0
Receiving objects: 100% (494900/494900), 77.33 MiB | 11.68 MiB/s, done.
Resolving deltas: 100% (106801/106801), done.
Checking out files: 100% (223925/223925), done.
```

I guess to test this I could compare cloning / downloading submodules from this branch to the master branch.