### PR TITLE
Split test resource bundles installed by each test spec

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -284,7 +284,7 @@ module Pod
               pod_target_installation_result.test_specs_by_native_target.each do |test_native_target, test_specs|
                 test_dependent_targets.each do |test_dependent_target|
                   dependency_installation_result = pod_target_installation_results_hash[test_dependent_target.name]
-                  dependency_installation_result.test_resource_bundle_targets.each do |test_resource_bundle_target|
+                  dependency_installation_result.test_resource_bundle_targets.values.flatten.each do |test_resource_bundle_target|
                     test_native_target.add_dependency(test_resource_bundle_target)
                   end
                   test_native_target.add_dependency(dependency_installation_result.native_target)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -35,14 +35,14 @@ module Pod
                 # For targets that should not be built (e.g. pre-built vendored frameworks etc), we add a placeholder
                 # PBXAggregateTarget that will be used to wire up dependencies later.
                 native_target = add_placeholder_target
-                resource_bundle_targets = add_resources_bundle_targets(file_accessors)
+                resource_bundle_targets = add_resources_bundle_targets(file_accessors).values.flatten
                 return TargetInstallationResult.new(target, native_target, resource_bundle_targets)
               end
 
               create_support_files_dir
 
               native_target = add_target
-              resource_bundle_targets = add_resources_bundle_targets(file_accessors)
+              resource_bundle_targets = add_resources_bundle_targets(file_accessors).values.flatten
 
               test_native_targets = add_test_targets
               test_app_host_targets = add_test_app_host_targets(test_native_targets)
@@ -51,7 +51,7 @@ module Pod
               add_files_to_build_phases(native_target, test_native_targets)
 
               create_xcconfig_file(native_target, resource_bundle_targets)
-              create_test_xcconfig_files(test_native_targets, test_resource_bundle_targets)
+              create_test_xcconfig_files(test_native_targets, test_resource_bundle_targets.values.flatten)
 
               if target.defines_module?
                 create_module_map(native_target) do |generator|
@@ -338,8 +338,8 @@ module Pod
           # @return [Array<PBXNativeTarget] the resource bundle native targets created.
           #
           def add_resources_bundle_targets(file_accessors)
-            file_accessors.flat_map do |file_accessor|
-              file_accessor.resource_bundles.map do |bundle_name, paths|
+            file_accessors.each_with_object({}) do |file_accessor, hash|
+              hash[file_accessor.spec.name] = file_accessor.resource_bundles.map do |bundle_name, paths|
                 label = target.resources_bundle_target_label(bundle_name)
                 resource_bundle_target = project.new_resources_bundle(label, file_accessor.spec_consumer.platform_name)
                 resource_bundle_target.product_reference.tap do |bundle_product|

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -27,9 +27,9 @@ module Pod
           #
           attr_reader :test_native_targets
 
-          # @return [Array<PBXNativeTarget>] test_resource_bundle_targets
-          #         The test resource bundle targets that were produced for this target. Can be empty if the target had
-          #         no resource bundles for any tests.
+          # @return [Hash{String=>Array<PBXNativeTarget>}] test_resource_bundle_targets
+          #         The test resource bundle targets that were produced for this target keyed by test spec name.
+          #         Can be empty if the target had no resource bundles for any tests.
           #
           attr_reader :test_resource_bundle_targets
 
@@ -44,11 +44,11 @@ module Pod
           # @param [PBXNativeTarget] native_target @see #native_target
           # @param [Array<PBXNativeTarget>] resource_bundle_targets @see #resource_bundle_targets
           # @param [Array<PBXNativeTarget>] test_native_targets @see #test_native_targets
-          # @param [Array<PBXNativeTarget>] test_resource_bundle_targets @see #test_resource_bundle_targets
+          # @param [Hash{String=>Array<PBXNativeTarget>}] test_resource_bundle_targets @see #test_resource_bundle_targets
           # @param [Array<PBXNativeTarget>] test_app_host_targets @see #test_app_host_targets
           #
           def initialize(target, native_target, resource_bundle_targets = [], test_native_targets = [],
-                         test_resource_bundle_targets = [], test_app_host_targets = [])
+                         test_resource_bundle_targets = {}, test_app_host_targets = [])
             @target = target
             @native_target = native_target
             @resource_bundle_targets = resource_bundle_targets


### PR DESCRIPTION
This is again a small step towards getting one-to-one test spec support. We now model all resource bundles created as a hash for each of the test spec that were created for.

This changes the underlying model but does not change the current integration at all (all test specs -> a single bundle target)