### PR TITLE
Do not try to integrate uncreated test native targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7746](https://github.com/CocoaPods/CocoaPods/issues/7746)
 
+* Do not try to integrate uncreated test native targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7394](https://github.com/CocoaPods/CocoaPods/issues/7394)
+
 * Do not crash when creating build settings for a missing user build configuration  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7698](https://github.com/CocoaPods/CocoaPods/pull/7698)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -73,9 +73,10 @@ module Pod
           #         an array of all the test specs associated with this native target.
           #
           def test_specs_by_native_target
-            target.test_specs.group_by do |test_spec|
+            test_specs_by_native_target = target.test_specs.group_by do |test_spec|
               test_native_target_from_spec(test_spec)
             end
+            test_specs_by_native_target.delete_if { |k, _| k.nil? }
           end
 
           private

--- a/spec/unit/installer/xcode/pods_project_generator/target_installation_result_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installation_result_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../../../spec_helper', __FILE__)
+
+module Pod
+  class Installer
+    class Xcode
+      class PodsProjectGenerator
+        describe TargetInstallationResult do
+          describe 'In General' do
+            before do
+              @coconut_spec = fixture_spec('coconut-lib/CoconutLib.podspec')
+              @coconut_test_spec = @coconut_spec.test_specs.first
+              @pod_target = fixture_pod_target_with_specs([@coconut_spec, @coconut_test_spec])
+            end
+
+            it 'groups test specs by the native target they are part of' do
+              native_target = stub('native_target')
+              test_native_target = stub('test_native_target', :symbol_type => :unit_test_bundle)
+              result = TargetInstallationResult.new(@pod_target, native_target, [], [test_native_target])
+              result.test_specs_by_native_target.should == { test_native_target => [@coconut_test_spec] }
+            end
+
+            it 'does not return test specs by native target which they were not integrated' do
+              native_target = stub('native_target')
+              result = TargetInstallationResult.new(@pod_target, native_target, [], [])
+              result.test_specs_by_native_target.should.be.empty
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As of 1.5.2 (and will be in 1.6.0) vendored pods (`should_build?` returns `false`) will not integrate their test specs. Some bigger changes are required to accomplish this.

This fixes an edge case in which a pod target must be integrated because it has script phases but it should not be built. The code assumes that a test target has been created for the test specs.

This fixes this edge case.

Found as part of https://github.com/CocoaPods/CocoaPods/issues/7394