### PR TITLE
Attempt to parse `SWIFT_VERSION` from xcconfig during target inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7394](https://github.com/CocoaPods/CocoaPods/issues/7394)
 
+* Attempt to parse `SWIFT_VERSION` from xcconfig during target inspection  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7731](https://github.com/CocoaPods/CocoaPods/issues/7731)
+
 * Do not crash when creating build settings for a missing user build configuration  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7698](https://github.com/CocoaPods/CocoaPods/pull/7698)

--- a/lib/cocoapods/installer/analyzer/target_inspector.rb
+++ b/lib/cocoapods/installer/analyzer/target_inspector.rb
@@ -218,7 +218,14 @@ module Pod
         #
         def compute_swift_version_from_targets(targets)
           versions_to_targets = targets.inject({}) do |memo, target|
-            versions = target.resolved_build_setting('SWIFT_VERSION').values
+            # User project may have an xcconfig that specifies the `SWIFT_VERSION`. We first check if that is true and
+            # that the xcconfig file actually exists. After the first integration the xcconfig set is most probably
+            # the one that was generated from CocoaPods. See https://github.com/CocoaPods/CocoaPods/issues/7731 for
+            # more details.
+            resolve_against_xcconfig = target.build_configuration_list.build_configurations.all? do |bc|
+              !bc.base_configuration_reference.nil? && File.exist?(bc.base_configuration_reference.real_path)
+            end
+            versions = target.resolved_build_setting('SWIFT_VERSION', resolve_against_xcconfig).values
             versions.each do |version|
               memo[version] = [] if memo[version].nil?
               memo[version] << target.name unless memo[version].include? target.name

--- a/spec/unit/installer/analyzer/target_inspector_spec.rb
+++ b/spec/unit/installer/analyzer/target_inspector_spec.rb
@@ -363,6 +363,50 @@ module Pod
         target_inspector = TargetInspector.new(target_definition, config.installation_root)
         target_inspector.send(:compute_swift_version_from_targets, user_targets).should.equal '2.3'
       end
+
+      describe 'with user xcconfig set' do
+        before do
+          @user_xcconfig = 'User.xcconfig'
+        end
+
+        after do
+          FileUtils.rm_f(@user_xcconfig) if File.exist?(@user_xcconfig)
+        end
+
+        it 'returns the xcconfig-level SWIFT_VERSION if the target has an existing user xcconfig set' do
+          user_project = Xcodeproj::Project.new('path')
+          user_project.build_configuration_list.set_setting('SWIFT_VERSION', '2.3')
+          target = user_project.new_target(:application, 'Target', :ios)
+          sample_config = user_project.new_file(@user_xcconfig)
+          File.write(sample_config.real_path, 'SWIFT_VERSION=3.0')
+          target.build_configurations.each do |config|
+            config.base_configuration_reference = sample_config
+          end
+
+          target_definition = Podfile::TargetDefinition.new(:default, nil)
+          user_targets = [target]
+
+          target_inspector = TargetInspector.new(target_definition, config.installation_root)
+          target_inspector.send(:compute_swift_version_from_targets, user_targets).should.equal '3.0'
+        end
+
+        it 'skips the xcconfig-level SWIFT_VERSION if the target has an existing user xcconfig set but without it' do
+          user_project = Xcodeproj::Project.new('path')
+          user_project.build_configuration_list.set_setting('SWIFT_VERSION', '2.3')
+          target = user_project.new_target(:application, 'Target', :ios)
+          sample_config = user_project.new_file(@user_xcconfig)
+          File.write(sample_config.real_path, 'SOMETHING_ELSE=3.0')
+          target.build_configurations.each do |config|
+            config.base_configuration_reference = sample_config
+          end
+
+          target_definition = Podfile::TargetDefinition.new(:default, nil)
+          user_targets = [target]
+
+          target_inspector = TargetInspector.new(target_definition, config.installation_root)
+          target_inspector.send(:compute_swift_version_from_targets, user_targets).should.equal '2.3'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7731

- [x] specs