### PR TITLE
Properly follow symlinks within macOS universal frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7825](https://github.com/CocoaPods/CocoaPods/pull/7825)
 
+* Properly follow symlinks within macOS universal frameworks  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7587](https://github.com/CocoaPods/CocoaPods/issues/7587)
+  
 * Fix `INFOPLIST_FILE` being overridden when set in a Podspec's `pod_target_xcconfig`  
   [Eric Amorde](https://github.com/amorde)
   [#7530](https://github.com/CocoaPods/CocoaPods/issues/7530)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -84,8 +84,13 @@ module Pod
             local basename
             basename="$(basename -s .framework "$1")"
             binary="${destination}/${basename}.framework/${basename}"
+
             if ! [ -r "$binary" ]; then
               binary="${destination}/${basename}"
+            elif [ -L "${binary}" ]; then
+              echo "Destination binary is symlinked..."
+              dirname="$(dirname "${binary}")"
+              binary="${dirname}/$(readlink "${binary}")"
             fi
 
             # Strip invalid architectures so "fat" simulator / device frameworks work on device


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7814
closes https://github.com/CocoaPods/CocoaPods/issues/7587

@CodingMarkus I spent a bit more time on this and figured out why I could not repro. I did have a universal framework but:
```bash
  # Strip invalid architectures so "fat" simulator / device frameworks work on device
  if [[ "$(file "$binary")" == *"dynamically linked shared library"* ]]; then
    strip_invalid_archs "$binary"
  fi
```
This check was failing and so no stripping was happening at all, even though I had applied your fix within `strip_invalid_archs`.

That is because the result of `"$(file "$binary")"` returned `"/path/to/framework/binary : symbolic link to Versions/Current/framework"` and so it was never executing.

The fix was to properly figure out the final location of the binary was and propagate it through like you recommended but at an earlier stage.

@CodingMarkus, I'd appreciate it if you can manually apply the fix to your own `Pods-<yourapp>-frameworks.sh` file and verify that it works.

Also verified the same fix is not required if a `dSYM` is present. Architectures were properly stripped on the the `.framework` and the `dSYM`.