### PR TITLE
Do not crash when creating build settings for a missing user build configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not crash when creating build settings for a missing user build configuration  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7698](https://github.com/CocoaPods/CocoaPods/pull/7698)
+
 * Do not include test dependencies input and output paths  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7688](https://github.com/CocoaPods/CocoaPods/pull/7688)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -95,6 +95,7 @@ module Pod
           #
           def create_xcconfig_file(native_target)
             native_target.build_configurations.each do |configuration|
+              next unless target.user_build_configurations.key?(configuration.name)
               path = target.xcconfig_path(configuration.name)
               build_settings = target.build_settings(configuration.name)
               update_changed_file(build_settings, path)


### PR DESCRIPTION
If a user project does not contain 'Release' or 'Debug' then generating build settings should not crash.