### PR TITLE
Adding force true option to the remove_entry call from FileUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Refactor build settings generation to perform much better on large projects.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Make sure the temporary directory used to download the pod is remove even if an error is throwed
+  [augustorsouza](https://github.com/augustorsouza)
+
 ##### Bug Fixes
 
 * Fix `INFOPLIST_FILE` being overridden when set in a Podspec's `pod_target_xcconfig`  

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -180,7 +180,7 @@ module Pod
         tmpdir = Pathname(Dir.mktmpdir)
         blk.call(tmpdir)
       ensure
-        FileUtils.remove_entry(tmpdir) if tmpdir && tmpdir.exist?
+        FileUtils.remove_entry(tmpdir, :force => true) if tmpdir && tmpdir.exist?
       end
 
       # Copies the `source` directory to `destination`, cleaning the directory


### PR DESCRIPTION
I had an issue in a project I work with a private pod that caused the method `copy_and_clean` to throw an error. The issue was in our directory structure, we had a path too long and this made the line `FileUtils.cp_r(source, destination)` to produce an error related to this path. 

The major problem was that after this, another error was produced, this time by the call inside `ensure` to `remove_entry` of `in_tmpdir` showing me that the directory inside the temp folder was not removed because the directory wasn't empty. Since the main purpose seams to be to ensure the removal of this directory I think a forced `remove_entry` is a better choice, this way any error produced inside the block called by the `in_tmpdir` method will not avoid the removal of the directory. 

I think this is not a common flow, but since the code is there I think it is a good addition to make it ensure the removal of the tmp folder. 

I am totally available to make more changes if requested. I tried to uni test this changes but there are located majorly inside private methods.