### PR TITLE
[Resolver] Fix performance issue with exponential growth of dependency nodes cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Improve performance of the dependency resolver by removing duplicates for dependency nodes.
+  [Jacek Suliga](https://github.com/jmkk)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -577,7 +577,7 @@ module Pod
 
         dependency_nodes.flat_map do |item|
           valid_dependencies_for_target_from_node(target, dependencies, item)
-        end.concat dependency_nodes
+        end.concat(dependency_nodes).uniq
       end
     end
 


### PR DESCRIPTION
Calling "pod install" on our project (with over 100 podspec dependencies) was very slow - profiling showed dependency resolver to be the bottleneck, with the dependency cache returning hundreds of millions specs at the end.

The issue was that dependency nodes returned from `valid_dependencies_for_target_from_node` had thousands of duplicates, resulting in exponential dependency resolution times for each additional target.

This ensures we remove duplicates when returning target appropriate nodes from `valid_dependencies_for_target_from_node`, reducing our pod install times by a factor of 2x.