### PR TITLE
Allow scoping framework and resource paths by specs

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -478,8 +478,8 @@ module Pod
             pod_targets = target.all_dependent_targets
             resource_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
               resources_by_config[config] = pod_targets.flat_map do |pod_target|
-                include_test_spec_paths = pod_target == target
-                pod_target.resource_paths(include_test_spec_paths)
+                spec_paths_to_include = pod_target == target ? pod_target.specs.map(&:name) : pod_target.non_test_specs.map(&:name)
+                pod_target.resource_paths.values_at(*spec_paths_to_include).flatten.compact
               end
             end
             generator = Generator::CopyResourcesScript.new(resource_paths_by_config, target.platform)
@@ -499,8 +499,8 @@ module Pod
             pod_targets = target.all_dependent_targets
             framework_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, paths_by_config|
               paths_by_config[config] = pod_targets.flat_map do |pod_target|
-                include_test_spec_paths = pod_target == target
-                pod_target.framework_paths(include_test_spec_paths)
+                spec_paths_to_include = pod_target == target ? pod_target.specs.map(&:name) : pod_target.non_test_specs.map(&:name)
+                pod_target.framework_paths.values_at(*spec_paths_to_include).flatten.compact.uniq
               end
             end
             generator = Generator::EmbedFrameworksScript.new(framework_paths_by_config)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
@@ -53,8 +53,8 @@ module Pod
             test_type = target.test_type_for_product_type(native_target.symbol_type)
             script_path = "${PODS_ROOT}/#{target.copy_resources_script_path_for_test_type(test_type).relative_path_from(target.sandbox.root)}"
             resource_paths = target.all_dependent_targets.flat_map do |dependent_target|
-              include_test_spec_paths = dependent_target == target
-              dependent_target.resource_paths(include_test_spec_paths)
+              spec_paths_to_include = dependent_target == target ? dependent_target.specs.map(&:name) : dependent_target.non_test_specs.map(&:name)
+              dependent_target.resource_paths.values_at(*spec_paths_to_include).flatten.compact
             end
             input_paths = []
             output_paths = []
@@ -74,10 +74,9 @@ module Pod
           def add_embed_frameworks_script_phase(native_target)
             test_type = target.test_type_for_product_type(native_target.symbol_type)
             script_path = "${PODS_ROOT}/#{target.embed_frameworks_script_path_for_test_type(test_type).relative_path_from(target.sandbox.root)}"
-            all_dependent_targets = target.all_dependent_targets
-            framework_paths = all_dependent_targets.flat_map do |dependent_target|
-              include_test_spec_paths = dependent_target == target
-              dependent_target.framework_paths(include_test_spec_paths)
+            framework_paths = target.all_dependent_targets.flat_map do |dependent_target|
+              spec_paths_to_include = dependent_target == target ? dependent_target.specs.map(&:name) : dependent_target.non_test_specs.map(&:name)
+              dependent_target.framework_paths.values_at(*spec_paths_to_include).flatten.compact.uniq
             end
             input_paths = []
             output_paths = []

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -199,7 +199,10 @@ module Pod
         framework_paths_by_config = {}
         user_build_configurations.keys.each do |config|
           relevant_pod_targets = pod_targets_for_build_configuration(config)
-          framework_paths_by_config[config] = relevant_pod_targets.flat_map { |pt| pt.framework_paths(false) }
+          framework_paths_by_config[config] = relevant_pod_targets.flat_map do |pod_target|
+            non_test_specs = pod_target.non_test_specs.map(&:name)
+            pod_target.framework_paths.values_at(*non_test_specs).flatten.compact.uniq
+          end
         end
         framework_paths_by_config
       end
@@ -214,7 +217,9 @@ module Pod
         end
         user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
           resources_by_config[config] = (relevant_pod_targets & pod_targets_for_build_configuration(config)).flat_map do |pod_target|
-            (pod_target.resource_paths(false) + [bridge_support_file].compact).uniq
+            non_test_specs = pod_target.non_test_specs.map(&:name)
+            resource_paths = pod_target.resource_paths.values_at(*non_test_specs).flatten.compact
+            (resource_paths + [bridge_support_file].compact).uniq
           end
         end
       end

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -231,70 +231,52 @@ module Pod
       test_specs.map(&:test_type).uniq
     end
 
