### PR TITLE
Pass project into target installer instead of deriving it

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -171,12 +171,12 @@ module Pod
             end.compact.group_by(&:dirname)
 
             pod_targets.sort_by(&:name).each do |pod_target|
-              target_installer = PodTargetInstaller.new(sandbox, pod_target, umbrella_headers_by_dir)
+              target_installer = PodTargetInstaller.new(sandbox, project, pod_target, umbrella_headers_by_dir)
               target_installer.install!
             end
 
             aggregate_targets.sort_by(&:name).each do |target|
-              target_installer = AggregateTargetInstaller.new(sandbox, target)
+              target_installer = AggregateTargetInstaller.new(sandbox, project, target)
               target_installer.install!
             end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -14,11 +14,12 @@ module Pod
           # Initialize a new instance
           #
           # @param [Sandbox] sandbox @see TargetInstaller#sandbox
+          # @param [Pod::Project] project @see TargetInstaller#project
           # @param [Target] target @see TargetInstaller#target
           # @param [Hash{Pathname => Pathname}] umbrella_headers_by_dir @see #umbrella_headers_by_dir
           #
-          def initialize(sandbox, target, umbrella_headers_by_dir = nil)
-            super(sandbox, target)
+          def initialize(sandbox, project, target, umbrella_headers_by_dir = nil)
+            super(sandbox, project, target)
             @umbrella_headers_by_dir = umbrella_headers_by_dir
           end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -12,6 +12,11 @@ module Pod
           #
           attr_reader :sandbox
 
+          # @return [Pod::Project]
+          #         The `Pods/Pods.xcodeproj` to install the target into.
+          #
+          attr_reader :project
+
           # @return [Target] target
           #         The library whose target needs to be generated.
           #
@@ -20,10 +25,12 @@ module Pod
           # Initialize a new instance
           #
           # @param [Sandbox] sandbox @see #sandbox
+          # @param [Pod::Project] project @see #project
           # @param [Target] target  @see #target
           #
-          def initialize(sandbox, target)
+          def initialize(sandbox, project, target)
             @sandbox = sandbox
+            @project = project
             @target = target
           end
 
@@ -235,12 +242,6 @@ module Pod
           #-----------------------------------------------------------------------#
 
           # @!group Private helpers.
-
-          # @return [Project] the Pods project of the sandbox.
-          #
-          def project
-            sandbox.project
-          end
 
           # @return [PBXGroup] the group where the file references to the support
           #         files should be stored.

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -29,7 +29,7 @@ module Pod
               user_build_configurations = { 'Debug' => :debug, 'Release' => :release, 'AppStore' => :release, 'Test' => :debug }
               @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), [@spec], [@target_definition], [file_accessor])
               @target = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), @target_definition, config.sandbox.root.dirname, nil, nil, [@pod_target])
-              @installer = AggregateTargetInstaller.new(config.sandbox, @target)
+              @installer = AggregateTargetInstaller.new(config.sandbox, @project, @target)
               @spec.prefix_header_contents = '#import "BlocksKit.h"'
             end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -31,7 +31,7 @@ module Pod
 
               user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
               @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '4.3'), [@spec], [@target_definition], [file_accessor])
-              @installer = PodTargetInstaller.new(config.sandbox, @pod_target)
+              @installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
               @spec.prefix_header_contents = '#import "BlocksKit.h"'
             end
@@ -176,9 +176,9 @@ module Pod
                 all_specs = [@coconut_spec, *@coconut_spec.recursive_subspecs]
                 file_accessors = [file_accessor, test_file_accessor]
                 @coconut_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), all_specs, [@target_definition], file_accessors)
-                @installer = PodTargetInstaller.new(config.sandbox, @coconut_pod_target)
+                @installer = PodTargetInstaller.new(config.sandbox, @project, @coconut_pod_target)
                 @coconut_pod_target2 = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:osx, '10.8'), all_specs, [@target_definition2], file_accessors)
-                @installer2 = PodTargetInstaller.new(config.sandbox, @coconut_pod_target2)
+                @installer2 = PodTargetInstaller.new(config.sandbox, @project, @coconut_pod_target2)
               end
 
               it 'adds the native test target to the project for iOS targets with code signing' do
@@ -371,7 +371,7 @@ module Pod
 
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
                 @minions_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, [@minions_spec, *@minions_spec.recursive_subspecs], [@target_definition], [file_accessor])
-                @installer = PodTargetInstaller.new(config.sandbox, @minions_pod_target)
+                @installer = PodTargetInstaller.new(config.sandbox, @project, @minions_pod_target)
 
                 @first_json_file = file_accessor.source_files.find { |sf| sf.extname == '.json' }
               end
@@ -482,7 +482,7 @@ module Pod
 
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
                 @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, [@spec], [@target_definition], [file_accessor])
-                @installer = PodTargetInstaller.new(config.sandbox, @pod_target)
+                @installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
               end
 
               after do
@@ -520,7 +520,7 @@ module Pod
             describe 'with a scoped pod target' do
               before do
                 @pod_target = @pod_target.scoped.first
-                @installer = PodTargetInstaller.new(config.sandbox, @pod_target)
+                @installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
               end
 
               it 'adds file references for the support files of the target' do
@@ -923,7 +923,7 @@ module Pod
 
                 @pod_target = fixture_pod_target(@spec, false, 'Debug' => :debug, 'Release' => :release)
                 @pod_target.stubs(:requires_frameworks? => true)
-                target_installer = PodTargetInstaller.new(config.sandbox, @pod_target)
+                target_installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
                 # Use a file references installer to add the files so that the correct ones are added.
                 file_ref_installer = Installer::Xcode::PodsProjectGenerator::FileReferencesInstaller.new(config.sandbox, [@pod_target], @project)
@@ -981,7 +981,7 @@ module Pod
                 @project.add_pod_group('BananaLib', fixture('banana-lib'))
 
                 @pod_target = fixture_pod_target(@spec, false, 'Debug' => :debug, 'Release' => :release)
-                target_installer = PodTargetInstaller.new(config.sandbox, @pod_target)
+                target_installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
                 # Use a file references installer to add the files so that the correct ones are added.
                 file_ref_installer = Installer::Xcode::PodsProjectGenerator::FileReferencesInstaller.new(config.sandbox, [@pod_target], @project)

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -11,7 +11,7 @@ module Pod
             user_build_configurations = { 'Debug' => :debug, 'Release' => :release, 'AppStore' => :release, 'Test' => :debug }
             archs = ['$(ARCHS_STANDARD_64_BIT)']
             @target = Target.new(config.sandbox, false, user_build_configurations, archs, Platform.ios)
-            @installer = TargetInstaller.new(config.sandbox, @target)
+            @installer = TargetInstaller.new(config.sandbox, @project, @target)
           end
 
           it 'adds the architectures to the custom build configurations of the user target' do


### PR DESCRIPTION
`project` should eventually be removed from being managed by the `sandbox`... This makes it easier to create `TargetInstaller` instances without depending for something to have setup the `project` attribute into the `sandbox` magically.

Helps to avoid figuring out at what point things happen...