### PR TITLE
Remove codesign suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Maxime Le Moine](https://github.com/MaximeLM)
   [#7590](https://github.com/CocoaPods/CocoaPods/issues/7590)
 
+* Remove codesign suppression  
+  [Jaehong Kang](https://github.com/sinoru)
+  [#7606](https://github.com/CocoaPods/CocoaPods/issues/7606)
 
 ## 1.5.0 (2018-04-04)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -165,7 +165,6 @@ module Pod
               build_configuration.build_settings['TVOS_DEPLOYMENT_TARGET'] = tvos_deployment_target.to_s if tvos_deployment_target
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
-              build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
             end
           end
         end

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -166,7 +166,6 @@ module Pod
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
               build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
-              build_configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
             end
           end
         end


### PR DESCRIPTION
Fixes #7606 

This will remove `CODE_SIGNING_REQUIRED`, `CODE_SIGNING_ALLOWED` config from Pods' Project which suppress code signing for all situation.

Now even dummy codesigning (with com.apple.security.get-task-allow entitlement) required when attach to process on simulator (Changes from Xcode 9.3), and this enforces linked frameworks codesigned too.
But those config suppress codesign which failed to launch from simulator specifically `@IBDesignable` classes (which lookup from: `$TARGET_BUILD_DIR`)
```
Did find:
	@{Linked Binary}: required code signature missing for @{Linking Binary}
```