### PR TITLE
Remove unused #specific_source attribute

### DIFF
--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -91,19 +91,13 @@ module Pod
         end
       end
 
-      # @return [Hash] @see Downloader#checkout_options
-      #
-      attr_reader :specific_source
-
       #-----------------------------------------------------------------------#
 
       private
 
       # @!group Installation Steps
 
-      # Downloads the source of the Pod. It also stores the specific options
-      # needed to recreate the same exact installation if needed in
-      # `#specific_source`.
+      # Downloads the source of the Pod.
       #
       # @return [void]
       #
@@ -111,7 +105,7 @@ module Pod
         verify_source_is_secure(root_spec)
         download_result = Downloader.download(download_request, root, :can_cache => can_cache?)
 
-        if (@specific_source = download_result.checkout_options) && specific_source != root_spec.source
+        if (specific_source = download_result.checkout_options) && specific_source != root_spec.source
           sandbox.store_checkout_source(root_spec.name, specific_source)
         end
       end

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -18,7 +18,6 @@ module Pod
         it 'downloads the source' do
           @spec.source = { :git => SpecHelper.fixture('banana-lib'), :tag => 'v1.0' }
           @installer.install!
-          @installer.specific_source[:tag].should == 'v1.0'
           pod_folder = config.sandbox.pod_dir('BananaLib')
           pod_folder.should.exist
         end
@@ -26,7 +25,6 @@ module Pod
         it 'returns the checkout options of the downloader if any' do
           @spec.source = { :git => SpecHelper.fixture('banana-lib'), :branch => 'topicbranch' }
           @installer.install!
-          @installer.specific_source[:commit].should == '446b22414597f1bb4062a62c4eed7af9627a3f1b'
           pod_folder = config.sandbox.pod_dir('BananaLib')
           pod_folder.should.exist
         end


### PR DESCRIPTION
Nothing is using it, maybe something did in the past but there is no reason to expose this attribute and hold on to it.