### PR TITLE
Link vendored static libraries into dynamic frameworks

### DIFF
--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -603,8 +603,7 @@ module Pod
         define_build_settings_method :libraries, :memoized => true, :sorted => true, :uniqued => true do
           return [] if (!target.requires_frameworks? || target.static_framework?) && !test_xcconfig?
 
-          libraries = vendored_dynamic_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') }
-          libraries.concat spec_consumers.flat_map(&:libraries)
+          libraries = libraries_to_import.dup
           libraries.concat dependent_targets.flat_map { |pt| pt.build_settings.dynamic_libraries_to_import }
           libraries.concat dependent_targets.flat_map { |pt| pt.build_settings.static_libraries_to_import } if test_xcconfig?
           libraries
@@ -630,7 +629,9 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :library_search_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
-          vendored = vendored_dynamic_library_search_paths.dup
+          return [] if (!target.requires_frameworks? || target.static_framework?) && !test_xcconfig?
+
+          vendored = library_search_paths_to_import.dup
           vendored.concat dependent_targets.flat_map { |t| t.build_settings.vendored_dynamic_library_search_paths }
           if test_xcconfig?
             vendored.concat dependent_targets.flat_map { |t| t.build_settings.library_search_paths_to_import }

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -220,7 +220,8 @@ module Pod
             @generator.spec_consumers.each { |sc| sc.stubs(:frameworks => []) }
             @generator.stubs(:dependent_targets => [pod_target])
             @generator.send :__clear__
-            @generator.other_ldflags.should.be == %w(-l"VendoredDyld" -l"xml2" -framework "Bananalib" -framework "VendoredFramework" -framework "XCTest" -weak_framework "iAd")
+            @generator.other_ldflags.should.
+              be == %w(-l"Bananalib" -l"VendoredDyld" -l"xml2" -framework "Bananalib" -framework "VendoredFramework" -framework "XCTest" -weak_framework "iAd")
           end
         end
 


### PR DESCRIPTION
This fixes missing symbol errors at link time

This mirrors the treatment vendored static libraries get