### PR TITLE
Validator adds a Swift file if any of the pod targets use Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7587](https://github.com/CocoaPods/CocoaPods/issues/7587)
   
+* Validator adds a Swift file if any of the pod targets use Swift  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7738](https://github.com/CocoaPods/CocoaPods/issues/7738)
+
 * Fix `INFOPLIST_FILE` being overridden when set in a Podspec's `pod_target_xcconfig`  
   [Eric Amorde](https://github.com/amorde)
   [#7530](https://github.com/CocoaPods/CocoaPods/issues/7530)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -528,8 +528,9 @@ module Pod
       app_project = Xcodeproj::Project.open(validation_dir + 'App.xcodeproj')
       app_target = app_project.targets.first
       pod_target = @installer.pod_targets.find { |pt| pt.pod_name == spec.root.name }
-      Pod::Generator::AppTargetHelper.add_app_project_import(app_project, app_target, pod_target, consumer.platform_name, use_frameworks)
+      Pod::Generator::AppTargetHelper.add_app_project_import(app_project, app_target, pod_target, consumer.platform_name)
       Pod::Generator::AppTargetHelper.add_xctest_search_paths(app_target) if @installer.pod_targets.any? { |pt| pt.spec_consumers.any? { |c| c.frameworks.include?('XCTest') } }
+      Pod::Generator::AppTargetHelper.add_empty_swift_file(app_project, app_target) if @installer.pod_targets.any?(&:uses_swift?)
       app_project.save
       Xcodeproj::XCScheme.share_scheme(app_project.path, 'App')
       # Share the pods xcscheme only if it exists. For pre-built vendored pods there is no xcscheme generated.


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7738

If the pod being linted does not use Swift but any of its dependencies do, then a dummy Swift file is added to the 'App' in order to ensure Swift will be linked.
