### PR TITLE
Fix Swift static libary test specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix building Swift static library test specs.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 1.5.0.beta.1 (2018-03-23)

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -357,7 +357,7 @@ module Pod
           end
 
           other_swift_flags = module_map_files.tap(&:uniq!).flat_map { |f| ['-Xcc', f] }
-          if target.is_a?(PodTarget) && !target.requires_frameworks? && target.defines_module?
+          if target.is_a?(PodTarget) && !target.requires_frameworks? && target.defines_module? && !test_xcconfig
             # make it possible for a mixed swift/objc static library to be able to import the objc from within swift
             other_swift_flags += ['-import-underlying-module', '-Xcc', '-fmodule-map-file="${SRCROOT}/${MODULEMAP_FILE}"']
           end


### PR DESCRIPTION
This stops us pointing to a module map that does not exist, since we don't generate module maps for test specs.