### PR TITLE
Set `CURRENT_PROJECT_VERSION` for generated app host targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Set `CURRENT_PROJECT_VERSION` for generated app host targets  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7825](https://github.com/CocoaPods/CocoaPods/pull/7825)
+
 * Fix `INFOPLIST_FILE` being overridden when set in a Podspec's `pod_target_xcconfig`  
   [Eric Amorde](https://github.com/amorde)
   [#7530](https://github.com/CocoaPods/CocoaPods/issues/7530)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -278,6 +278,7 @@ module Pod
                   configuration.build_settings['PRODUCT_NAME'] = name
                   configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
                   configuration.build_settings['CODE_SIGN_IDENTITY'] = '' if platform == :osx
+                  configuration.build_settings['CURRENT_PROJECT_VERSION'] = '1'
                 end
                 Pod::Generator::AppTargetHelper.add_app_host_main_file(project, app_host_target, platform_name, name)
                 app_host_info_plist_path = app_host_info_plist_path_for_test_type(name, spec_consumer.test_type)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -351,6 +351,11 @@ module Pod
                   app_host_target = @project.targets[2]
                   app_host_target.name.should == 'AppHost-iOS-Unit-Tests'
                   app_host_target.symbol_type.should == :application
+                  app_host_target.build_configurations.each do |bc|
+                    bc.build_settings['PRODUCT_NAME'].should == 'AppHost-iOS-Unit-Tests'
+                    bc.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+                    bc.build_settings['CURRENT_PROJECT_VERSION'].should == '1'
+                  end
                   test_native_target = @project.targets[1]
                   test_native_target.build_configurations.each do |bc|
                     bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-iOS-Unit-Tests.app/AppHost-iOS-Unit-Tests'
@@ -371,6 +376,7 @@ module Pod
                   app_host_target.build_configurations.each do |bc|
                     bc.build_settings['PRODUCT_NAME'].should == 'AppHost-macOS-Unit-Tests'
                     bc.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+                    bc.build_settings['CURRENT_PROJECT_VERSION'].should == '1'
                   end
                   test_native_target = @project.targets[1]
                   test_native_target.build_configurations.each do |bc|


### PR DESCRIPTION
Every generated `Info.plist` file from CocoaPods points to `CURRENT_PROJECT_VERSION` variable for the value of `CFBundleVersion`.

For test specs that require an app host this value is not set because it is generated by CocoaPods. This fixes it by setting the value for generated app host targets.

See https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/generator/info_plist_file.rb#L103