### PR TITLE
Add a way to still build\lint iOS frameworks that may still include invalid archs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add `--build-active-ios-arch-only` parameter to `pod spec lint` and `pod lib lint` and `pod repo push` to allow linting and pushing of frameworks that may still have i386 support.  
+  [Dan Fischer](https://github.com/fischerdan)
+  [#5854](https://github.com/CocoaPods/CocoaPods/issues/5854)
+
 * Add `--platforms` parameter to `pod spec lint` and `pod lib lint` to specify which platforms to lint.  
   [Eric Amorde](https://github.com/amorde)
   [#7783](https://github.com/CocoaPods/CocoaPods/issues/7783)

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -28,21 +28,23 @@ module Pod
              'This takes precedence over a .swift-version file.'],
             ['--skip-import-validation', 'Lint skips validating that the pod can be imported'],
             ['--skip-tests', 'Lint skips building and running tests during validation'],
+            ['--build-active-ios-arch-only', 'Lint builds the iOS library with only active architecture'],
           ].concat(super)
         end
 
         def initialize(argv)
-          @quick           = argv.flag?('quick')
-          @allow_warnings  = argv.flag?('allow-warnings')
-          @clean           = argv.flag?('clean', true)
-          @fail_fast       = argv.flag?('fail-fast', false)
-          @subspecs        = argv.flag?('subspecs', true)
-          @only_subspec    = argv.option('subspec')
-          @use_frameworks  = !argv.flag?('use-libraries')
-          @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
-          @platforms       = argv.option('platforms', '').split(',')
-          @private         = argv.flag?('private', false)
-          @swift_version   = argv.option('swift-version', nil)
+          @quick                      = argv.flag?('quick')
+          @allow_warnings             = argv.flag?('allow-warnings')
+          @clean                      = argv.flag?('clean', true)
+          @fail_fast                  = argv.flag?('fail-fast', false)
+          @subspecs                   = argv.flag?('subspecs', true)
+          @only_subspec               = argv.option('subspec')
+          @use_frameworks             = !argv.flag?('use-libraries')
+          @source_urls                = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @platforms                  = argv.option('platforms', '').split(',')
+          @private                    = argv.flag?('private', false)
+          @swift_version              = argv.option('swift-version', nil)
+          @build_active_ios_arch_only = argv.flag?('build-active-ios-arch-only', false)
           @skip_import_validation = argv.flag?('skip-import-validation', false)
           @skip_tests = argv.flag?('skip-tests', false)
           @podspecs_paths = argv.arguments!
@@ -67,6 +69,7 @@ module Pod
             validator.use_frameworks = @use_frameworks
             validator.ignore_public_only_results = @private
             validator.swift_version = @swift_version
+            validator.build_active_ios_arch_only = @build_active_ios_arch_only
             validator.skip_import_validation = @skip_import_validation
             validator.skip_tests = @skip_tests
             validator.validate

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -37,6 +37,7 @@ module Pod
             ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used when linting the spec. ' \
              'This takes precedence over a .swift-version file.'],
             ['--no-overwrite', 'Disallow pushing that would overwrite an existing spec.'],
+            ['--build-active-ios-arch-only', 'Lint builds the iOS library with only active architectures'],
           ].concat(super)
         end
 
@@ -54,6 +55,7 @@ module Pod
           @use_json = argv.flag?('use-json')
           @swift_version = argv.option('swift-version', nil)
           @skip_import_validation = argv.flag?('skip-import-validation', false)
+          @build_active_ios_arch_only = argv.flag?('build-active-ios-arch-only', false)
           @skip_tests = argv.flag?('skip-tests', false)
           @allow_overwrite = argv.flag?('overwrite', true)
           super
@@ -135,6 +137,7 @@ module Pod
             validator.swift_version = @swift_version
             validator.skip_import_validation = @skip_import_validation
             validator.skip_tests = @skip_tests
+            validator.build_active_ios_arch_only = @build_active_ios_arch_only
             begin
               validator.validate
             rescue => e

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -34,21 +34,23 @@ module Pod
              'This takes precedence over a .swift-version file.'],
             ['--skip-import-validation', 'Lint skips validating that the pod can be imported'],
             ['--skip-tests', 'Lint skips building and running tests during validation'],
+            ['--build-active-ios-arch-only', 'Lint builds the iOS library with only active architecture'],
           ].concat(super)
         end
 
         def initialize(argv)
-          @quick           = argv.flag?('quick')
-          @allow_warnings  = argv.flag?('allow-warnings')
-          @clean           = argv.flag?('clean', true)
-          @fail_fast       = argv.flag?('fail-fast', false)
-          @subspecs        = argv.flag?('subspecs', true)
-          @only_subspec    = argv.option('subspec')
-          @use_frameworks  = !argv.flag?('use-libraries')
-          @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
-          @platforms       = argv.option('platforms', '').split(',')
-          @private         = argv.flag?('private', false)
-          @swift_version   = argv.option('swift-version', nil)
+          @quick                      = argv.flag?('quick')
+          @allow_warnings             = argv.flag?('allow-warnings')
+          @clean                      = argv.flag?('clean', true)
+          @fail_fast                  = argv.flag?('fail-fast', false)
+          @subspecs                   = argv.flag?('subspecs', true)
+          @only_subspec               = argv.option('subspec')
+          @use_frameworks             = !argv.flag?('use-libraries')
+          @source_urls                = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @platforms                  = argv.option('platforms', '').split(',')
+          @private                    = argv.flag?('private', false)
+          @swift_version              = argv.option('swift-version', nil)
+          @build_active_ios_arch_only = argv.flag?('build-active-ios-arch-only', false)
           @skip_import_validation = argv.flag?('skip-import-validation', false)
           @skip_tests = argv.flag?('skip-tests', false)
           @podspecs_paths = argv.arguments!
@@ -69,6 +71,7 @@ module Pod
             validator.use_frameworks = @use_frameworks
             validator.ignore_public_only_results = @private
             validator.swift_version = @swift_version
+            validator.build_active_ios_arch_only = @build_active_ios_arch_only
             validator.skip_import_validation = @skip_import_validation
             validator.skip_tests = @skip_tests
             validator.validate

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -248,6 +248,11 @@ module Pod
     #
     attr_accessor :ignore_public_only_results
 
+    # @return [Boolean] Whether iOS builds should be for only active architectures
+    #         Bool be skipped.
+    #
+    attr_accessor :build_active_ios_arch_only
+
     attr_accessor :skip_import_validation
     alias_method :skip_import_validation?, :skip_import_validation
 
@@ -899,6 +904,9 @@ module Pod
       when :ios
         command += %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator)
         command += Fourflusher::SimControl.new.destination(:oldest, 'iOS', deployment_target)
+        if build_active_ios_arch_only
+          command += %w( ONLY_ACTIVE_ARCH=YES)
+        end
       when :watchos
         command += %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         command += Fourflusher::SimControl.new.destination(:oldest, 'watchOS', deployment_target)


### PR DESCRIPTION
There's a handful of issues stemming from xcodebuild taking the default route of building all architectures. This adds a very basic way to allow the build process to continue instead of forcing through via skipping the build step on lint or push.

https://github.com/CocoaPods/CocoaPods/issues/5854
https://github.com/CocoaPods/CocoaPods/issues/6074
https://github.com/CocoaPods/CocoaPods/issues/5664
