### PR TITLE
Prevent duplicated targets from being stripped out from the framework search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7434](https://github.com/CocoaPods/CocoaPods/issues/7434)
 
+* Prevent duplicated targets from being stripped out from the framework search paths  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#7644](https://github.com/CocoaPods/CocoaPods/pull/7644)
 
 ## 1.5.0 (2018-04-04)
 

--- a/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
+++ b/lib/cocoapods/generator/xcconfig/xcconfig_helper.rb
@@ -307,7 +307,7 @@ module Pod
 
           # Filter out dependent targets that are subsets of another target.
           subset_targets = []
-          dependent_targets.combination(2) do |a, b|
+          dependent_targets.uniq.combination(2) do |a, b|
             if (a.specs - b.specs).empty?
               subset_targets << a
             elsif (b.specs - a.specs).empty?

--- a/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
+++ b/spec/unit/generator/xcconfig/xcconfig_helper_spec.rb
@@ -83,6 +83,18 @@ module Pod
             build_settings['FRAMEWORK_SEARCH_PATHS'].should == '"AB"'
           end
 
+          it 'adds the frameworks search paths once if there are duplicated targets' do
+            target = stub(
+              :specs => %w(A, B),
+              :should_build? => true,
+              :requires_frameworks? => true,
+              :configuration_build_dir => 'AB',
+            )
+            dependent_targets = [target, target]
+            build_settings = @sut.search_paths_for_dependent_targets(nil, dependent_targets)
+            build_settings['FRAMEWORK_SEARCH_PATHS'].should == '"AB"'
+          end
+
           it 'adds the libraries of the xcconfig for a static framework' do
             spec = stub('spec', :test_specification? => false)
             target_definition = stub('target_definition', :inheritance => 'search_paths')


### PR DESCRIPTION
When cocoapods is searching for specs subsets, it does not take into account the fact that some targets might be duplicated. If this is the case, this has the results of removing a dependency entirely and the build to not find the framework at all.

This was introduced by https://github.com/CocoaPods/CocoaPods/issues/6967
I have checked that the example project related to this issue is still working with this change.