### PR TITLE
Move computing pod targets by config to the analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
 
 
+* Improve performance of grouping pods by configuration.  
+  [Samuel Giddins](https://github.com/segiddins)
+
+
 ## 1.5.0 (2018-04-04)
 
 ##### Enhancements

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -61,10 +61,10 @@ module Pod
     # @param [Pathname] client_root @see #client_root
     # @param [Xcodeproj::Project] user_project @see #user_project
     # @param [Array<String>] user_target_uuids @see #user_target_uuids
-    # @param [Array<PodTarget>] pod_targets @see #pod_targets
+    # @param [Array<PodTarget>] pod_targets_for_build_configuration @see #pod_targets_for_build_configuration
     #
     def initialize(sandbox, host_requires_frameworks, user_build_configurations, archs, platform, target_definition,
-                   client_root, user_project, user_target_uuids, pod_targets)
+                   client_root, user_project, user_target_uuids, pod_targets_for_build_configuration)
       super(sandbox, host_requires_frameworks, user_build_configurations, archs, platform)
       raise "Can't initialize an AggregateTarget without a TargetDefinition!" if target_definition.nil?
       raise "Can't initialize an AggregateTarget with an abstract TargetDefinition!" if target_definition.abstract?
@@ -72,7 +72,8 @@ module Pod
       @client_root = client_root
       @user_project = user_project
       @user_target_uuids = user_target_uuids
-      @pod_targets = pod_targets
+      @pod_targets_for_build_configuration = pod_targets_for_build_configuration
+      @pod_targets = pod_targets_for_build_configuration.values.flatten.uniq
       @search_paths_aggregate_targets = []
       @xcconfigs = {}
     end
@@ -157,10 +158,7 @@ module Pod
     #         configuration.
     #
     def pod_targets_for_build_configuration(build_configuration)
-      @pod_targets_for_build_configuration ||= {}
-      @pod_targets_for_build_configuration[build_configuration] ||= pod_targets.select do |pod_target|
-        pod_target.include_in_build_config?(target_definition, build_configuration)
-      end
+      @pod_targets_for_build_configuration[build_configuration] || []
     end
 
     # @return [Array<Specification>] The specifications used by this aggregate target.

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -471,37 +471,6 @@ module Pod
       [self, *recursive_dependent_targets, *recursive_test_dependent_targets].uniq
     end
 
-    # Checks if the target should be included in the build configuration with
-    # the given name of a given target definition.
-    #
-    # @param  [TargetDefinition] target_definition
-    #         The target definition to check.
-    #
-    # @param  [String] configuration_name
-    #         The name of the build configuration.
-    #
-    def include_in_build_config?(target_definition, configuration_name)
-      key = [target_definition.label, configuration_name]
-      if @build_config_cache.key?(key)
-        return @build_config_cache[key]
-      end
-
-      whitelists = target_definition_dependencies(target_definition).map do |dependency|
-        target_definition.pod_whitelisted_for_configuration?(dependency.name, configuration_name)
-      end.uniq
-
-      if whitelists.empty?
-        @build_config_cache[key] = true
-      elsif whitelists.count == 1
-        @build_config_cache[key] = whitelists.first
-      else
-        raise Informative, "The subspecs of `#{pod_name}` are linked to " \
-          "different build configurations for the `#{target_definition}` " \
-          'target. CocoaPods does not currently support subspecs across ' \
-          'different build configurations.'
-      end
-    end
-
     # Checks if warnings should be inhibited for this pod.
     #
     # @return [Bool]
@@ -596,20 +565,6 @@ module Pod
     end
 
     private
-
-    # @param  [TargetDefinition] target_definition
-    #         The target definition to check.
-    #
-    # @return [Array<Dependency>] The dependency of the target definition for
-    #         this Pod. Return an empty array if the Pod is not a direct
-    #         dependency of the target definition but the dependency of one or
-    #         more Pods.
-    #
-    def target_definition_dependencies(target_definition)
-      target_definition.dependencies.select do |dependency|
-        Specification.root_name(dependency.name) == pod_name
-      end
-    end
 
     def create_build_settings
       BuildSettings::PodTargetSettings.new(self, false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -150,7 +150,7 @@ def fixture_aggregate_target(pod_targets = [], host_requires_frameworks = false,
                              archs = [], platform = Pod::Platform.new(:ios, '6.0'), target_definition = nil)
   target_definition ||= pod_targets.flat_map(&:target_definitions).first || fixture_target_definition
   Pod::AggregateTarget.new(config.sandbox, host_requires_frameworks, user_build_configurations, archs, platform,
-                           target_definition, config.sandbox.root.dirname, nil, nil, pod_targets)
+                           target_definition, config.sandbox.root.dirname, nil, nil, 'Release' => pod_targets)
 end
 
 #-----------------------------------------------------------------------------#

