### PR TITLE
Only include header search paths for dependencies of aggregate targets

### DIFF
--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -157,7 +157,9 @@ module Pod
             build_settings
           else
             # Make headers discoverable from $PODS_ROOT/Headers directory
-            header_search_paths = target.sandbox.public_headers.search_paths(target.platform)
+            header_search_paths = pod_targets.flat_map do |pod_target|
+              target.sandbox.public_headers.search_paths(target.platform, pod_target.pod_name, false)
+            end.uniq
             {
               # TODO: remove quote imports in CocoaPods 2.0
               # by `#import "…"`

--- a/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/aggregate_xcconfig_spec.rb
@@ -384,6 +384,26 @@ module Pod
 
         #-----------------------------------------------------------------------#
 
+        describe '#settings_to_import_pod_targets' do
+          it 'should not include import settings for non-dependent pod targets' do
+            config.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
+            config.sandbox.public_headers.add_search_path('CoconutLib', Platform.ios)
+            banana_spec = fixture_spec('banana-lib/BananaLib.podspec')
+            banana_pod_target = pod_target(banana_spec, @target_definition)
+            target = fixture_aggregate_target([banana_pod_target], @target_definition)
+            target.target_definition.whitelist_pod_for_configuration(banana_spec.name, 'Release')
+            generator = AggregateXCConfig.new(target, 'Release')
+            target.stubs(:requires_frameworks?).returns(false)
+            result = generator.send(:settings_to_import_pod_targets)
+            # CoconutLib is part of the sandbox public header search paths but it is not a dependency to this aggregate
+            # target, therefore it should not include its header search paths as part of its xcconfig.
+            result['HEADER_SEARCH_PATHS'].should == '"${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/BananaLib"'
+            result['OTHER_CFLAGS'].should == '-isystem "${PODS_ROOT}/Headers/Public" -isystem "${PODS_ROOT}/Headers/Public/BananaLib"'
+          end
+        end
+
+        #-----------------------------------------------------------------------#
+
         describe 'when no pods are whitelisted for the given configuration' do
           before do
             @generator.stubs(:configuration_name).returns('.invalid')


### PR DESCRIPTION
Does not fix https://github.com/CocoaPods/CocoaPods/issues/7558 but the issue did surface this change right here.

Aggregate targets with static library mode are blindly including header search paths for everything that matches the aggregate targets platform.

With this change, only the settings for dependent targets will be included instead.

Given:

```ruby
platform :ios, '6.0'
pod 'Reachability', '3.1.0' # will be inherited by both concrete children

target 'SampleApp' do
  target 'SampleAppTests' do
    inherit! :search_paths
    pod 'JSONKit'
  end
end

target 'SampleApp_2' do
  pod 'JSONKit'
end
```

Then `Pods-SampleApp.debug.xcconfig` should *not* include header search paths for `JSONKit` because it does not link it or depend on it. Before this change this was wrong.