### PR TITLE
[Pods Project Generator] Improve performance by removing redundant processing for native target dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Improve performance of the dependency resolver by removing duplicates for dependency nodes.
   [Jacek Suliga](https://github.com/jmkk)
 
+* Improve performance of Pods project generator by skipping native targets for which dependent targets have already been added.
+  [Jacek Suliga](https://github.com/jmkk)
+
 ##### Bug Fixes
 
 * Inhibit warnings for all dependencies during validation except for the one being validated  

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -312,6 +312,10 @@ module Pod
         end
 
         def add_dependent_targets_to_native_target(dependent_targets, native_target, is_app_extension, requires_frameworks, frameworks_group)
+          @processed_native_targets ||= Set.new
+          return if @processed_native_targets.include? native_target
+          @processed_native_targets << native_target
+
           dependent_targets.each do |pod_dependency_target|
             next unless pod_dependency_target.should_build?
             native_target.add_dependency(pod_dependency_target.native_target)

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -217,6 +217,7 @@ module Pod
         def set_target_dependencies
           frameworks_group = project.frameworks_group
           test_only_pod_targets = pod_targets.dup
+          pod_targets_for_deps = Set.new
           aggregate_targets.each do |aggregate_target|
             is_app_extension = !(aggregate_target.user_targets.map(&:symbol_type) &
                                  [:app_extension, :watch_extension, :watch2_extension, :tv_extension, :messages_extension]).empty?
@@ -239,15 +240,13 @@ module Pod
               aggregate_target.native_target.add_dependency(pod_target.native_target)
               configure_app_extension_api_only_for_target(pod_target) if is_app_extension
 
-              add_dependent_targets_to_native_target(pod_target.dependent_targets,
-                                                     pod_target.native_target, is_app_extension,
-                                                     pod_target.requires_frameworks? && !pod_target.static_framework?,
-                                                     frameworks_group)
+              pod_targets_for_deps << pod_target
               unless pod_target.static_framework?
                 add_pod_target_test_dependencies(pod_target, frameworks_group)
               end
             end
           end
+          test_pod_targets_for_deps = Set.new
           # Wire up remaining pod targets used only by tests and are not used by any aggregate target.
           test_only_pod_targets.each do |pod_target|
             unless pod_target.should_build?
@@ -255,11 +254,23 @@ module Pod
               next
             end
             unless pod_target.static_framework?
-              add_dependent_targets_to_native_target(pod_target.dependent_targets,
-                                                     pod_target.native_target, false,
-                                                     pod_target.requires_frameworks?, frameworks_group)
+              test_pod_targets_for_deps << pod_target
               add_pod_target_test_dependencies(pod_target, frameworks_group)
             end
+          end
+
+          # Actually add the dependent targets
+          pod_targets_for_deps.each do |pod_target|
+            add_dependent_targets_to_native_target(pod_target.dependent_targets,
+                                         pod_target.native_target, is_app_extension,
+                                         pod_target.requires_frameworks? && !pod_target.static_framework?,
+                                         frameworks_group)
+          end
+
+          test_pod_targets_for_deps.each do |test_pod_target|
+            add_dependent_targets_to_native_target(test_pod_target.dependent_targets,
+                                                   test_pod_target.native_target, false,
+                                                   test_pod_target.requires_frameworks?, frameworks_group)
           end
         end
 
@@ -312,10 +323,6 @@ module Pod
         end
 
         def add_dependent_targets_to_native_target(dependent_targets, native_target, is_app_extension, requires_frameworks, frameworks_group)
-          @processed_native_targets ||= Set.new
-          return if @processed_native_targets.include? native_target
-          @processed_native_targets << native_target
-
           dependent_targets.each do |pod_dependency_target|
             next unless pod_dependency_target.should_build?
             native_target.add_dependency(pod_dependency_target.native_target)


### PR DESCRIPTION
When profiling slow `podinstall` times for our project, almost a third of the time was being spent in `set_target_dependencies`, with hundreds of calls to the expensive `add_dependent_targets_to_native_target` function. Debugging showed that function gets called multiple times for the same native target, which in the end results in no new dependencies getting added - but slow product name resolution meant slow execution of this task (note over 5M calls made c99ext_identifier - for a project with about 100 pods and 60 targets).

<img width="915" alt="profile_before" src="https://user-images.githubusercontent.com/3430965/38462288-4db7197e-3a99-11e8-9b04-b991bfd11868.png">

This fix, or rather a work around, adds a cache to short-circuit and return if we've already handled adding dependencies for a given target. This speeds up `podinstall` for us by 25% (same gain observed when applied on top of #7541).

<img width="716" alt="profile_after" src="https://user-images.githubusercontent.com/3430965/38462306-ae4a2c2c-3a99-11e8-9bb9-6639292ac1bd.png">

Now, it's likely this is not the right fix. Please treat this PR more like a flag and discussion started around performance work in the Pods Project Generator. I feel `set_target_dependencies` needs some work to remove dups in the outer arrays, as even with the fix we're still iterating over 1.6M items for our project. In the meantime, we're monkey-patching with this change to get the performance boost.