### PR TITLE
Fix `INFOPLIST_FILE` being overridden when set in `pod_target_xcconfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix `INFOPLIST_FILE` being overridden when set in a Podspec's `pod_target_xcconfig`  
+  [Eric Amorde](https://github.com/amorde)
+  [#7530](https://github.com/CocoaPods/CocoaPods/issues/7530)
+
 * Raise an error if user target `SWIFT_VERSION` is missing  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7770](https://github.com/CocoaPods/CocoaPods/issues/7770)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -79,7 +79,7 @@ module Pod
               end
 
               if target.requires_frameworks?
-                unless target.static_framework?
+                unless skip_info_plist?(native_target)
                   create_info_plist_file(target.info_plist_path, native_target, target.version, target.platform)
                 end
                 create_build_phase_to_symlink_header_folders(native_target)
@@ -112,6 +112,18 @@ module Pod
           #
           def skip_pch?(specs)
             specs.any? { |spec| spec.prefix_header_file.is_a?(FalseClass) }
+          end
+
+          # True if info.plist generation should be skipped
+          #
+          # @param [PXNativeTarget] native_target
+          #
+          # @return [Boolean] Whether the target should build an Info.plist file
+          #
+          def skip_info_plist?(native_target)
+            return true if target.static_framework?
+            existing_setting = native_target.resolved_build_setting('INFOPLIST_FILE', true).values.compact
+            !existing_setting.empty?
           end
 
           # Remove the default headers folder path settings for static library pod


### PR DESCRIPTION
Fixes #7530

@dnkoutso We may also be able to mark #3032 and #7486 as done, unless they should stay open for future DSL to be added

Podspecs utilizing this may need to set `s.resources = 'PATH_TO_INFO_PLIST.plist'` so that the file is not discarded during install