### PR TITLE
Yes, improving performance again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: a5fafbc2bfe80966917307c2deaa1664898af5bc
+  revision: 35b53a939c553c510e81fcf2cec0ff6682399b9a
   branch: master
   specs:
     cocoapods-core (1.5.0)

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -119,9 +119,13 @@ module Pod
           rescue => _
             raise Informative, "Failed to download '#{name}'."
           end
-          spec = download_result.spec
 
+          spec = download_result.spec
           raise Informative, "Unable to find a specification for '#{name}'." unless spec
+
+          # since the podspec might be cleaned, we want the checksum to refer
+          # to the json in the sandbox
+          spec.defined_in_file = nil
 
           store_podspec(sandbox, spec)
           sandbox.store_pre_downloaded_pod(name)
@@ -161,7 +165,7 @@ module Pod
                  when String
                    path = "#{name}.podspec"
                    path << '.json' if json
-                   Specification.from_string(spec, path)
+                   Specification.from_string(spec, path).tap {|s| s.defined_in_file = nil }
                  when Specification
                    spec.dup
                  else

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -170,8 +170,10 @@ module Pod
         rescue Pod::DSLError => e
           raise Informative, "Failed to load '#{name}' podspec: #{e.message}"
         end
+        defined_in_file = spec.defined_in_file
         spec.defined_in_file = nil
         validate_podspec(spec)
+        spec.defined_in_file = defined_in_file
         sandbox.store_podspec(name, spec, true, true)
       end
 

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -172,7 +172,7 @@ module Pod
         end
         spec.defined_in_file = nil
         validate_podspec(spec)
-        sandbox.store_podspec(name, spec.to_pretty_json, true, true)
+        sandbox.store_podspec(name, spec, true, true)
       end
 
       def validate_podspec(podspec)

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -170,14 +170,15 @@ module Pod
         rescue Pod::DSLError => e
           raise Informative, "Failed to load '#{name}' podspec: #{e.message}"
         end
-        defined_in_file = spec.defined_in_file
-        spec.defined_in_file = nil
+
         validate_podspec(spec)
-        spec.defined_in_file = defined_in_file
         sandbox.store_podspec(name, spec, true, true)
       end
 
       def validate_podspec(podspec)
+        defined_in_file = podspec.defined_in_file
+        podspec.defined_in_file = nil
+
         validator = validator_for_podspec(podspec)
         validator.quick = true
         validator.allow_warnings = true
@@ -188,6 +189,8 @@ module Pod
         unless validator.validated?
           raise Informative, "The `#{name}` pod failed to validate due to #{validator.failure_reason}:\n#{validator.results_message}"
         end
+      ensure
+        podspec.defined_in_file = defined_in_file
       end
 
       def validator_for_podspec(podspec)

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -165,7 +165,7 @@ module Pod
                  when String
                    path = "#{name}.podspec"
                    path << '.json' if json
-                   Specification.from_string(spec, path).tap {|s| s.defined_in_file = nil }
+                   Specification.from_string(spec, path).tap { |s| s.defined_in_file = nil }
                  when Specification
                    spec.dup
                  else

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -66,8 +66,8 @@ module Pod
     # @param  [Lockfile] lockfile    @see #lockfile
     #
     def initialize(sandbox, podfile, lockfile = nil)
-      @sandbox  = sandbox
-      @podfile  = podfile
+      @sandbox  = sandbox || raise(ArgumentError, "need a sandbox")
+      @podfile  = podfile || raise(ArgumentError, "need a podfile")
       @lockfile = lockfile
 
       @use_default_plugins = true

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -687,8 +687,6 @@ module Pod
           raise Pod::Informative, 'The `Pods` directory is out-of-date, you must run `pod install`'
         end
 
-        create_file_accessors
-
         aggregate_targets
       end
     end

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -66,8 +66,8 @@ module Pod
     # @param  [Lockfile] lockfile    @see #lockfile
     #
     def initialize(sandbox, podfile, lockfile = nil)
-      @sandbox  = sandbox || raise(ArgumentError, 'need a sandbox')
-      @podfile  = podfile || raise(ArgumentError, 'need a podfile')
+      @sandbox  = sandbox || raise(ArgumentError, 'Missing required argument `sandbox`')
+      @podfile  = podfile || raise(ArgumentError, 'Missing required argument `podfile`')
       @lockfile = lockfile
 
       @use_default_plugins = true

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -56,6 +56,7 @@ module Pod
         @test_pod_target_analyzer_cache = {}
         @test_pod_target_key = Struct.new(:name, :pod_targets)
         @podfile_dependency_cache = PodfileDependencyCache.from_podfile(podfile)
