### PR TITLE
Make modular header private header access consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#7592](https://github.com/CocoaPods/CocoaPods/issues/7592)
 
+* Make modular header private header access consistent with frameworks and static libraries.  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7596](https://github.com/CocoaPods/CocoaPods/issues/7596)
+
 * Inhibit warnings for all dependencies during validation except for the one being validated  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7434](https://github.com/CocoaPods/CocoaPods/issues/7434)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -564,7 +564,7 @@ module Pod
     #
     def header_search_paths(include_test_dependent_targets = false)
       header_search_paths = []
-      header_search_paths.concat(build_headers.search_paths(platform, nil, uses_modular_headers?))
+      header_search_paths.concat(build_headers.search_paths(platform, nil, false))
       header_search_paths.concat(sandbox.public_headers.search_paths(platform, pod_name, uses_modular_headers?))
       dependent_targets = recursive_dependent_targets
       dependent_targets += recursive_test_dependent_targets if include_test_dependent_targets

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -313,7 +313,8 @@ module Pod
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private"' \
+              ' "${PODS_ROOT}/Headers/Private/CoconutLib"' \
               ' "${PODS_ROOT}/Headers/Public"' \
           end
 
@@ -330,7 +331,8 @@ module Pod
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, false)
             xcconfig = generator.generate
-            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private/CoconutLib"' \
+            xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private"' \
+              ' "${PODS_ROOT}/Headers/Private/CoconutLib"' \
               ' "${PODS_ROOT}/Headers/Public"' \
           end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -296,6 +296,7 @@ module Pod
           @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
             '${PODS_ROOT}/Headers/Public',
           ]
@@ -306,6 +307,7 @@ module Pod
           @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
             '${PODS_ROOT}/Headers/Public',
           ]
@@ -321,6 +323,7 @@ module Pod
           @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
             '${PODS_ROOT}/Headers/Public',
           ]
@@ -337,6 +340,7 @@ module Pod
           @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
             '${PODS_ROOT}/Headers/Public',
             '${PODS_ROOT}/Headers/Public/monkey',
@@ -354,6 +358,7 @@ module Pod
           header_search_paths = @pod_target.header_search_paths
           # The monkey lib header search paths should not be present since they are only present in OSX.
           header_search_paths.sort.should == [
+            '${PODS_ROOT}/Headers/Private',
             '${PODS_ROOT}/Headers/Private/BananaLib',
             '${PODS_ROOT}/Headers/Public',
           ]


### PR DESCRIPTION
 Make modular header private header access consistent with frameworks and static libraries

Closes #7596