### PR TITLE
Do not add copy resources script phase for static library user targets

### DIFF
--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -322,6 +322,8 @@ module Pod
         #
         def add_copy_resources_script_phase
           native_targets.each do |native_target|
+            # Static library targets cannot include resources. Skip this phase from being added instead.
+            next if native_target.symbol_type == :static_library
             script_path = target.copy_resources_script_relative_path
             resource_paths_by_config = target.resource_paths_by_config
             if resource_paths_by_config.values.all?(&:empty?)


### PR DESCRIPTION
Given:
```ruby
target 'StaticLibrary'
  pod 'Something' # which includes resource bundles
end
```

CocoaPods integrates the `Copy Pods Resources` script phase  into user static library targets unnecessarily, including the input and output paths which could cause unnecessary and confusing diffs.

This change mirrors what we do for `add_embed_frameworks_script_phase` which is only integrated and added for targets that make sense.