-    # Returns the framework paths associated with this target. By default all paths include the framework paths
-    # that are part of test specifications.
+    # @return [Hash{String=>Array<Hash{Symbol=>String}>}] The vendored and non vendored framework paths this target
+    #         depends upon keyed by spec name. For the root spec and subspecs the framework path of the target itself
+    #         is included.
     #
-    # @param  [Boolean] include_test_spec_paths
-    #         Whether to include framework paths from test specifications or not.
-    #
-    # @return [Array<Hash{Symbol => [String]}>] The vendored and non vendored framework paths
-    #         this target depends upon.
-    #
-    def framework_paths(include_test_spec_paths = true)
-      @framework_paths ||= {}
-      return @framework_paths[include_test_spec_paths] if @framework_paths.key?(include_test_spec_paths)
-      @framework_paths[include_test_spec_paths] = begin
-        accessors = file_accessors
-        accessors = accessors.reject { |a| a.spec.test_specification? } unless include_test_spec_paths
-        frameworks = []
-        accessors.flat_map(&:vendored_dynamic_artifacts).map do |framework_path|
-          relative_path_to_sandbox = framework_path.relative_path_from(sandbox.root)
-          framework = { :name => framework_path.basename.to_s,
-                        :input_path => "${PODS_ROOT}/#{relative_path_to_sandbox}",
-                        :output_path => "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{framework_path.basename}" }
-          # Until this can be configured, assume the dSYM file uses the file name as the framework.
-          # See https://github.com/CocoaPods/CocoaPods/issues/1698
-          dsym_name = "#{framework_path.basename}.dSYM"
-          dsym_path = Pathname.new("#{framework_path.dirname}/#{dsym_name}")
-          if dsym_path.exist?
-            framework[:dsym_name] = dsym_name
-            framework[:dsym_input_path] = "${PODS_ROOT}/#{relative_path_to_sandbox}.dSYM"
-            framework[:dsym_output_path] = "${DWARF_DSYM_FOLDER_PATH}/#{dsym_name}"
+    def framework_paths
+      @framework_paths ||= begin
+        file_accessors.each_with_object({}) do |file_accessor, hash|
+          frameworks = []
+          file_accessor.vendored_dynamic_artifacts.map do |framework_path|
+            relative_path_to_sandbox = framework_path.relative_path_from(sandbox.root)
+            framework = { :name => framework_path.basename.to_s,
+                          :input_path => "${PODS_ROOT}/#{relative_path_to_sandbox}",
+                          :output_path => "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{framework_path.basename}" }
+            # Until this can be configured, assume the dSYM file uses the file name as the framework.
+            # See https://github.com/CocoaPods/CocoaPods/issues/1698
+            dsym_name = "#{framework_path.basename}.dSYM"
+            dsym_path = Pathname.new("#{framework_path.dirname}/#{dsym_name}")
+            if dsym_path.exist?
+              framework[:dsym_name] = dsym_name
+              framework[:dsym_input_path] = "${PODS_ROOT}/#{relative_path_to_sandbox}.dSYM"
+              framework[:dsym_output_path] = "${DWARF_DSYM_FOLDER_PATH}/#{dsym_name}"
+            end
+            frameworks << framework
           end
-          frameworks << framework
+          if !file_accessor.spec.test_specification? && should_build? && requires_frameworks? && !static_framework?
+            frameworks << { :name => product_name,
+                            :input_path => build_product_path('${BUILT_PRODUCTS_DIR}'),
+                            :output_path => "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{product_name}" }
+          end
+          hash[file_accessor.spec.name] = frameworks
         end
-        if should_build? && requires_frameworks? && !static_framework?
-          frameworks << { :name => product_name,
-                          :input_path => build_product_path('${BUILT_PRODUCTS_DIR}'),
-                          :output_path => "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{product_name}" }
-        end
-        frameworks
       end
     end
 
-    # Returns the resource paths associated with this target. By default all paths include the resource paths
-    # that are part of test specifications.
+    # @return [Hash{String=>Array<String>}] The resource and resource bundle paths this target depends upon keyed by
+    #         spec name.
     #