+        @result = nil
       end
 
       # Performs the analysis.
@@ -70,6 +71,7 @@ module Pod
       # @return [AnalysisResult]
       #
       def analyze(allow_fetches = true)
+        return @result if @result
         validate_podfile!
         validate_lockfile_version!
         @result = AnalysisResult.new

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -231,7 +231,7 @@ module Pod
           UI.section 'Finding Podfile changes' do
             pods_by_state = lockfile.detect_changes_with_podfile(podfile)
             pods_state = SpecsState.new(pods_by_state)
-            pods_state.print
+            pods_state.print if config.verbose?
           end
           pods_state
         else

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -748,7 +748,7 @@ module Pod
             deps_to_fetch = deps_with_external_source.select { |dep| pods_to_fetch.include?(dep.root_name) }
             deps_to_fetch_if_needed = deps_with_external_source.select { |dep| result.podfile_state.unchanged.include?(dep.root_name) }
             deps_to_fetch += deps_to_fetch_if_needed.select do |dep|
-              sandbox.specification(dep.root_name).nil? ||
+              sandbox.specification_path(dep.root_name).nil? ||
                 !dep.external_source[:path].nil? ||
                 !sandbox.pod_dir(dep.root_name).directory? ||
                 checkout_requires_update?(dep)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -678,7 +678,7 @@ module Pod
           pods_to_update = result.podfile_state.changed + result.podfile_state.deleted
           pods_to_update += update[:pods] if update_mode == :selected
           local_pod_names = @podfile_dependency_cache.podfile_dependencies.select(&:local?).map(&:root_name)
-          pods_to_unlock = local_pod_names.reject do |pod_name|
+          pods_to_unlock = local_pod_names.to_set.delete_if do |pod_name|
             sandbox.specification(pod_name).checksum == lockfile.checksum(pod_name)
           end
           LockingDependencyAnalyzer.generate_version_locking_dependencies(lockfile, pods_to_update, pods_to_unlock)

--- a/lib/cocoapods/installer/analyzer/pod_variant.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant.rb
@@ -38,6 +38,7 @@ module Pod
           @test_specs = test_specs
           @platform = platform
           @requires_frameworks = requires_frameworks
+          @hash = [specs, platform, requires_frameworks].hash
         end
 
         # @note Test specs are intentionally not included as part of the equality for pod variants since a
@@ -48,9 +49,9 @@ module Pod
         #
         def ==(other)
           self.class == other.class &&
-            specs == other.specs &&
+            requires_frameworks == other.requires_frameworks &&
             platform == other.platform &&
-            requires_frameworks == other.requires_frameworks
+            specs == other.specs
         end
         alias_method :eql?, :==
 
@@ -59,9 +60,7 @@ module Pod
         # This adds support to make instances usable as Hash keys.
         #
         # @!visibility private
-        def hash
-          [specs, platform, requires_frameworks].hash
-        end
+        attr_reader :hash
       end
     end
   end

--- a/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
+++ b/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
@@ -103,8 +103,7 @@ module Pod
         #
         def pod_added?(pod)
           return true if resolved_pods.include?(pod) && !sandbox_pods.include?(pod)
-          return true unless folder_exist?(pod)
-          return false if !folder_exist?(pod) && !sandbox.local?(pod)
+          return true if !folder_exist?(pod) && !sandbox.local?(pod)
           false
         end
 

--- a/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
+++ b/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
@@ -104,6 +104,7 @@ module Pod
         def pod_added?(pod)
           return true if resolved_pods.include?(pod) && !sandbox_pods.include?(pod)
           return true unless folder_exist?(pod)
+          return false if !folder_exist?(pod) && !sandbox.local?(pod)
           false
         end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -115,8 +115,8 @@ module Pod
                 next unless sandbox.local?(pod_name)
                 root_name = Specification.root_name(pod_name)
                 paths = file_accessor.developer_files
+                group = pods_project.group_for_spec(root_name, :developer)
                 paths.each do |path|
-                  group = pods_project.group_for_spec(root_name, :developer)
                   ref = pods_project.add_file_reference(path, group, false)
                   if path.extname == '.podspec'
                     pods_project.mark_ruby_file_ref(ref)
