### PR TITLE
Make the generated Podfile consistent with the docs

### DIFF
--- a/lib/cocoapods/command/spec/create.rb
+++ b/lib/cocoapods/command/spec/create.rb
@@ -60,7 +60,7 @@ module Pod
           data[:author_email]  = `git config --get user.email`.strip
           data[:source_url]    = "http://EXAMPLE/#{name}.git"
           data[:ref_type]      = ':tag'
-          data[:ref]           = '#{s.version}'
+          data[:ref]           = '#{spec.version}'
           data
         end
 
@@ -100,8 +100,8 @@ module Pod
           else
             data[:ref_type] = ':tag'
             data[:ref]      = versions_tags[version]
-            data[:ref]      = '#{s.version}' if "#{version}" == versions_tags[version]
-            data[:ref]      = 'v#{s.version}' if "v#{version}" == versions_tags[version]
+            data[:ref]      = '#{spec.version}' if "#{version}" == versions_tags[version]
+            data[:ref]      = 'v#{spec.version}' if "v#{version}" == versions_tags[version]
           end
           data
         end
@@ -125,20 +125,20 @@ Pod::Spec.new do |s|
   #  summary should be tweet-length, and the description more in depth.
   #
 
-  s.name         = "#{data[:name]}"
-  s.version      = "#{data[:version]}"
-  s.summary      = "#{data[:summary]}"
+  spec.name         = "#{data[:name]}"
+  spec.version      = "#{data[:version]}"
+  spec.summary      = "#{data[:summary]}"
 
   # This description is used to generate tags and improve search results.
   #   * Think: What does it do? Why did you write it? What is the focus?
   #   * Try to keep it short, snappy and to the point.
   #   * Write the description between the DESC delimiters below.
   #   * Finally, don't worry about the indent, CocoaPods strips it!
-  s.description  = <<-DESC
+  spec.description  = <<-DESC
                    DESC
 
-  s.homepage     = "#{data[:homepage]}"
-  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+  spec.homepage     = "#{data[:homepage]}"
+  # spec.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
 
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -148,8 +148,8 @@ Pod::Spec.new do |s|
   #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
   #
 
-  s.license      = "MIT (example)"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+  spec.license      = "MIT (example)"
+  # spec.license      = { :type => "MIT", :file => "FILE_LICENSE" }
 
 
   # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -162,10 +162,10 @@ Pod::Spec.new do |s|
   #  profile URL.
   #
 
-  s.author             = { "#{data[:author_name]}" => "#{data[:author_email]}" }
-  # Or just: s.author    = "#{data[:author_name]}"
-  # s.authors            = { "#{data[:author_name]}" => "#{data[:author_email]}" }
-  # s.social_media_url   = "https://twitter.com/#{data[:author_name]}"
+  spec.author             = { "#{data[:author_name]}" => "#{data[:author_email]}" }
+  # Or just: spec.author    = "#{data[:author_name]}"
+  # spec.authors            = { "#{data[:author_name]}" => "#{data[:author_email]}" }
+  # spec.social_media_url   = "https://twitter.com/#{data[:author_name]}"
 
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
@@ -173,14 +173,14 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  # s.platform     = :ios
-  # s.platform     = :ios, "5.0"
+  # spec.platform     = :ios
+  # spec.platform     = :ios, "5.0"
 
   #  When using multiple platforms
-  # s.ios.deployment_target = "5.0"
-  # s.osx.deployment_target = "10.7"
-  # s.watchos.deployment_target = "2.0"
-  # s.tvos.deployment_target = "9.0"
+  # spec.ios.deployment_target = "5.0"
+  # spec.osx.deployment_target = "10.7"
+  # spec.watchos.deployment_target = "2.0"
+  # spec.tvos.deployment_target = "9.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -189,7 +189,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "#{data[:source_url]}", #{data[:ref_type]} => "#{data[:ref]}" }
+  spec.source       = { :git => "#{data[:source_url]}", #{data[:ref_type]} => "#{data[:ref]}" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -200,10 +200,10 @@ Pod::Spec.new do |s|
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = "Classes", "Classes/**/*.{h,m}"
-  s.exclude_files = "Classes/Exclude"
+  spec.source_files  = "Classes", "Classes/**/*.{h,m}"
+  spec.exclude_files = "Classes/Exclude"
 
-  # s.public_header_files = "Classes/**/*.h"
+  # spec.public_header_files = "Classes/**/*.h"
 
 
   # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -214,10 +214,10 @@ Pod::Spec.new do |s|
   #  non-essential files like tests, examples and documentation.
   #
 
-  # s.resource  = "icon.png"
-  # s.resources = "Resources/*.png"
+  # spec.resource  = "icon.png"
+  # spec.resources = "Resources/*.png"
 
-  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+  # spec.preserve_paths = "FilesToSave", "MoreFilesToSave"
 
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -226,11 +226,11 @@ Pod::Spec.new do |s|
   #  the lib prefix of their name.
   #
 
-  # s.framework  = "SomeFramework"
-  # s.frameworks = "SomeFramework", "AnotherFramework"
+  # spec.framework  = "SomeFramework"
+  # spec.frameworks = "SomeFramework", "AnotherFramework"
 
-  # s.library   = "iconv"
-  # s.libraries = "iconv", "xml2"
+  # spec.library   = "iconv"
+  # spec.libraries = "iconv", "xml2"
 
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -239,10 +239,10 @@ Pod::Spec.new do |s|
   #  where they will only apply to your library. If you depend on other Podspecs
   #  you can include multiple dependencies to ensure it works.
 
-  # s.requires_arc = true
+  # spec.requires_arc = true
 
-  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  # s.dependency "JSONKit", "~> 1.4"
+  # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # spec.dependency "JSONKit", "~> 1.4"
 
 end
           SPEC

--- a/lib/cocoapods/command/spec/create.rb
+++ b/lib/cocoapods/command/spec/create.rb
@@ -116,7 +116,7 @@ module Pod
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-Pod::Spec.new do |s|
+Pod::Spec.new do |spec|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #

--- a/spec/functional/command/spec_spec.rb
+++ b/spec/functional/command/spec_spec.rb
@@ -132,7 +132,7 @@ module Pod
         spec = Specification.from_file(path)
         spec.version.should == Version.new('1.4.0')
         spec.source.should == { :git => 'https://github.com/lukeredpath/libPusher.git', :tag => '1.4.0' }
-        File.open(path, 'r') { |f| f.read.should.include ':tag => "#{s.version}"' }
+        File.open(path, 'r') { |f| f.read.should.include ':tag => "#{spec.version}"' }
       end
 
       it 'correctly reuses version variable in source if matching tag with prefix is found on github' do
@@ -151,7 +151,7 @@ module Pod
         spec = Specification.from_file(path)
         spec.version.should == Version.new('1.4.0')
         spec.source.should == { :git => 'https://github.com/lukeredpath/libPusher.git', :tag => 'v1.4.0' }
-        File.open(path, 'r') { |f| f.read.should.include ':tag => "v#{s.version}"' }
+        File.open(path, 'r') { |f| f.read.should.include ':tag => "v#{spec.version}"' }
       end
 
       it "raises an informative message when the GitHub repository doesn't have any commits" do


### PR DESCRIPTION
The [official docs](https://guides.cocoapods.org/syntax/podspec.html) uses `spec` instead of `s`, so why not make it consistent?