-    # @param  [Boolean] include_test_spec_paths
-    #         Whether to include resource paths from test specifications or not.
-    #
-    # @return [Array<String>] The resource and resource bundle paths this target depends upon.
-    #
-    def resource_paths(include_test_spec_paths = true)
-      @resource_paths ||= {}
-      return @resource_paths[include_test_spec_paths] if @resource_paths.key?(include_test_spec_paths)
-      @resource_paths[include_test_spec_paths] = begin
-        accessors = file_accessors
-        accessors = accessors.reject { |a| a.spec.test_specification? } unless include_test_spec_paths
-        resource_paths = accessors.flat_map do |accessor|
-          accessor.resources.flat_map { |res| "${PODS_ROOT}/#{res.relative_path_from(sandbox.project.path.dirname)}" }
+    def resource_paths
+      @resource_paths ||= begin
+        file_accessors.each_with_object({}) do |file_accessor, hash|
+          resource_paths = file_accessor.resources.map { |res| "${PODS_ROOT}/#{res.relative_path_from(sandbox.project.path.dirname)}" }
+          prefix = Pod::Target::BuildSettings::CONFIGURATION_BUILD_DIR_VARIABLE
+          prefix = configuration_build_dir unless file_accessor.spec.test_specification?
+          resource_bundle_paths = file_accessor.resource_bundles.keys.map { |name| "#{prefix}/#{name.shellescape}.bundle" }
+          hash[file_accessor.spec.name] = resource_paths + resource_bundle_paths
         end
-        resource_bundles = accessors.flat_map do |accessor|
-          prefix = BuildSettings::CONFIGURATION_BUILD_DIR_VARIABLE
-          prefix = configuration_build_dir unless accessor.spec.test_specification?
-          accessor.resource_bundles.keys.map { |name| "#{prefix}/#{name.shellescape}.bundle" }
-        end
-        resource_paths + resource_bundles
       end
     end
 

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -7,7 +7,9 @@ module Pod
         @target_definition = Podfile::TargetDefinition.new('Pods', nil)
         @target_definition.abstract = false
         project_path = SpecHelper.fixture('SampleProject/SampleProject.xcodeproj')
-        @target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition, config.sandbox.root.dirname, Xcodeproj::Project.open(project_path), ['A346496C14F9BE9A0080D870'], {})
+        @target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition,
+                                      config.sandbox.root.dirname, Xcodeproj::Project.open(project_path),
+                                      ['A346496C14F9BE9A0080D870'], {})
       end
 
       it 'returns the target_definition that generated it' do
@@ -87,13 +89,18 @@ module Pod
         @target_definition = Podfile::TargetDefinition.new('Pods', nil)
         @target_definition.abstract = false
         @target_definition.set_platform(:ios, '10.0')
-        @pod_target = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@spec], [@target_definition])
-        @target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition, config.sandbox.root.dirname, nil, nil, 'Release' => [@pod_target], 'Debug' => [@pod_target])
+        file_accessor = fixture_file_accessor(@spec, Platform.ios)
+        @pod_target = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@spec], [@target_definition],
+                                    [file_accessor])
+        @target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios, @target_definition,
+                                      config.sandbox.root.dirname, nil, nil, 'Release' => [@pod_target], 'Debug' => [@pod_target])
       end
 
       describe 'with configuration dependent pod targets' do
         before do
-          @pod_target_release = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@spec], [@target_definition])
+          file_accessor = fixture_file_accessor(@spec, Platform.ios)
+          @pod_target_release = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@spec],
+                                              [@target_definition], [file_accessor])
           @target.stubs(:pod_targets_for_build_configuration).with('Debug').returns([@pod_target])
           @target.stubs(:pod_targets_for_build_configuration).with('Release').returns([@pod_target, @pod_target_release])
           @target.stubs(:pod_targets).returns([@pod_target, @pod_target_release])
@@ -116,7 +123,10 @@ module Pod
       describe 'frameworks by config and input output paths' do
         before do
           @coconut_spec = fixture_spec('coconut-lib/CoconutLib.podspec')
-          @pod_target_release = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@coconut_spec], [@target_definition])
+          file_accessor = fixture_file_accessor(@coconut_spec, Platform.ios)
+          @pod_target_release = PodTarget.new(config.sandbox, false, {}, [],
+                                              Platform.ios, [@coconut_spec], [@target_definition],
+                                              [file_accessor])
           @target.stubs(:pod_targets).returns([@pod_target])
           @target.stubs(:user_build_configurations).returns('Debug' => :debug, 'Release' => :release)
         end