@@ -208,8 +208,8 @@ module Pod
               paths = file_accessor.send(file_accessor_key)
               paths = allowable_project_paths(paths)
               base_path = local ? common_path(paths) : nil
+              group = pods_project.group_for_spec(pod_name, group_key)
               paths.each do |path|
-                group = pods_project.group_for_spec(pod_name, group_key)
                 pods_project.add_file_reference(path, group, local && reflect_file_system_structure_for_development, base_path)
               end
             end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -115,6 +115,7 @@ module Pod
                 next unless sandbox.local?(pod_name)
                 root_name = Specification.root_name(pod_name)
                 paths = file_accessor.developer_files
+                next if paths.empty?
                 group = pods_project.group_for_spec(root_name, :developer)
                 paths.each do |path|
                   ref = pods_project.add_file_reference(path, group, false)
@@ -203,10 +204,12 @@ module Pod
           #
           def add_file_accessors_paths_to_pods_group(file_accessor_key, group_key = nil, reflect_file_system_structure_for_development = false)
             file_accessors.each do |file_accessor|
-              pod_name = file_accessor.spec.name
-              local = sandbox.local?(pod_name)
               paths = file_accessor.send(file_accessor_key)
               paths = allowable_project_paths(paths)
+              next if paths.empty?
+
+              pod_name = file_accessor.spec.name
+              local = sandbox.local?(pod_name)
               base_path = local ? common_path(paths) : nil
               group = pods_project.group_for_spec(pod_name, group_key)
               paths.each do |path|

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -109,13 +109,13 @@ module Pod
           # @return [Object] the result of the generator.
           #
           def update_changed_file(generator, path)
-            path.dirname.mkpath
             if path.exist?
               result = generator.save_as(support_files_temp_dir)
               unless FileUtils.identical?(support_files_temp_dir, path)
                 FileUtils.mv(support_files_temp_dir, path)
               end
             else
+              path.dirname.mkpath
               result = generator.save_as(path)
             end
             clean_support_files_temp_dir if support_files_temp_dir.exist?

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -139,7 +139,7 @@ module Pod
           resolver_specs_by_target[target] = vertices.
             map do |vertex|
               payload = vertex.payload
-              test_only = vertex.recursive_predecessors.all? { |v| !v.root? || v.payload.test_specification? } && (!vertex.root? || payload.test_specification?)
+              test_only = (!vertex.root? || payload.test_specification?) && vertex.recursive_predecessors.all? { |v| !v.root? || v.payload.test_specification? }
               spec_source = payload.respond_to?(:spec_source) && payload.spec_source
               ResolverSpecification.new(payload, test_only, spec_source)
             end.
@@ -535,7 +535,9 @@ module Pod
     #
     # @return [Bool]
     def spec_is_platform_compatible?(dependency_graph, dependency, spec)
-      return true if locked_dependencies.vertex_named(spec.name) # HACK: this probably isn't safe?
+      # This is safe since a pod will only be in locked dependencies if we're
+      # using the same exact version
+      return true if locked_dependencies.vertex_named(spec.name)
 
       vertex = dependency_graph.vertex_named(dependency.name)
       predecessors = vertex.recursive_predecessors.select(&:root?)

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -261,9 +261,10 @@ module Pod
         unless podspec.exist?
           raise Informative, "No podspec found for `#{name}` in #{podspec}"
         end
+        spec = Specification.from_file(podspec)
         FileUtils.copy(podspec, output_path)
       when Specification
-        raise ArgumentError unless json
+        raise ArgumentError, "can only store Specification objects as json" unless json
         output_path.open('w') { |f| f.puts(podspec.to_pretty_json) }
         spec = podspec.dup
       else

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -266,8 +266,8 @@ module Pod
         raise ArgumentError unless json
         output_path.open('w') { |f| f.puts(podspec.to_pretty_json) }
         spec = podspec.dup
-        spec.defined_in_file = output_path
-      else raise ArgumentError
+      else
+        raise ArgumentError, "Unknown type for podspec: #{podspec.inspect}"
       end
 
       spec ||= Specification.from_file(output_path)

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -272,6 +272,7 @@ module Pod
       end
 
       spec ||= Specification.from_file(output_path)
