### PR TITLE
Always generate FRAMEWORK_SEARCH_PATHS for vendored_frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7611](https://github.com/CocoaPods/CocoaPods/pull/7611)
 
+* Always generate FRAMEWORK_SEARCH_PATHS for vendored_frameworks.  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7591](https://github.com/CocoaPods/CocoaPods/issues/7591)
+
 * Fix modular header access to header_dir's.  
   [Paul Beusterien](https://github.com/paulb777)
   [#7597](https://github.com/CocoaPods/CocoaPods/issues/7597)

--- a/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/pod_xcconfig.rb
@@ -72,7 +72,7 @@ module Pod
           XCConfigHelper.add_target_specific_settings(target, xcconfig)
           recursive_dependent_targets = target.recursive_dependent_targets
           xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, recursive_dependent_targets, test_xcconfig?)
-          XCConfigHelper.generate_vendored_build_settings(target, recursive_dependent_targets, xcconfig, false, test_xcconfig?) if target.requires_frameworks?
+          XCConfigHelper.generate_vendored_build_settings(target, recursive_dependent_targets, xcconfig, false, test_xcconfig?)
           if test_xcconfig?
             test_dependent_targets = [target, *target.recursive_test_dependent_targets].uniq
             xcconfig.merge! XCConfigHelper.search_paths_for_dependent_targets(target, test_dependent_targets - recursive_dependent_targets, test_xcconfig?)

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -114,12 +114,12 @@ module Pod
             @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/DDD')
           end
 
-          it 'vendored frameworks dont get added to frameworks paths if use_frameworks! isnt set' do
+          it 'vendored frameworks should be added to frameworks paths if use_frameworks! isnt set' do
             @pod_target.stubs(:requires_frameworks?).returns(false)
             @xcconfig = @generator.generate
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('spec/fixtures/monkey')
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/AAA')
-            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.not.include('${PODS_ROOT}/CCC')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('spec/fixtures/monkey')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/AAA')
+            @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/CCC')
           end
 
           it 'sets the PODS_ROOT build variable' do
@@ -255,7 +255,7 @@ module Pod
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
-            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
+            xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/BananaLib" "${PODS_ROOT}/../../spec/fixtures/banana-lib" "${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib"'
           end
 
           it 'adds correct header search paths for dependent and test targets without modular headers' do


### PR DESCRIPTION
Close #7591 

Vendored framework headers get found via FRAMEWORK_SEARCH_PATHS when use_modular_headers! is on. 

For static libraries without use_modular_headers!, the same symbolically linked header is available both from FRAMEWORK_SEARCH_PATHS and HEADER_SEARCH_PATHS.