@@ -151,7 +161,7 @@ module Pod
           @pod_target.stubs(:should_build?).returns(true)
           @pod_target.stubs(:requires_frameworks?).returns(true)
           @pod_target.stubs(:static_framework?).returns(true)
-          @pod_target.stubs(:resource_paths).returns(['MyResources.bundle'])
+          @pod_target.stubs(:resource_paths).returns('BananaLib' => ['MyResources.bundle'])
           @target.stubs(:bridge_support_file).returns(nil)
           resource_paths_by_config = @target.resource_paths_by_config
           resource_paths_by_config['Debug'].should == ['MyResources.bundle']

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -296,8 +296,8 @@ module Pod
           @pod_target.sandbox.public_headers.add_search_path('BananaLib', Platform.ios)
           @pod_target.sandbox.public_headers.add_search_path('monkey', Platform.ios)
           monkey_spec = fixture_spec('monkey/monkey.podspec')
-          monkey_pod_target = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [monkey_spec], [@target_definition])
-          monkey_pod_target.stubs(:platform).returns(Platform.ios)
+          monkey_pod_target = PodTarget.new(config.sandbox, false, {}, [],
+                                            Platform.ios, [monkey_spec], [@target_definition])
           @pod_target.stubs(:dependent_targets).returns([monkey_pod_target])
           header_search_paths = @pod_target.header_search_paths
           header_search_paths.sort.should == [
@@ -559,44 +559,46 @@ module Pod
           fa = Sandbox::FileAccessor.new(nil, @coconut_spec.test_specs.first.consumer(@platform))
           fa.stubs(:resource_bundles).returns('TestResourceBundle' => [Pathname.new('Model.xcdatamodeld')])
           fa.stubs(:resources).returns([])
-          fa.stubs(:spec).returns(stub(:test_specification? => true))
           @test_pod_target.stubs(:file_accessors).returns([fa])
-          @test_pod_target.resource_paths.should == ['${PODS_CONFIGURATION_BUILD_DIR}/TestResourceBundle.bundle']
+          @test_pod_target.resource_paths.should == { 'CoconutLib/Tests' => ['${PODS_CONFIGURATION_BUILD_DIR}/TestResourceBundle.bundle'] }
         end
 
         it 'includes framework paths from test specifications' do
-          fa = Sandbox::FileAccessor.new(nil, @coconut_spec.test_specs.first.consumer(@platform))
+          fa = Sandbox::FileAccessor.new(nil, @coconut_spec.consumer(@platform))
           fa.stubs(:vendored_dynamic_artifacts).returns([config.sandbox.root + Pathname.new('Vendored/Vendored.framework')])
-          fa.stubs(:spec).returns(stub(:test_specification? => false))
           test_fa = Sandbox::FileAccessor.new(nil, @coconut_spec.test_specs.first.consumer(@platform))
           test_fa.stubs(:vendored_dynamic_artifacts).returns([config.sandbox.root + Pathname.new('Vendored/TestVendored.framework')])
-          test_fa.stubs(:spec).returns(stub(:test_specification? => true))
           @test_pod_target.stubs(:file_accessors).returns([fa, test_fa])
           @test_pod_target.stubs(:should_build?).returns(true)
-          @test_pod_target.framework_paths.should == [
-            { :name => 'Vendored.framework',
-              :input_path => '${PODS_ROOT}/Vendored/Vendored.framework',
-              :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vendored.framework' },
-            { :name => 'TestVendored.framework',
-              :input_path => '${PODS_ROOT}/Vendored/TestVendored.framework',
-              :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TestVendored.framework' },
-          ]
+          @test_pod_target.framework_paths.should == {
+            'CoconutLib' => [
+              { :name => 'Vendored.framework',
+                :input_path => '${PODS_ROOT}/Vendored/Vendored.framework',
+                :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vendored.framework',
+              },
+            ],
+            'CoconutLib/Tests' => [
+              { :name => 'TestVendored.framework',
+                :input_path => '${PODS_ROOT}/Vendored/TestVendored.framework',
+                :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TestVendored.framework',
+              },
+            ],
+          }
         end
 
         it 'excludes framework paths from test specifications when not requested' do
           fa = Sandbox::FileAccessor.new(nil, @coconut_spec.consumer(@platform))
           fa.stubs(:vendored_dynamic_artifacts).returns([config.sandbox.root + Pathname.new('Vendored/Vendored.framework')])
-          fa.stubs(:spec).returns(stub(:test_specification? => false))
-          test_fa = Sandbox::FileAccessor.new(nil, @coconut_spec.test_specs.first.consumer(@platform))
-          test_fa.stubs(:vendored_dynamic_artifacts).returns([config.sandbox.root + Pathname.new('Vendored/TestVendored.framework')])
-          test_fa.stubs(:spec).returns(stub(:test_specification? => true))
-          @test_pod_target.stubs(:file_accessors).returns([fa, test_fa])
+          @test_pod_target.stubs(:file_accessors).returns([fa])
           @test_pod_target.stubs(:should_build?).returns(true)
-          @test_pod_target.framework_paths(false).should == [
-            { :name => 'Vendored.framework',
-              :input_path => '${PODS_ROOT}/Vendored/Vendored.framework',
-              :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vendored.framework' },
-          ]
+          @test_pod_target.framework_paths.should == {
+            'CoconutLib' => [
+              { :name => 'Vendored.framework',
+                :input_path => '${PODS_ROOT}/Vendored/Vendored.framework',
+                :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vendored.framework',
+                },
+            ],
+          }
         end
 
         it 'includes resource paths from test specifications' do
@@ -604,27 +606,29 @@ module Pod
           fa = Sandbox::FileAccessor.new(nil, @coconut_spec.consumer(@platform))
           fa.stubs(:resource_bundles).returns({})
           fa.stubs(:resources).returns([Pathname.new('Model.xcdatamodeld')])
-          fa.stubs(:spec).returns(stub(:test_specification? => false))
           test_fa = Sandbox::FileAccessor.new(nil, @coconut_spec.test_specs.first.consumer(@platform))
           test_fa.stubs(:resource_bundles).returns({})
           test_fa.stubs(:resources).returns([Pathname.new('TestModel.xcdatamodeld')])
-          test_fa.stubs(:spec).returns(stub(:test_specification? => true))
           @test_pod_target.stubs(:file_accessors).returns([fa, test_fa])
-          @test_pod_target.resource_paths.should == ['${PODS_ROOT}/Model.xcdatamodeld', '${PODS_ROOT}/TestModel.xcdatamodeld']
+          @test_pod_target.resource_paths.should == {
+            'CoconutLib' => ['${PODS_ROOT}/Model.xcdatamodeld'],
+            'CoconutLib/Tests' => ['${PODS_ROOT}/TestModel.xcdatamodeld'],
+          }
         end
 
-        it 'excludes resource paths from test specifications when not requested' do
+        it 'returns resource paths from all specifications by default' do
           config.sandbox.stubs(:project => stub(:path => Pathname.new('ProjectPath')))
           fa = Sandbox::FileAccessor.new(nil, @coconut_spec.consumer(@platform))
           fa.stubs(:resource_bundles).returns({})
           fa.stubs(:resources).returns([Pathname.new('Model.xcdatamodeld')])
-          fa.stubs(:spec).returns(stub(:test_specification? => false))
           test_fa = Sandbox::FileAccessor.new(nil, @coconut_spec.test_specs.first.consumer(@platform))
           test_fa.stubs(:resource_bundles).returns({})
           test_fa.stubs(:resources).returns([Pathname.new('TestModel.xcdatamodeld')])
-          test_fa.stubs(:spec).returns(stub(:test_specification? => true))
           @test_pod_target.stubs(:file_accessors).returns([fa, test_fa])
-          @test_pod_target.resource_paths(false).should == ['${PODS_ROOT}/Model.xcdatamodeld']
+          @test_pod_target.resource_paths.should == {
+            'CoconutLib' => ['${PODS_ROOT}/Model.xcdatamodeld'],
+            'CoconutLib/Tests' => ['${PODS_ROOT}/TestModel.xcdatamodeld'],
+          }
         end
       end
     end


### PR DESCRIPTION
One more step closer to https://github.com/CocoaPods/CocoaPods/issues/7573

I believe there is one more PR left to complete this feature.

This basically allows to scope out resource and framework paths by each podspec. It does not change any logic. It will help by assigning different input and output paths for each test bundle that will be created.