+      spec.defined_in_file ||= output_path
 
       unless spec.name == name
         raise Informative, "The name of the given podspec `#{spec.name}` doesn't match the expected one `#{name}`"

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -211,8 +211,8 @@ module Pod
     #
     def specification(name)
       @stored_podspecs[name] ||= if file = specification_path(name)
-        original_path = development_pods[name]
-        Specification.from_file(original_path || file)
+                                   original_path = development_pods[name]
+                                   Specification.from_file(original_path || file)
       end
     end
 
@@ -264,7 +264,7 @@ module Pod
         spec = Specification.from_file(podspec)
         FileUtils.copy(podspec, output_path)
       when Specification
-        raise ArgumentError, "can only store Specification objects as json" unless json
+        raise ArgumentError, 'can only store Specification objects as json' unless json
         output_path.open('w') { |f| f.puts(podspec.to_pretty_json) }
         spec = podspec.dup
       else

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -54,7 +54,7 @@ module Pod
         return @search_paths_cache[key] if @search_paths_cache.key?(key)
         search_paths = @search_paths.select do |entry|
           matches_platform = entry[:platform] == platform.name
-          matches_target = target_name.nil? || (entry[:path].basename.to_s == target_name)
+          matches_target = target_name.nil? || (File.basename(entry[:path]) == target_name)
           matches_platform && matches_target
         end
         headers_dir = root.relative_path_from(sandbox.root).dirname
@@ -98,7 +98,7 @@ module Pod
       def add_files(namespace, relative_header_paths)
         root.join(namespace).mkpath unless relative_header_paths.empty?
         relative_header_paths.map do |relative_header_path|
-          add_file(namespace, relative_header_path)
+          add_file(namespace, relative_header_path, :mkdir => false)
         end
       end
 
@@ -116,9 +116,9 @@ module Pod
       #
       # @return [Pathname]
       #
-      def add_file(namespace, relative_header_path, directory_made: false)
+      def add_file(namespace, relative_header_path, mkdir: true)
         namespaced_path = root + namespace
-        namespaced_path.mkpath unless directory_made
+        namespaced_path.mkpath if mkdir
 
         absolute_source = (sandbox.root + relative_header_path)
         source = absolute_source.relative_path_from(namespaced_path)
@@ -129,7 +129,7 @@ module Pod
       # Adds an header search path to the sandbox.
       #
       # @param  [Pathname] path
-      #         the path tho add.
+      #         the path to add.
       #
       # @param  [String] platform
       #         the platform the search path applies to
@@ -137,7 +137,7 @@ module Pod
       # @return [void]
       #
       def add_search_path(path, platform)
-        @search_paths << { :platform => platform.name, :path => (Pathname.new(@relative_path) + path) }
+        @search_paths << { :platform => platform.name, :path => File.join(@relative_path, path) }
       end
 
       #-----------------------------------------------------------------------#

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -96,6 +96,7 @@ module Pod
       # @return [Array<Pathname>]
       #
       def add_files(namespace, relative_header_paths)
+        root.join(namespace).mkpath unless relative_header_paths.empty?
         relative_header_paths.map do |relative_header_path|
           add_file(namespace, relative_header_path)
         end
@@ -115,9 +116,9 @@ module Pod
       #
       # @return [Pathname]
       #
-      def add_file(namespace, relative_header_path)
+      def add_file(namespace, relative_header_path, directory_made: false)
         namespaced_path = root + namespace
-        namespaced_path.mkpath unless File.exist?(namespaced_path)
+        namespaced_path.mkpath unless directory_made
 
         absolute_source = (sandbox.root + relative_header_path)
         source = absolute_source.relative_path_from(namespaced_path)

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -185,10 +185,10 @@ module Pod
     end
 
     it 'validates specs as frameworks by default' do
-      Validator.any_instance.expects(:podfile_from_spec).with(:ios, '8.0', true, []).times(3)
-      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, true, []).twice
-      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, true, []).twice
-      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, true, []).twice
+      Validator.any_instance.expects(:podfile_from_spec).with(:ios, '8.0', true, []).times(3).returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, true, []).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, true, []).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, true, []).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
@@ -199,10 +199,10 @@ module Pod
     end
 
     it 'validates specs as libraries if requested' do
