### PR TITLE
[PodsProjectGenerator] Add target dependencies when inheriting search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Fix building Swift static library test specs.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Swift static libraries can be used in targets whose search paths are inherited.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ## 1.5.0.beta.1 (2018-03-23)
 
 ##### Enhancements

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -223,6 +223,10 @@ module Pod
                                  [:app_extension, :watch_extension, :watch2_extension, :tv_extension, :messages_extension]).empty?
             is_app_extension ||= aggregate_target.user_targets.any? { |ut| ut.common_resolved_build_setting('APPLICATION_EXTENSION_API_ONLY') == 'YES' }
 
+            aggregate_target.search_paths_aggregate_targets.each do |search_paths_target|
+              aggregate_target.native_target.add_dependency(search_paths_target.native_target)
+            end
+
             aggregate_target.pod_targets.each do |pod_target|
               test_only_pod_targets.delete(pod_target)
               configure_app_extension_api_only_for_target(aggregate_target) if is_app_extension

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -202,6 +202,17 @@ module Pod
               @generator.send(:set_target_dependencies)
             end
 
+            it 'adds target dependencies when inheriting search paths' do
+              native_target = mock('SearchPathsAggregateNativeTarget')
+              @target.stubs(:search_paths_aggregate_targets).returns([
+                mock('SearchPathsAggregateTarget', :native_target => native_target),
+              ])
+
+              @mock_target.expects(:add_dependency).with(native_target)
+
+              @generator.send(:set_target_dependencies)
+            end
+
             it 'configures APPLICATION_EXTENSION_API_ONLY for app extension targets' do
               test_extension_target(:app_extension)
             end


### PR DESCRIPTION
Allows Swift static libraries to be used in targets whose search paths are inherited