### PR TITLE
[Analyser] Inspect targets to integrate even if not integrating to user project

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -74,9 +74,8 @@ module Pod
         validate_lockfile_version!
         @result = AnalysisResult.new
         @result.podfile_dependency_cache = @podfile_dependency_cache
-        if installation_options.integrate_targets?
-          @result.target_inspections = inspect_targets_to_integrate
-        else
+        @result.target_inspections = inspect_targets_to_integrate
+        unless installation_options.integrate_targets?
           verify_platforms_specified!
         end
         @result.podfile_state = generate_podfile_state


### PR DESCRIPTION
I believe the `swift_version` support changes broke [CocoaPods/Rome](https://github.com/CocoaPods/Rome). The generated `Pods.xcodeproj` doesn't have a value for the `SWIFT_VERSION` build setting per Pod, so it can't generate the libraries to integrate. This is probably because the value is fetched either by inspecting the user's project target or using the specified value in the Podspec, if the Pod declares one.

Running `inspect_targets_to_integrate` even when not integrating fixes this, but I do not know if this has other side effects than the ones I'm describing here.