--- a/spec/unit/installer/post_install_hooks_context_spec.rb
+++ b/spec/unit/installer/post_install_hooks_context_spec.rb
@@ -11,7 +11,7 @@ module Pod
       user_target = user_project.native_targets.find { |np| np.name == 'SampleProject' }
       target_definition = fixture_target_definition
       pod_target = PodTarget.new(sandbox, false, {}, [], Platform.ios, [spec], [target_definition], nil)
-      umbrella = AggregateTarget.new(sandbox, false, {}, [], Platform.ios, target_definition, config.sandbox.root.dirname, user_project, [user_target.uuid], [pod_target])
+      umbrella = AggregateTarget.new(sandbox, false, {}, [], Platform.ios, target_definition, config.sandbox.root.dirname, user_project, [user_target.uuid], 'Release' => [pod_target])
       umbrella.stubs(:platform).returns(Platform.new(:ios, '8.0'))
 
       result = Installer::PostInstallHooksContext.generate(sandbox, [umbrella])

--- a/spec/unit/installer/user_project_integrator/target_integrator/xcconfig_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator/xcconfig_integrator_spec.rb
@@ -9,7 +9,7 @@ module Pod
       @target = @project.targets.first
       target_definition = Podfile::TargetDefinition.new('Pods', nil)
       target_definition.abstract = false
-      @pod_bundle = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, target_definition, project_path.dirname, @project, [@target.uuid], [])
+      @pod_bundle = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, target_definition, project_path.dirname, @project, [@target.uuid], {})
       configuration = Xcodeproj::Config.new(
         'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1',
       )

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -15,7 +15,7 @@ module Pod
         target_definition = Podfile::TargetDefinition.new('Pods', nil)
         target_definition.abstract = false
         user_build_configurations = { 'Release' => :release, 'Debug' => :debug }
-        @pod_bundle = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, target_definition, project_path.dirname, @project, [@target.uuid], [])
+        @pod_bundle = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, target_definition, project_path.dirname, @project, [@target.uuid], {})
         @pod_bundle.stubs(:resource_paths_by_config).returns('Release' => %w(${PODS_ROOT}/Lib/Resources/image.png))
         @pod_bundle.stubs(:framework_paths_by_config).returns('Release' => [{ :input_path => '${PODS_BUILD_DIR}/Lib/Lib.framework' }])
         configuration = Xcodeproj::Config.new(

--- a/spec/unit/installer/user_project_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator_spec.rb
@@ -18,8 +18,8 @@ module Pod
         config.sandbox.project = Project.new(config.sandbox.project_path)
         config.sandbox.project.save
         user_build_configurations = { 'Release' => :release, 'Debug' => :debug }
-        @target = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, @podfile.target_definitions['SampleProject'], sample_project_path.dirname, Xcodeproj::Project.open(@sample_project_path), ['A346496C14F9BE9A0080D870'], [])
-        @empty_library = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, @podfile.target_definitions[:empty], sample_project_path.dirname, @target.user_project, ['C0C495321B9E5C47004F9854'], [])
+        @target = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, @podfile.target_definitions['SampleProject'], sample_project_path.dirname, Xcodeproj::Project.open(@sample_project_path), ['A346496C14F9BE9A0080D870'], {})
+        @empty_library = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, @podfile.target_definitions[:empty], sample_project_path.dirname, @target.user_project, ['C0C495321B9E5C47004F9854'], {})
         @integrator = UserProjectIntegrator.new(@podfile, config.sandbox, temporary_directory, [@target, @empty_library])
       end
 

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -28,7 +28,8 @@ module Pod
 
               user_build_configurations = { 'Debug' => :debug, 'Release' => :release, 'AppStore' => :release, 'Test' => :debug }
               @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), [@spec], [@target_definition], [file_accessor])
-              @target = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), @target_definition, config.sandbox.root.dirname, nil, nil, [@pod_target])
+              pod_targets_by_config = Hash[user_build_configurations.each_key.map { |c| [c, [@pod_target]] }]
+              @target = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), @target_definition, config.sandbox.root.dirname, nil, nil, pod_targets_by_config)
               @installer = AggregateTargetInstaller.new(config.sandbox, @project, @target)
               @spec.prefix_header_contents = '#import "BlocksKit.h"'
             end

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -325,7 +325,7 @@ module Pod
             target = AggregateTarget.new(config.sandbox, false,
                                          { 'App Store' => :release, 'Debug' => :debug, 'Release' => :release, 'Test' => :debug },
                                          [], Platform.new(:ios, '6.0'), fixture_target_definition,
-                                         config.sandbox.root.dirname, proj, nil, [])
+                                         config.sandbox.root.dirname, proj, nil, {})
 
             target.stubs(:user_targets).returns([user_target])
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -421,7 +421,7 @@ module Pod
         end
 
         it 'deletes the target support file dirs of the removed aggregate targets' do
