### PR TITLE
Add `--platforms` parameter to `pod spec lint` and `pod lib lint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add `--platforms` parameter to `pod spec lint` and `pod lib lint` to specify which platforms to lint.  
+  [Eric Amorde](https://github.com/amorde)
+  [#7783](https://github.com/CocoaPods/CocoaPods/issues/7783)
+
 * Warn if 'git://' protocol is used as the source of a pod  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7705](https://github.com/CocoaPods/CocoaPods/issues/7705)

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -20,6 +20,9 @@ module Pod
             ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependent pods ' \
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
+            ['--platforms=ios,macos', 'Lint against specific platforms' \
+              '(defaults to all platforms supported by the podspec).' \
+              'Multiple platforms must be comma-delimited'],
             ['--private', 'Lint skips checks that apply only to public specs'],
             ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec. ' \
              'This takes precedence over a .swift-version file.'],
@@ -37,6 +40,7 @@ module Pod
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @platforms       = argv.option('platforms', '').split(',')
           @private         = argv.flag?('private', false)
           @swift_version   = argv.option('swift-version', nil)
           @skip_import_validation = argv.flag?('skip-import-validation', false)
@@ -52,7 +56,7 @@ module Pod
         def run
           UI.puts
           podspecs_to_lint.each do |podspec|
-            validator                = Validator.new(podspec, @source_urls)
+            validator                = Validator.new(podspec, @source_urls, @platforms)
             validator.local          = true
             validator.quick          = @quick
             validator.no_clean       = !@clean

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -26,6 +26,9 @@ module Pod
             ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependent pods ' \
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
+            ['--platforms=ios,macos', 'Lint against specific platforms' \
+              '(defaults to all platforms supported by the podspec).' \
+              'Multiple platforms must be comma-delimited'],
             ['--private', 'Lint skips checks that apply only to public specs'],
             ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec. ' \
              'This takes precedence over a .swift-version file.'],
@@ -43,6 +46,7 @@ module Pod
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @platforms       = argv.option('platforms', '').split(',')
           @private         = argv.flag?('private', false)
           @swift_version   = argv.option('swift-version', nil)
           @skip_import_validation = argv.flag?('skip-import-validation', false)
@@ -55,7 +59,7 @@ module Pod
           UI.puts
           failure_reasons = []
           podspecs_to_lint.each do |podspec|
-            validator                = Validator.new(podspec, @source_urls)
+            validator                = Validator.new(podspec, @source_urls, @platforms)
             validator.quick          = @quick
             validator.no_clean       = !@clean
             validator.fail_fast      = @fail_fast

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -198,7 +198,7 @@ module Pod
       end
 
       def validator_for_podspec(podspec)
-        Validator.new(podspec, [])
+        Validator.new(podspec, [], [])
       end
     end
   end

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -18,6 +18,10 @@ module Pod
     #
     DEFAULT_SWIFT_VERSION = '3.2'.freeze
 
+    # The valid platforms for linting
+    #
+    VALID_PLATFORMS = Platform.all.freeze
+
     # @return [Specification::Linter] the linter instance from CocoaPods
     #         Core.
     #
@@ -31,13 +35,28 @@ module Pod
     # @param  [Array<String>] source_urls
     #         the Source URLs to use in creating a {Podfile}.
     #
-    def initialize(spec_or_path, source_urls)
+    # @param. [Array<String>] platforms
+    #         the platforms to lint.
+    #
+    def initialize(spec_or_path, source_urls, platforms = [])
       @linter = Specification::Linter.new(spec_or_path)
       @source_urls = if @linter.spec && @linter.spec.dependencies.empty? && @linter.spec.recursive_subspecs.all? { |s| s.dependencies.empty? }
                        []
                      else
                        source_urls.map { |url| config.sources_manager.source_with_name_or_url(url) }.map(&:url)
                      end
+
+      @platforms = platforms.map do |platform|
+        result =  case platform.to_s.downcase
+                  # Platform doesn't recognize 'macos' as being the same as 'osx' when initializing
+                  when 'macos' then Platform.macos
+                  else Platform.new(platform, nil)
+                  end
+        unless valid_platform?(result)
+          raise Informative, "Unrecognized platform `#{platform}`. Valid platforms: #{VALID_PLATFORMS.join(', ')}"
+        end
+        result
+      end
     end
 
     #-------------------------------------------------------------------------#
@@ -53,6 +72,28 @@ module Pod
     #
     def file
       @linter.file
+    end
+
+    # Returns a list of platforms to lint for a given Specification
+    #
+    # @param [Specification] spec
+    #         The specification to lint
+    #
+    # @return [Array<Platform>] platforms to lint for the given specification
+    #
+    def platforms_to_lint(spec)
+      return spec.available_platforms if @platforms.empty?
+
+      # Validate that the platforms specified are actually supported by the spec
+      results = @platforms.map do |platform|
+        matching_platform = spec.available_platforms.find { |p| p.name == platform.name }
+        unless matching_platform
+          raise Informative, "Platform `#{platform}` is not supported by specification `#{spec}`."
+        end
+        matching_platform
+      end.uniq
+
+      results
     end
 
     # @return [Sandbox::FileAccessor] the file accessor for the spec.
@@ -309,7 +350,9 @@ module Pod
       validate_documentation_url(spec)
       validate_source_url(spec)
 
-      valid = spec.available_platforms.send(fail_fast ? :all? : :each) do |platform|
+      platforms = platforms_to_lint(spec)
+
+      valid = platforms.send(fail_fast ? :all? : :each) do |platform|
         UI.message "\n\n#{spec} - Analyzing on #{platform} platform.".green.reversed
         @consumer = spec.consumer(platform)
         setup_validation_environment
@@ -879,6 +922,45 @@ module Pod
     #
     def _xcodebuild(command, raise_on_failure = false)
       Executable.execute_command('xcodebuild', command, raise_on_failure)
+    end
+
+    # Whether the platform with the specified name is valid
+    #
+    # @param  [Platform] platform
+    #         The platform to check
+    #
+    # @return [Bool] True if the platform is valid
+    #
+    def valid_platform?(platform)
+      VALID_PLATFORMS.any? { |p| p.name == platform.name }
+    end
+
+    # Whether the platform is supported by the specification
+    #
+    # @param  [Platform] platform
+    #         The platform to check
+    #
+    # @param  [Specification] specification
+    #         The specification which must support the provided platform
+    #
+    # @return [Bool] Whether the platform is supported by the specification
+    #
+    def supported_platform?(platform, spec)
+      available_platforms = spec.available_platforms
+
+      available_platforms.any? { |p| p.name == platform.name }
+    end
+
+    # Whether the provided name matches the platform
+    #
+    # @param  [Platform] platform
+    #         The platform
+    #
+    # @param  [String] name
+    #         The name to check against the provided platform
+    #
+    def platform_name_match?(platform, name)
+      [platform.name, platform.string_name].any? { |n| n.casecmp(name) == 0 }
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
Closes #7783

Supports setting multiple platforms by passing a comma-separated list, ex. `ios,osx`