### PR TITLE
Fix static framework dependent target double linking 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#7597](https://github.com/CocoaPods/CocoaPods/issues/7597)
 
+* Fix static framework dependent target double linking without use_frameworks  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7592](https://github.com/CocoaPods/CocoaPods/issues/7592)
+
 * Inhibit warnings for all dependencies during validation except for the one being validated  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7434](https://github.com/CocoaPods/CocoaPods/issues/7434)

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -489,7 +489,7 @@ module Pod
           unless aggregate_target.nil?
             dependent_targets = aggregate_target.search_paths_aggregate_targets
             dependent_targets.each do |dependent_target|
-              if dependent_target.pod_targets.any?(&:static_framework?)
+              if aggregate_target.requires_frameworks? && dependent_target.pod_targets.any?(&:static_framework?)
                 generate_other_ld_flags(dependent_target, dependent_target.pod_targets, xcconfig)
               end
             end


### PR DESCRIPTION
Fix static framework dependent target double linking without use_frameworks

Close #7592 

While related to #7155, #7592 and this fix only impact static_frameworks being used from Podfiles without use_frameworks!