### PR TITLE
Escape double quotes for module map contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Escape double quotes for module map contents  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7549](https://github.com/CocoaPods/CocoaPods/pull/7549)
+
 * Fix building Swift static library test specs.  
   [Samuel Giddins](https://github.com/segiddins)
-
 
 ## 1.5.0.beta.1 (2018-03-23)
 

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -6,7 +6,7 @@ module Pod
     # with existing headers of the podspec.
     #
     class ModuleMap
-      # @return [PodTarget] the target represented by this Info.plist.
+      # @return [PodTarget, AggregateTarget] the target the module map is generated for.
       #
       attr_reader :target
 
@@ -21,7 +21,7 @@ module Pod
             (:umbrella if umbrella),
             (:exclude if exclude),
             'header',
-            %("#{path}"),
+            %("#{path.to_s.gsub('"', '\"')}"),
             attrs,
           ].compact.join(' ')
         end
@@ -38,7 +38,7 @@ module Pod
 
       # Initialize a new instance
       #
-      # @param  [PodTarget] target @see target
+      # @param  [PodTarget, AggregateTarget] target @see target
       #
       def initialize(target)
         @target = target

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -35,5 +35,21 @@ module Pod
         }
       EOS
     end
+
+    it 'escapes double quotes properly for module map contents' do
+      path = temporary_directory + 'BananaLib.modulemap'
+      @pod_target.stubs(:umbrella_header_path).returns(Pathname.new('BananaLibWith"Quotes"-umbrella.h'))
+      @pod_target.stubs(:requires_frameworks?).returns(true)
+      gen = Generator::ModuleMap.new(@pod_target)
+      gen.save_as(path)
+      path.read.should == <<-EOS.strip_heredoc
+        framework module BananaLib {
+          umbrella header "BananaLibWith\\"Quotes\\"-umbrella.h"
+
+          export *
+          module * { export * }
+        }
+      EOS
+    end
   end
 end


### PR DESCRIPTION
Found this during investigating https://github.com/CocoaPods/CocoaPods/issues/7546