### PR TITLE
Allow EXPANDED_CODE_SIGN_IDENTITY to be unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#7570](https://github.com/CocoaPods/CocoaPods/pull/7570)
 
+* Allow `EXPANDED_CODE_SIGN_IDENTITY` to be unset.  
+  [Keith Smiley](https://github.com/keith)
+  [#7708](https://github.com/CocoaPods/CocoaPods/issues/7708)
 
 ## 1.5.2 (2018-05-09)
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -138,7 +138,7 @@ module Pod
 
           # Signs a framework with the provided identity
           code_sign_if_enabled() {
-            if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
+            if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
               local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements '$1'"


### PR DESCRIPTION
This is unset for some test target configurations.