### PR TITLE
Do not build pod target if it contains script phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not build pod target if it only contains script phases  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7746](https://github.com/CocoaPods/CocoaPods/issues/7746)
+
 * Do not crash when creating build settings for a missing user build configuration  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7698](https://github.com/CocoaPods/CocoaPods/pull/7698)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -162,7 +162,7 @@ module Pod
           #
           def create_or_update_user_script_phases(script_phases, native_target)
             script_phase_names = script_phases.map { |k| k[:name] }
-            # Delete script phases no longer present in the target definition.
+            # Delete script phases no longer present in the target.
             native_target_script_phases = native_target.shell_script_build_phases.select { |bp| !bp.name.nil? && bp.name.start_with?(USER_BUILD_PHASE_PREFIX) }
             native_target_script_phases.each do |script_phase|
               script_phase_name_without_prefix = script_phase.name.sub(USER_BUILD_PHASE_PREFIX, '')
@@ -171,16 +171,16 @@ module Pod
               end
             end
             # Create or update the ones that are expected to be.
-            script_phases.each do |td_script_phase|
-              name_with_prefix = USER_BUILD_PHASE_PREFIX + td_script_phase[:name]
+            script_phases.each do |script_phase|
+              name_with_prefix = USER_BUILD_PHASE_PREFIX + script_phase[:name]
               phase = TargetIntegrator.create_or_update_build_phase(native_target, name_with_prefix)
-              phase.shell_script = td_script_phase[:script]
-              phase.shell_path = td_script_phase[:shell_path] if td_script_phase.key?(:shell_path)
-              phase.input_paths = td_script_phase[:input_files] if td_script_phase.key?(:input_files)
-              phase.output_paths = td_script_phase[:output_files] if td_script_phase.key?(:output_files)
-              phase.show_env_vars_in_log = td_script_phase[:show_env_vars_in_log] ? '1' : '0' if td_script_phase.key?(:show_env_vars_in_log)
+              phase.shell_script = script_phase[:script]
+              phase.shell_path = script_phase[:shell_path] if script_phase.key?(:shell_path)
+              phase.input_paths = script_phase[:input_files] if script_phase.key?(:input_files)
+              phase.output_paths = script_phase[:output_files] if script_phase.key?(:output_files)
+              phase.show_env_vars_in_log = script_phase[:show_env_vars_in_log] ? '1' : '0' if script_phase.key?(:show_env_vars_in_log)
 
-              execution_position = td_script_phase[:execution_position]
+              execution_position = script_phase[:execution_position]
               unless execution_position == :any
                 compile_build_phase_index = native_target.build_phases.index do |bp|
                   bp.is_a?(Xcodeproj::Project::Object::PBXSourcesBuildPhase)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -146,7 +146,6 @@ module Pod
     #
     def should_build?
       return @should_build if defined? @should_build
-      return @should_build = true if contains_script_phases?
       accessors = file_accessors.reject { |fa| fa.spec.test_specification? }
       source_files = accessors.flat_map(&:source_files)
       source_files -= accessors.flat_map(&:headers)

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -587,7 +587,8 @@ module Pod
 
             it 'adds values from all subspecs' do
               @consumer_b.stubs(:user_target_xcconfig).returns('OTHER_CPLUSPLUSFLAGS' => '-std=c++1y')
-              consumer_c = mock('consumer_c', :user_target_xcconfig => { 'OTHER_CPLUSPLUSFLAGS' => '-stdlib=libc++' }, :script_phases => [], :spec => mock(:test_specification? => false), :frameworks => [], :libraries => [])
+              consumer_c = mock('consumer_c', :user_target_xcconfig => { 'OTHER_CPLUSPLUSFLAGS' => '-stdlib=libc++' },
+                                              :spec => mock(:test_specification? => false), :frameworks => [], :libraries => [])
               @pod_targets[1].stubs(:spec_consumers).returns([@consumer_b, consumer_c])
               @xcconfig = @generator.generate
               @xcconfig.to_hash['OTHER_CPLUSPLUSFLAGS'].should == '-std=c++1y -stdlib=libc++'

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -88,13 +88,13 @@ module Pod
         @pod_target.should_build?.should == false
       end
 
-      it 'builds a pod target if there are no actual source files but there are script phases' do
+      it 'does not build a pod target if there are no actual source files but there are script phases' do
         fa = Sandbox::FileAccessor.new(nil, @banana_spec.consumer(Platform.ios))
         fa.stubs(:source_files).returns([Pathname.new('foo.h')])
         @pod_target.stubs(:file_accessors).returns([fa])
         @pod_target.root_spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
 
-        @pod_target.should_build?.should == true
+        @pod_target.should_build?.should == false
       end
     end
 


### PR DESCRIPTION
In 1.6.0 we now add a `PBXAggregateTarget` for pod targets that should not be built. This means we can integrate script phases to them instead of forcing a pod target to be actually built (`should_build?` to return `true`).

closes https://github.com/CocoaPods/CocoaPods/issues/7746

This is how it looks after this change:

![screen_shot_2018-05-15_at_10_42_49_am](https://user-images.githubusercontent.com/310370/40073807-c4e969ec-582c-11e8-9071-2219c727ba0a.png)
