### PR TITLE
[Gemspec] Bump ruby-macho to '~> 1.2'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.6.5)
       nap (~> 1.0)
-      ruby-macho (~> 1.1)
+      ruby-macho (~> 1.2)
       xcodeproj (>= 1.5.8, < 2.0)
 
 GEM
@@ -236,7 +236,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
     ruby-graphviz (1.2.2)
-    ruby-macho (1.1.0)
+    ruby-macho (1.2.0)
     ruby-prof (0.15.2)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '~> 2.0.1'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '~> 1.1'
+  s.add_runtime_dependency 'ruby-macho',    '~> 1.2'
 
   s.add_development_dependency 'bacon', '~> 1.1'
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
macOS 10.14 introduces (or at least begins to use) two new load commands, so ruby-macho has been updated accordingly.

The 1.3 release will contain an option to ignore new load commands in the future, but 1.2 is just a stopgap.