-      Validator.any_instance.expects(:podfile_from_spec).with(:ios, nil, false, []).times(3)
-      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, []).twice
-      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, []).twice
-      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, []).twice
+      Validator.any_instance.expects(:podfile_from_spec).with(:ios, nil, false, []).times(3).returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, []).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, []).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, []).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master', '--use-libraries')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,14 +55,10 @@ require 'spec_helper/webmock'         # Cleans up mocks after each spec
 #
 module Pod
   class Specification
-    alias_method :original_source, :source
     def source
       fixture = SpecHelper.fixture("integration/#{name}")
       result = super
-      if fixture.exist?
-        # puts "Using fixture [#{name}]"
-        result[:git] = fixture.to_s
-      end
+      result[:git] = fixture.to_s if fixture.exist?
       result
     end
   end
@@ -98,6 +94,17 @@ Mocha::Configuration.prevent(:stubbing_non_existent_method)
 module SpecHelper
   def self.temporary_directory
     ROOT + 'tmp'
+  end
+
+  def self.reset_config_instance
+    ::Pod::Config.instance = nil
+    ::Pod::Config.instance.tap do |c|
+      c.verbose           =  false
+      c.silent            =  true
+      c.repos_dir         =  fixture('spec-repos')
+      c.installation_root =  SpecHelper.temporary_directory
+      c.cache_root        =  SpecHelper.temporary_directory + 'Cache'
+    end
   end
 end
 

--- a/spec/spec_helper/pre_flight.rb
+++ b/spec/spec_helper/pre_flight.rb
@@ -5,14 +5,7 @@ module Bacon
     old_run_requirement = instance_method(:run_requirement)
 
     define_method(:run_requirement) do |description, spec|
-      ::Pod::Config.instance = nil
-      ::Pod::Config.instance.tap do |c|
-        c.verbose           =  false
-        c.silent            =  true
-        c.repos_dir         =  fixture('spec-repos')
-        c.installation_root =  SpecHelper.temporary_directory
-        c.cache_root        =  SpecHelper.temporary_directory + 'Cache'
-      end
+      ::SpecHelper.reset_config_instance
 
       ::Pod::UI.output = ''
       ::Pod::UI.warnings = ''

--- a/spec/unit/external_sources/abstract_external_source_spec.rb
+++ b/spec/unit/external_sources/abstract_external_source_spec.rb
@@ -69,7 +69,6 @@ module Pod
     describe 'Subclasses helpers' do
       it 'pre-downloads the Pod and stores the relevant information in the sandbox' do
         @subject.expects(:validate_podspec).with do |spec|
-          spec.defined_in_file.should.be.nil
           spec.name.should == 'Reachability'
         end
         @subject.send(:pre_download, config.sandbox)

--- a/spec/unit/external_sources/downloader_source_spec.rb
+++ b/spec/unit/external_sources/downloader_source_spec.rb
@@ -9,6 +9,7 @@ module Pod
       }
       dep = Dependency.new('Reachability', params)
       @subject = ExternalSources.from_dependency(dep, nil, true)
+      config.sandbox.specifications_root.mkpath
     end
 
     it 'creates a copy of the podspec' do

--- a/spec/unit/external_sources/path_source_spec.rb
+++ b/spec/unit/external_sources/path_source_spec.rb
@@ -7,6 +7,7 @@ module Pod
       dependency = Dependency.new('Reachability', params)
       podfile_path = fixture('integration/Podfile')
       @subject = ExternalSources.from_dependency(dependency, podfile_path, true)
+      config.sandbox.specifications_root.mkpath
     end
 
     it 'creates a copy of the podspec' do

--- a/spec/unit/external_sources/podspec_source_spec.rb
+++ b/spec/unit/external_sources/podspec_source_spec.rb
@@ -11,6 +11,7 @@ module Pod
     end
 
     it 'creates a copy of the podspec' do
+      config.sandbox.specifications_root.mkpath
       @subject.fetch(config.sandbox)
       path = config.sandbox.specifications_root + 'Reachability.podspec.json'
       path.should.exist?

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -1040,6 +1040,7 @@ module Pod
         @sandbox_manifest = Pod::Lockfile.new(@lockfile.internal_data.deep_dup)
         @analyzer.sandbox.manifest = @sandbox_manifest
         @analyzer.sandbox.stubs(:specification).with('BananaLib').returns(stub)
