### PR TITLE
🌈Using xcodeproj to generate .xcassets list

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -136,7 +136,7 @@ module Pod
           #
           def create_copy_resources_script
             path = target.copy_resources_script_path
-            generator = Generator::CopyResourcesScript.new(target.resource_paths_by_config, target.platform)
+            generator = Generator::CopyResourcesScript.new(target.resource_paths_by_config, target.platform, target.user_project.path, target.name)
             update_changed_file(generator, path)
             add_file_to_support_group(path)
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -469,7 +469,7 @@ module Pod
                 pod_target.resource_paths(include_test_spec_paths)
               end
             end
-            generator = Generator::CopyResourcesScript.new(resource_paths_by_config, target.platform)
+            generator = Generator::CopyResourcesScript.new(resource_paths_by_config, target.platform, target.user_project.path, target.name)
             update_changed_file(generator, path)
             add_file_to_support_group(path)
           end

--- a/spec/unit/generator/copy_resources_script_spec.rb
+++ b/spec/unit/generator/copy_resources_script_spec.rb
@@ -4,15 +4,15 @@ module Pod
   describe Generator::CopyResourcesScript do
     it 'returns the copy resources script' do
       resources = { 'Release' => ['path/to/resource.png'] }
-      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
+      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'), Pathname.new("path/to/project.xcodeproj"), "Pods-Target")
       generator.send(:script).should.include 'path/to/resource.png'
       generator.send(:script).should.include 'storyboard'
     end
 
     it 'instructs ibtool to use the --reference-external-strings-file if set to do so' do
       resources = { 'Release' => ['path/to/resource.png'] }
-      generator_1 = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '4.0'))
-      generator_2 = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
+      generator_1 = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '4.0'), Pathname.new("path/to/project.xcodeproj"), "Pods-Target")
+      generator_2 = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'), Pathname.new("path/to/project.xcodeproj"), "Pods-Target")
 
       generator_1.send(:script).should.not.include '--reference-external-strings-file'
       generator_2.send(:script).should.include '--reference-external-strings-file'
@@ -20,7 +20,7 @@ module Pod
 
     it 'adds configuration dependent resources with a call wrapped in an if statement' do
       resources = { 'Debug' => %w(Lookout.framework) }
-      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
+      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'), Pathname.new("path/to/project.xcodeproj"), "Pods-Target")
       script = generator.send(:script)
       script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "Debug" ]]; then
@@ -31,7 +31,7 @@ module Pod
 
     it 'adds resource bundles with a call wrapped in an if statement' do
       resources = { 'Debug' => %w(${BUILT_PRODUCTS_DIR}/Resources.bundle) }
-      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'))
+      generator = Pod::Generator::CopyResourcesScript.new(resources, Platform.new(:ios, '6.0'), Pathname.new("path/to/project.xcodeproj"), "Pods-Target")
       script = generator.send(:script)
       script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "Debug" ]]; then


### PR DESCRIPTION
Related open issues:
https://github.com/CocoaPods/CocoaPods/issues/7745
https://github.com/CocoaPods/CocoaPods/issues/6159

The PR is not yet ready, I'd just like to get some feedback to see if the direction is good.
**The problem:**
As stated in the generated `copy_pods_resuources` script
```
# Find all other xcassets (this unfortunately includes those of path pods and other targets).
OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)
```
The script searches for all `.xcassets` in the project folder recursively, excluding `Pods` folder afterwards. This might pick up some `.xcassets` we don't want in a certain target.

**Proposed solution**
Use the `xcodeproj` gem to extract the list of `.xcassets` to be copied for a certain target and only use those

Code that prints out paths to `.xcassets` for a given target and project:
```
require 'xcodeproj';
project_path = 'Project.xcodeproj'
target_name = 'MyTarget'
project = Xcodeproj::Project.open(project_path)

target = project.targets.find { |t| t.name == target_name }
files = target.resources_build_phase.files
xcassets = files.select { | file | file.display_name.end_with?('.xcassets') }

xcassets.each { | file | puts file.file_ref.real_path }
```

In order to do that, `copy_resources_script.rb` needs to know the location of the user project and the target we're adding the pods to.

Stuff I'd like to get feedback on:
1. Is this an acceptable way of solving this problem?
2. Is there a better way of getting a reference to the `user_project` (Currently works for `AggregatedTargetInstaller`, not sure about `PodTargetInstaller`)
3. Is there a better way of getting the user project target name?
4. The script inserts ruby code in the `.sh` script, is that acceptable? (`.xcassets` files can be added after `pod install` is ran, so the `xcassets` resolution needs to be done in the build script)

I ran the modified code on an example project, and no unwanted `.xcassets` file were included.