### PR TITLE
Do not crash in pods project generation when adding framework file references to stub targets

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -338,7 +338,7 @@ module Pod
         end
 
         def add_framework_file_reference_to_native_target(native_target, pod_target, dependent_target, frameworks_group)
-          if pod_target.requires_frameworks? && !pod_target.static_framework? && dependent_target.should_build?
+          if pod_target.should_build? && pod_target.requires_frameworks? && !pod_target.static_framework? && dependent_target.should_build?
             product_ref = frameworks_group.files.find { |f| f.path == dependent_target.product_name } ||
                 frameworks_group.new_product_ref_for_target(dependent_target.product_basename, dependent_target.product_type)
             native_target.frameworks_build_phase.add_file_reference(product_ref, true)

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -240,6 +240,27 @@ module Pod
             ]
           end
 
+          it 'adds framework file references for framework pod targets that require building' do
+            @orangeframework_pod_target.stubs(:requires_frameworks?).returns(true)
+            @coconut_ios_pod_target.stubs(:requires_frameworks?).returns(true)
+            @coconut_ios_pod_target.stubs(:should_build?).returns(true)
+            @generator.generate!
+            native_target = @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS' }
+            native_target.isa.should == 'PBXNativeTarget'
+            native_target.frameworks_build_phase.file_display_names.sort.should == [
+              'Foundation.framework',
+              'OrangeFramework.framework',
+            ]
+          end
+
+          it 'does not add framework references for framework pod targets that do not require building' do
+            @orangeframework_pod_target.stubs(:requires_frameworks?).returns(true)
+            @coconut_ios_pod_target.stubs(:requires_frameworks?).returns(true)
+            @coconut_ios_pod_target.stubs(:should_build?).returns(false)
+            @generator.generate!
+            @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.isa.should == 'PBXAggregateTarget'
+          end
+
           it 'configures APPLICATION_EXTENSION_API_ONLY for pod targets of an aggregate target' do
             user_target = stub('SampleApp-iOS-User-Target', :symbol_type => :app_extension)
             @ios_target.stubs(:user_targets).returns([user_target])


### PR DESCRIPTION
A regression discovered by https://github.com/CocoaPods/CocoaPods/issues/7648

This is because we now add a `PBXAggregateTarget` placeholder into targets that do not require building.

Does not actually fix #7648 though.

/cc @artmz