+        @analyzer.sandbox.stubs(:specification_path).with('BananaLib').returns(stub)
         pod_dir = stub
         pod_dir.stubs(:directory?).returns(true)
         @analyzer.sandbox.stubs(:pod_dir).with('BananaLib').returns(pod_dir)

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -713,7 +713,7 @@ module Pod
       it 'does not include pod target if its used by tests only' do
         spec1 = Resolver::ResolverSpecification.new(stub, true, nil)
         spec2 = Resolver::ResolverSpecification.new(stub, true, nil)
-        target_definition = stub
+        target_definition = stub('TargetDefinition')
         pod_target = stub(:name => 'Pod1', :target_definitions => [target_definition], :specs => [spec1.spec, spec2.spec])
         resolver_specs_by_target = { target_definition => [spec1, spec2] }
         @analyzer.send(:filter_pod_targets_for_target_definition, target_definition, [pod_target], resolver_specs_by_target).should.be.empty

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -22,6 +22,7 @@ module Pod
             options.integrate_targets = integrate_targets
           end
 
+          sandbox.specifications_root.mkpath
           @analyzer = Analyzer.new(sandbox, podfile, lockfile).tap do |analyzer|
             analyzer.installation_options = installation_options
           end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -776,7 +776,6 @@ module Pod
         @installer = Installer.new(config.sandbox, podfile, lockfile)
         @installer.expects(:integrate_user_project)
         @installer.install!
-        pod_targets = @installer.aggregate_targets.map(&:pod_targets)
 
         ::SpecHelper.reset_config_instance
 
@@ -804,7 +803,6 @@ module Pod
         @installer = Installer.new(config.sandbox, podfile, lockfile)
         @installer.expects(:integrate_user_project)
         @installer.install!
-        pod_targets = @installer.aggregate_targets.map(&:pod_targets)
 
         ::SpecHelper.reset_config_instance
 

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -470,9 +470,9 @@ module Pod
         spec_names.should == %w(
           Expecta MainSpec MainSpec/Tests
         )
-        resolved_specs.find { |rs| rs.name == 'Expecta' }.used_by_tests_only?.should.be.false
-        resolved_specs.find { |rs| rs.name == 'MainSpec' }.used_by_tests_only?.should.be.false
-        resolved_specs.find { |rs| rs.name == 'MainSpec/Tests' }.used_by_tests_only?.should.be.true
+        resolved_specs.find { |rs| rs.name == 'Expecta' }.should.not.be.used_by_tests_only
+        resolved_specs.find { |rs| rs.name == 'MainSpec' }.should.not.be.used_by_tests_only
+        resolved_specs.find { |rs| rs.name == 'MainSpec/Tests' }.should.be.used_by_tests_only
       end
 
       it 'allows pre-release spec versions when a requirement has an ' \

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -107,13 +107,8 @@ module Pod
       it 'loads the stored specification from the original path' do
         spec_file = fixture('banana-lib/BananaLib.podspec')
         spec = Specification.from_file(spec_file)
-        Specification.expects(:from_file).with do
-          Dir.pwd == fixture('banana-lib').to_s
-        end.once.returns(spec)
 
-        Specification.expects(:from_file).with do |path|
-          path == spec_file
-        end.once.returns(spec)
+        Specification.expects(:from_file).with(spec_file).once.returns(spec)
 
         @sandbox.store_podspec('BananaLib', spec_file)
         @sandbox.store_local_path('BananaLib', spec_file)

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -38,6 +38,7 @@ module Pod
       it 'cleans any trace of the Pod with the given name' do
         pod_root = @sandbox.pod_dir('BananaLib')
         pod_root.mkpath
+        @sandbox.specifications_root.mkpath
         @sandbox.store_podspec('BananaLib', fixture('banana-lib/BananaLib.podspec'))
         specification_path = @sandbox.specification_path('BananaLib')
         @sandbox.clean_pod('BananaLib')
@@ -93,8 +94,12 @@ module Pod
     #-------------------------------------------------------------------------#
 
     describe 'Specification store' do
+      before do
+        # This is normally done in #prepare
+        @sandbox.specifications_root.mkdir
+      end
+
       it 'loads the stored specification with the given name' do
-        (@sandbox.specifications_root).mkdir
         FileUtils.cp(fixture('banana-lib/BananaLib.podspec'), @sandbox.specifications_root)
         @sandbox.specification('BananaLib').name.should == 'BananaLib'
       end
@@ -121,7 +126,6 @@ module Pod
       end
 
       it "returns the path to a spec file in the 'Local Podspecs' dir" do
