### PR TITLE
Fix compatibility with RubyGems v2.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix compatibility with RubyGems 2.7.7.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#7765](https://github.com/CocoaPods/CocoaPods/issues/7765)
+  [#7766](https://github.com/CocoaPods/CocoaPods/issues/7766)
+  [#7763](https://github.com/CocoaPods/CocoaPods/issues/7763)
 
 
 ## 1.5.2 (2018-05-09)

--- a/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
+++ b/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb
@@ -106,7 +106,7 @@ module Pod
           target.target_definition.swift_version unless target.target_definition.swift_version.blank?
         end
 
-        EMBED_STANDARD_LIBRARIES_MINIMUM_VERSION = Gem::Version.new('2.3')
+        EMBED_STANDARD_LIBRARIES_MINIMUM_VERSION = Version.new('2.3')
 
         # @return [Hash<String, String>] the build settings necessary for Swift
         #  targets to be correctly embedded in their host.
@@ -120,7 +120,7 @@ module Pod
           # cause an App Store rejection because frameworks cannot be embedded
           # in embedded targets.
 
-          swift_version = Gem::Version.new(target_swift_version)
+          swift_version = Version.new(target_swift_version)
           should_embed = !target.requires_host_target? && pod_targets.any?(&:uses_swift?)
           config = {}
           if should_embed


### PR DESCRIPTION
Done by using Pod::Version instead of Gem::Version, which in 2.7.7 stop allowing initializing a version with `nil`

Closes #7765.