### PR TITLE
Fix a bug that umbrella  header import fails in a specific case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Umbrella header import path gets wrong when `header_dir` is specified in PodSpec + try to build statically + Modular header is enabled  
+  [chuganzy](https://github.com/chuganzy)
+  [#7724](https://github.com/CocoaPods/CocoaPods/pull/7724)
+
 * Do not build pod target if it only contains script phases  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7746](https://github.com/CocoaPods/CocoaPods/issues/7746)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -261,6 +261,35 @@ module Pod
                 content.should.not =~ /"CoconutTestHeader.h"/
               end
 
+              it 'uses header_dir to umbrella header imports' do
+                @coconut_pod_target.file_accessors.first.spec_consumer.stubs(:header_dir).returns('Coconut')
+                @coconut_pod_target.stubs(:requires_frameworks?).returns(false)
+                @coconut_pod_target.stubs(:defines_module?).returns(true)
+                @installer.install!
+                content = @coconut_pod_target.umbrella_header_path.read
+                content.should =~ %r{"Coconut/Coconut.h"}
+              end
+
+              it 'uses header_dir and header_mappings_dir to umbrella header imports' do
+                @coconut_pod_target.file_accessors.first.spec_consumer.stubs(:header_dir).returns('Coconut2')
+                @coconut_pod_target.file_accessors.first.spec_consumer.stubs(:header_mappings_dir).returns('Classes')
+                @coconut_pod_target.stubs(:requires_frameworks?).returns(false)
+                @coconut_pod_target.stubs(:defines_module?).returns(true)
+                @installer.install!
+                content = @coconut_pod_target.umbrella_header_path.read
+                content.should =~ %r{"Coconut2/Coconut.h"}
+              end
+
+              it 'does not use header_dir to umbrella header imports' do
+                @coconut_pod_target.file_accessors.first.spec_consumer.stubs(:header_dir).returns('Coconut')
+                @coconut_pod_target.stubs(:requires_frameworks?).returns(true)
+                @coconut_pod_target.stubs(:defines_module?).returns(true)
+                @installer.install!
+                content = @coconut_pod_target.umbrella_header_path.read
+                content.should.not =~ %r{"Coconut/Coconut.h"}
+                content.should =~ /"Coconut.h"/
+              end
+
               it 'adds test xcconfig file reference for test resource bundle targets' do
                 @coconut_spec.test_specs.first.resource_bundle = { 'CoconutLibTestResources' => ['Model.xcdatamodeld'] }
                 installation_result = @installer.install!


### PR DESCRIPTION
In case that:

1. static library is enabled
2. modular header is enabled
3. header_dir is specified in PodSpec

the project fails to build since the umbrella header's import paths are wrong - it does not take header_dir into account so far which is still fine with Embedded Frameworks since it force flatten the header directories but not with Static libraries

Example projects which causes this issue: [ReactNative](https://github.com/facebook/react-native/blob/master/React.podspec) / [Lottie](https://github.com/airbnb/lottie-ios/blob/master/lottie-ios.podspec)

Example Podfile:

```ruby
...

use_modular_headers!
pod 'React', :path => '../node_modules/react-native', :subspecs => [
  'Core',
  'CxxBridge',
  'DevSupport',
  'RCTText',
  'RCTNetwork',
  'RCTWebSocket',
  'RCTAnimation',
]

...
```