-          aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil, nil, [])
+          aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil, nil, {})
           @installer.stubs(:aggregate_targets).returns([aggregate_target])
           FileUtils.mkdir_p(config.sandbox.target_support_files_root)
           FileUtils.mkdir_p(@installer.aggregate_targets.first.support_files_dir)
@@ -434,7 +434,7 @@ module Pod
         end
 
         it 'does not delete the target support file dirs for non removed aggregate targets' do
-          aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil, nil, [])
+          aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil, nil, {})
           @installer.stubs(:aggregate_targets).returns([aggregate_target])
           FileUtils.mkdir_p(config.sandbox.target_support_files_root)
           FileUtils.mkdir_p(@installer.aggregate_targets.first.support_files_dir)
@@ -638,7 +638,7 @@ module Pod
 
     describe 'Integrating client projects' do
       it 'integrates the client projects' do
-        target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, fixture_target_definition, config.sandbox.root.dirname, nil, nil, [])
+        target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, fixture_target_definition, config.sandbox.root.dirname, nil, nil, {})
         @installer.stubs(:aggregate_targets).returns([target])
         Installer::UserProjectIntegrator.any_instance.expects(:integrate!)
         @installer.send(:integrate_user_project)

--- a/spec/unit/library_spec.rb
+++ b/spec/unit/library_spec.rb
@@ -5,7 +5,7 @@ module Pod
     describe 'In general' do
       before do
         @target_definition = fixture_target_definition
-        @lib = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition, config.sandbox.root.dirname, nil, nil, [])
+        @lib = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition, config.sandbox.root.dirname, nil, nil, {})
       end
 
       it 'returns the target_definition that generated it' do
@@ -28,7 +28,7 @@ module Pod
     describe 'Support files' do
       before do
         @target_definition = fixture_target_definition
-        @lib = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition, config.sandbox.root.dirname, nil, nil, [])
+        @lib = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition, config.sandbox.root.dirname, nil, nil, {})
       end
 
       it 'returns the absolute path of the xcconfig file' do

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -223,7 +223,7 @@ module Pod
                              )
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target, false))
             aggregate_target = fixture_aggregate_target([pod_target])
-            @generator = AggregateTargetSettings.new(aggregate_target, 'Debug')
+            @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
             @generator.other_ldflags.should == %w(-ObjC -l"PodTarget" -l"StaticLibrary" -l"VendoredDyld" -l"xml2" -framework "StaticFramework" -framework "VendoredFramework" -framework "XCTest")
           end
         end
@@ -452,7 +452,7 @@ module Pod
                              )
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target, false))
             aggregate_target = fixture_aggregate_target([pod_target])
-            @generator = AggregateTargetSettings.new(aggregate_target, 'Debug')
+            @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
             @generator.other_ldflags.should == %w(-ObjC -l"StaticLibrary" -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "VendoredFramework" -framework "XCTest")
           end
 
@@ -494,7 +494,7 @@ module Pod
                              )
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target, false))
             aggregate_target = fixture_aggregate_target([pod_target])
-            @generator = AggregateTargetSettings.new(aggregate_target, 'Debug')
+            @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
             @generator.other_ldflags.should == %w(-ObjC -l"StaticLibrary" -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "StaticFramework" -framework "VendoredFramework" -framework "XCTest")
           end
         end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -71,28 +71,6 @@ module Pod
         @pod_target.dependencies.should == ['monkey']
       end
 
-      it 'returns whether it is whitelisted in a build configuration' do
-        @target_definition.store_pod('BananaLib')
-        @target_definition.whitelist_pod_for_configuration('BananaLib', 'debug')
-        @pod_target.include_in_build_config?(@target_definition, 'Debug').should.be.true
-        @pod_target.include_in_build_config?(@target_definition, 'Release').should.be.false
-      end
-
-      it 'is whitelisted on all build configurations of it is a dependency of other Pods' do
-        @pod_target.include_in_build_config?(@target_definition, 'Debug').should.be.true
-        @pod_target.include_in_build_config?(@target_definition, 'Release').should.be.true
-      end
-
-      it 'raises if a Pod is whitelisted for different build configurations' do
-        @target_definition.store_pod('BananaLib')
-        @target_definition.store_pod('BananaLib/Subspec')
-        @target_definition.whitelist_pod_for_configuration('BananaLib', 'debug')
-        message = should.raise Informative do
-          @pod_target.include_in_build_config?(@target_definition, 'release').should.be.true
-        end.message
-        message.should.match /subspecs across different build configurations/
-      end
-
       it 'builds a pod target if there are actual source files' do
         fa = Sandbox::FileAccessor.new(nil, @pod_target)
         fa.stubs(:source_files).returns([Pathname.new('foo.m')])


### PR DESCRIPTION
For performance, since the analyzer has the dependency cache

- [x] CHANGELOG
- [x] Docs
- [x] Move deleted tests