### PR TITLE
Remove :lockfile attribute from SandboxAnalyzer

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -861,7 +861,7 @@ module Pod
       def generate_sandbox_state
         sandbox_state = nil
         UI.section 'Comparing resolved specification to the sandbox manifest' do
-          sandbox_analyzer = SandboxAnalyzer.new(sandbox, result.specifications, update_mode?, lockfile)
+          sandbox_analyzer = SandboxAnalyzer.new(sandbox, result.specifications, update_mode?)
           sandbox_state = sandbox_analyzer.analyze
           sandbox_state.print
         end

--- a/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
+++ b/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
@@ -42,23 +42,16 @@ module Pod
 
         alias_method :update_mode?, :update_mode
 
-        # @return [Lockfile] The lockfile of the installation as a fall-back if
-        #         there is no sandbox manifest.
-        #
-        attr_reader :lockfile
-
         # Init a new SandboxAnalyzer
         #
-        # @param [Sandbox] sandbox @see #sandbox
-        # @param [Array<Specifications>] specs @see #specs
-        # @param [Bool] update_mode @see #update_mode
-        # @param [Lockfile] lockfile @see #lockfile
+        # @param [Sandbox] sandbox @see sandbox
+        # @param [Array<Specifications>] specs @see specs
+        # @param [Bool] update_mode @see update_mode
         #
-        def initialize(sandbox, specs, update_mode, lockfile = nil)
+        def initialize(sandbox, specs, update_mode)
           @sandbox = sandbox
           @specs = specs
           @update_mode = update_mode
-          @lockfile = lockfile
         end
 
         # Performs the analysis to the detect the state of the sandbox respect
@@ -160,7 +153,7 @@ module Pod
         # @return [Lockfile] The manifest to use for the sandbox.
         #
         def sandbox_manifest
-          sandbox.manifest || lockfile
+          sandbox.manifest
         end
 
         #--------------------------------------#

--- a/spec/unit/installer/analyzer/sandbox_analyzer_spec.rb
+++ b/spec/unit/installer/analyzer/sandbox_analyzer_spec.rb
@@ -92,13 +92,6 @@ module Pod
         @analyzer.send(:sandbox_manifest).should == @manifest
       end
 
-      it 'returns the lockfile as the sandbox if one is not available' do
-        lockfile = Lockfile.new({})
-        @sandbox.stubs(:manifest)
-        @analyzer.stubs(:lockfile).returns(lockfile)
-        @analyzer.send(:sandbox_manifest).should == lockfile
-      end
-
       #--------------------------------------#
 
       it 'returns the root name of the resolved Pods' do


### PR DESCRIPTION
This was added for backwards compatibility for versions < 0.18, which introduced the manifest.lock file