-        (@sandbox.root + 'Local Podspecs').mkdir
         FileUtils.cp(fixture('banana-lib/BananaLib.podspec'), @sandbox.root + 'Local Podspecs')
         @sandbox.specification_path('BananaLib').should ==
           @sandbox.root + 'Local Podspecs/BananaLib.podspec'

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -360,12 +360,14 @@ module Pod
           s.ios.deployment_target = '7.0'
         end
         validator.spec.stubs(:subspecs).returns([subspec])
-        validator.expects(:podfile_from_spec).with(:osx, nil, nil, []).once
-        validator.expects(:podfile_from_spec).with(:ios, nil, nil, []).once
-        validator.expects(:podfile_from_spec).with(:ios, '7.0', nil, []).once
-        validator.expects(:podfile_from_spec).with(:tvos, nil, nil, []).once
-        validator.expects(:podfile_from_spec).with(:watchos, nil, nil, []).once
+        validator.expects(:podfile_from_spec).with(:osx, nil, nil, []).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:ios, nil, nil, []).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:ios, '7.0', nil, []).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:tvos, nil, nil, []).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:watchos, nil, nil, []).once.returns(stub('Podfile'))
         validator.send(:perform_extensive_analysis, validator.spec)
+
+        validator.results_message.strip.should.be.empty
       end
 
       describe '#podfile_from_spec' do
@@ -799,11 +801,13 @@ module Pod
 
         setup_validator
 
-        @validator.expects(:podfile_from_spec).with(:osx, nil, true, []).once
-        @validator.expects(:podfile_from_spec).with(:ios, '8.0', true, []).once
-        @validator.expects(:podfile_from_spec).with(:tvos, nil, true, []).once
-        @validator.expects(:podfile_from_spec).with(:watchos, nil, true, []).once
+        @validator.expects(:podfile_from_spec).with(:osx, nil, true, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:ios, '8.0', true, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:tvos, nil, true, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:watchos, nil, true, []).once.returns(stub('Podfile'))
         @validator.send(:perform_extensive_analysis, @validator.spec)
+
+        @validator.results_message.strip.should.be.empty
       end
 
       it 'lint as a static library if specified' do
@@ -811,11 +815,13 @@ module Pod
 
         setup_validator
 
-        @validator.expects(:podfile_from_spec).with(:osx, nil, false, []).once
-        @validator.expects(:podfile_from_spec).with(:ios, nil, false, []).once
-        @validator.expects(:podfile_from_spec).with(:tvos, nil, false, []).once
-        @validator.expects(:podfile_from_spec).with(:watchos, nil, false, []).once
+        @validator.expects(:podfile_from_spec).with(:osx, nil, false, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:ios, nil, false, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:tvos, nil, false, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:watchos, nil, false, []).once.returns(stub('Podfile'))
         @validator.send(:perform_extensive_analysis, @validator.spec)
+
+        @validator.results_message.strip.should.be.empty
       end
 
       it 'shows an error when performing extensive analysis on a test spec' do


### PR DESCRIPTION
- [Analyzer] Speed up #filter_pod_targets_for_target_definition

- [Resolver] Speed up #resolver_specs_by_target

This brings the time down from 90s to 4s for us, by reducing the amount of times we perform graph traversal from something like O(x^n^n) to O(log n)

- [Sandbox] Allow storing specs directly

This also allows up to only create the `Local Podspecs` dir once

- Clean up specs to make failures more obvious

- [Sandbox] Cache “Local Podspec” specs

- [SandboxAnalyzer] Don’t treat a pod as added if it’s local

- [PodVariant] Avoid allocating arrays in #hash

- [LockingDependencyAnalyzer] Only add a dependency string to the graph once

This saves almost 2 seconds on our project

- [Analyzer] Avoid checking checksums for the same pod multiple times

- [Analyzer] Don’t analyze multiple times

- Fix storing cached specs in the sandbox

- [Installer] raise when sandbox / podfile not given

- [Analyzer] Avoid loading specs when determining deps to fetch

- Avoid “creating” the same directory over & over

- Allow resetting Config.instance within a spec

- [HeadersStore] mkpath less

- [FileReferencesInstaller] Compute groups less

- [Analyzer] Only try to print pods state when verbose

- [Installer] Add an API that just returns AggregateTargets from a sandbox

- Fix validator specs

- Fix checksums for external source pods