### PR TITLE
Track test dependent targets per test spec instead of flat list

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -224,7 +224,9 @@ module Pod
     #
     def pod_targets
       aggregate_target_pod_targets = aggregate_targets.flat_map(&:pod_targets)
-      test_dependent_targets = aggregate_target_pod_targets.flat_map(&:test_dependent_targets)
+      test_dependent_targets = aggregate_target_pod_targets.flat_map do |pod_target|
+        pod_target.test_dependent_targets_by_spec_name.values.flatten
+      end
       (aggregate_target_pod_targets + test_dependent_targets).uniq
     end
 

--- a/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
+++ b/spec/unit/generator/xcconfig/pod_xcconfig_spec.rb
@@ -235,14 +235,14 @@ module Pod
           end
 
           it 'includes other ld flags for test dependent targets' do
-            @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '-ObjC -l"CoconutLib" -l"monkey" -framework "dynamic-monkey"'
           end
 
           it 'adds settings for test dependent targets' do
-            @coconut_pod_target.test_dependent_targets = [@banana_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@banana_pod_target] }
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
@@ -251,7 +251,7 @@ module Pod
 
           it 'adds settings for test dependent targets excluding the parents targets' do
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
-            @coconut_pod_target.test_dependent_targets = [@banana_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@banana_pod_target] }
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
             xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"'
@@ -267,7 +267,7 @@ module Pod
             @coconut_pod_target.stubs(:defines_module?).returns(false)
             @coconut_pod_target.build_headers.add_search_path('CoconutLib', Platform.ios)
             @coconut_pod_target.sandbox.public_headers.add_search_path('CoconutLib', Platform.ios)
-            @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
@@ -288,7 +288,7 @@ module Pod
             @coconut_pod_target.stubs(:defines_module?).returns(false)
             @coconut_pod_target.build_headers.add_search_path('CoconutLib', Platform.ios)
             @coconut_pod_target.sandbox.public_headers.add_search_path('CoconutLib', Platform.ios)
-            @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             # This is not an test xcconfig so it should exclude header search paths for the 'monkey' pod
             generator = PodXCConfig.new(@coconut_pod_target, false)
@@ -309,7 +309,7 @@ module Pod
             @coconut_pod_target.stubs(:defines_module?).returns(true)
             @coconut_pod_target.build_headers.add_search_path('CoconutLib', Platform.ios)
             @coconut_pod_target.sandbox.public_headers.add_search_path('CoconutLib', Platform.ios)
-            @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, true)
             xcconfig = generator.generate
@@ -326,7 +326,7 @@ module Pod
             @coconut_pod_target.stubs(:defines_module?).returns(true)
             @coconut_pod_target.build_headers.add_search_path('CoconutLib', Platform.ios)
             @coconut_pod_target.sandbox.public_headers.add_search_path('CoconutLib', Platform.ios)
-            @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
             generator = PodXCConfig.new(@coconut_pod_target, false)
             xcconfig = generator.generate
@@ -335,7 +335,7 @@ module Pod
           end
 
           it 'does not include other ld flags for test dependent targets if its not a test xcconfig' do
-            @coconut_pod_target.test_dependent_targets = [@monkey_pod_target]
+            @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             generator = PodXCConfig.new(@coconut_pod_target)
             xcconfig = generator.generate
             xcconfig.to_hash['LIBRARY_SEARCH_PATHS'].should.be.nil

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -183,9 +183,9 @@ module Pod
       end
 
       it 'includes pod targets from test dependent targets' do
-        pod_target_one = stub(:test_dependent_targets => [])
-        pod_target_three = stub(:test_dependent_targets => [])
-        pod_target_two = stub(:test_dependent_targets => [pod_target_three])
+        pod_target_one = stub('PodTarget1', :test_dependent_targets_by_spec_name => {})
+        pod_target_three = stub('PodTarget2', :test_dependent_targets_by_spec_name => {})
+        pod_target_two = stub('PodTarget3', :test_dependent_targets_by_spec_name => { 'TestSpec1' => [pod_target_three] })
         aggregate_target = stub(:pod_targets => [pod_target_one, pod_target_two])
 
         result = stub(:targets => [aggregate_target])

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -467,7 +467,7 @@ module Pod
           @pod_dependency = fixture_pod_target('orange-framework/OrangeFramework.podspec', false, {}, [], Platform.ios, @pod_target.target_definitions)
           @test_pod_dependency = fixture_pod_target('matryoshka/matryoshka.podspec', false, {}, [], Platform.ios, @pod_target.target_definitions)
           @pod_target.dependent_targets = [@pod_dependency]
-          @pod_target.test_dependent_targets = [@test_pod_dependency]
+          @pod_target.test_dependent_targets_by_spec_name = { @pod_dependency.name => [@test_pod_dependency] }
         end
 
         it 'resolves simple dependencies' do
@@ -478,8 +478,8 @@ module Pod
           scoped_pod_target = @pod_target.scoped
           scoped_pod_target.first.dependent_targets.count.should == 1
           scoped_pod_target.first.dependent_targets.first.name.should == 'OrangeFramework-Pods'
-          scoped_pod_target.first.test_dependent_targets.count.should == 1
-          scoped_pod_target.first.test_dependent_targets.first.name.should == 'matryoshka-Pods'
+          scoped_pod_target.first.test_dependent_targets_by_spec_name.count.should == 1
+          scoped_pod_target.first.test_dependent_targets_by_spec_name['OrangeFramework'].first.name.should == 'matryoshka-Pods'
         end
 
         describe 'With cyclic dependencies' do


### PR DESCRIPTION
This is in preparation of getting each test spec to actually create a test bundle target (one-to-one map) instead of grouping them together by supported test types.

This PR can go by itself since it only changes the way we store dependencies but has no effect on how the integration works today.

It will help with figuring out which pods to to use for each test bundle that gets created instead of linking them all blindly.