### PR TITLE
Only add target dependencies for direct dependencies

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -285,8 +285,8 @@ module Pod
             end
             # Wire up test native targets.
             unless pod_target_installation_result.test_native_targets.empty?
-              test_dependent_targets = pod_target.all_dependent_targets
               pod_target_installation_result.test_specs_by_native_target.each do |test_native_target, test_specs|
+                test_dependent_targets = test_specs.flat_map { |s| pod_target.test_dependent_targets_by_spec_name[s.name] }.compact.unshift(pod_target).uniq
                 test_dependent_targets.each do |test_dependent_target|
                   dependency_installation_result = pod_target_installation_results_hash[test_dependent_target.name]
                   dependency_installation_result.test_resource_bundle_targets.values.flatten.each do |test_resource_bundle_target|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ require 'spec_helper/temporary_cache' # Allows to create temporary cache directo
 require 'spec_helper/user_interface'  # Redirects UI to UI.output & UI.warnings.
 require 'spec_helper/pre_flight'      # Cleans the temporary directory, the config & the UI.output before every test.
 require 'spec_helper/webmock'         # Cleans up mocks after each spec
+require 'spec_helper/mock_source'     # Allows building a mock source from Spec objects.
 
 #-----------------------------------------------------------------------------#
 

--- a/spec/spec_helper/mock_source.rb
+++ b/spec/spec_helper/mock_source.rb
@@ -1,0 +1,61 @@
+class MockSource < Pod::Source
+  attr_reader :name
+
+  def initialize(name, &blk)
+    @name = name
+    @_pods_by_name = Hash.new { |h, k| h[k] = [] }
+    @_current_pod = nil
+    instance_eval(&blk)
+    super('/mock/repo')
+  end
+
+  def pod(name, version = nil, platform: [[:ios, '9.0']], test_spec: false, &_blk)
+    cp = @_current_pod
+    Pod::Specification.new(cp, name, test_spec) do |spec|
+      @_current_pod = spec
+      if cp
+        cp.subspecs << spec
+      else
+        spec.version = version
+      end
+      platform.each { |pl, dt| spec.send(pl).deployment_target = dt }
+      yield spec if block_given?
+    end
+    @_pods_by_name[name] << @_current_pod if cp.nil?
+  ensure
+    @_current_pod = cp
+  end
+
+  def test_spec(name: 'Tests', &blk)
+    pod(name, :test_spec => true, &blk)
+  end
+
+  def all_specs
+    @_pods_by_name.values.flatten(1)
+  end
+
+  def pods
+    @_pods_by_name.keys
+  end
+
+  def search(query)
+    query = query.root_name if query.is_a?(Pod::Dependency)
+    set(query) if @_pods_by_name.key?(query)
+  end
+
+  def specification(name, version)
+    @_pods_by_name[name].find { |s| s.version == Pod::Version.new(version) }
+  end
+
+  def versions(name)
+    @_pods_by_name[name].map(&:version)
+  end
+
+  def specification_path(name, version)
+    pod_path(name).join(version.to_s, "#{name}.podspec")
+  end
+
+  def specs_dir
+    repo
+  end
+end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -263,6 +263,188 @@ module Pod
           aranalytics_target.dependent_targets.all?(&:scoped).should.be.true
         end
 
+        it 'does not mark transitive dependencies as dependent targets' do
+          @podfile = Pod::Podfile.new do
+            platform :ios, '8.0'
+            project 'SampleProject/SampleProject'
+            target 'SampleProject'
+            pod 'Firebase', '3.9.0'
+            pod 'ARAnalytics', '4.0.0', :subspecs => %w(Firebase)
+          end
+          @analyzer = Pod::Installer::Analyzer.new(config.sandbox, @podfile, nil)
+          result = @analyzer.analyze
+          result.targets.count.should == 1
+          target = result.targets.first
+
+          firebase_target = target.pod_targets.find { |pt| pt.pod_name == 'Firebase' }
+          firebase_target.dependent_targets.map(&:pod_name).sort.should == %w(
+            FirebaseAnalytics FirebaseCore
+          )
+          firebase_target.recursive_dependent_targets.map(&:pod_name).sort.should == %w(
+            FirebaseAnalytics FirebaseCore FirebaseInstanceID GoogleInterchangeUtilities GoogleSymbolUtilities GoogleToolboxForMac
+          )
+          firebase_target.dependent_targets.all?(&:scoped).should.be.true
+
+          aranalytics_target = target.pod_targets.find { |pt| pt.pod_name == 'ARAnalytics' }
+          aranalytics_target.dependent_targets.map(&:pod_name).sort.should == %w(
+            Firebase
+          )
+          aranalytics_target.recursive_dependent_targets.map(&:pod_name).sort.should == %w(
+            Firebase FirebaseAnalytics FirebaseCore FirebaseInstanceID GoogleInterchangeUtilities GoogleSymbolUtilities GoogleToolboxForMac
+          )
+          aranalytics_target.dependent_targets.all?(&:scoped).should.be.true
+        end
+
+        it 'does not mark transitive dependencies as dependent targets' do
+          @podfile = Pod::Podfile.new do
+            platform :ios, '8.0'
+            project 'SampleProject/SampleProject'
+            target 'SampleProject'
+            pod 'Firebase', '3.9.0'
+            pod 'ARAnalytics', '4.0.0', :subspecs => %w(Firebase)
+          end
+          @analyzer = Pod::Installer::Analyzer.new(config.sandbox, @podfile, nil)
+          result = @analyzer.analyze
+          result.targets.count.should == 1
+          target = result.targets.first
+
+          firebase_target = target.pod_targets.find { |pt| pt.pod_name == 'Firebase' }
+          firebase_target.dependent_targets.map(&:pod_name).sort.should == %w(
+            FirebaseAnalytics FirebaseCore
+          )
+          firebase_target.recursive_dependent_targets.map(&:pod_name).sort.should == %w(
+            FirebaseAnalytics FirebaseCore FirebaseInstanceID GoogleInterchangeUtilities GoogleSymbolUtilities GoogleToolboxForMac
+          )
+          firebase_target.dependent_targets.all?(&:scoped).should.be.true
+
+          aranalytics_target = target.pod_targets.find { |pt| pt.pod_name == 'ARAnalytics' }
+          aranalytics_target.dependent_targets.map(&:pod_name).sort.should == %w(
+            Firebase
+          )
+          aranalytics_target.recursive_dependent_targets.map(&:pod_name).sort.should == %w(
+            Firebase FirebaseAnalytics FirebaseCore FirebaseInstanceID GoogleInterchangeUtilities GoogleSymbolUtilities GoogleToolboxForMac
+          )
+          aranalytics_target.dependent_targets.all?(&:scoped).should.be.true
+        end
+
+        it 'correctly computes recursive dependent targets' do
+          @podfile = Pod::Podfile.new do
+            platform :ios, '10.0'
+            project 'SampleProject/SampleProject'
+
+            # The order of target definitions is important for this test.
+            target 'SampleProject' do
+              pod 'a', :testspecs => %w(Tests)
+              pod 'b', :testspecs => %w(Tests)
+              pod 'c', :testspecs => %w(Tests)
+              pod 'd', :testspecs => %w(Tests)
+              pod 'base'
+            end
+          end
+
+          source = MockSource.new 'Source' do
+            pod 'base' do
+              test_spec do |ts|
+                ts.dependency 'base_testing'
+              end
+            end
+
+            pod 'a' do |s|
+              s.dependency 'b'
+              s.dependency 'base'
+              test_spec do |ts|
+                ts.dependency 'a_testing'
+              end
+            end
+
+            pod 'b' do |s|
+              s.dependency 'c'
+              test_spec do |ts|
+              end
+            end
+
+            pod 'c' do |s|
+              s.dependency 'e'
+              test_spec do |ts|
+                ts.dependency 'a_testing'
+              end
+            end
+
+            pod 'd' do |s|
+              s.dependency 'a'
+              test_spec do |ts|
+                ts.dependency 'b'
+              end
+            end
+
+            pod 'e' do |s|
+              s.dependency 'base'
+              test_spec do |ts|
+              end
+            end
+
+            pod 'a_testing' do |s|
+              s.dependency 'a'
+              s.dependency 'base_testing'
+              test_spec do |ts|
+                ts.dependency 'base_testing'
+              end
+            end
+
+            pod 'base_testing' do |s|
+              s.dependency 'base'
+              test_spec do |ts|
+              end
+            end
+          end
+
+          @analyzer = Pod::Installer::Analyzer.new(config.sandbox, @podfile, nil)
+          @analyzer.stubs(:sources).returns([source])
+          result = @analyzer.analyze
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'a' }
+          pod_target.dependent_targets.map(&:name).sort.should == %w(b base)
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(b base c e)
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['a/Tests', ['a_testing']]]
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == %w(a a_testing b base base_testing c e)
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'a_testing' }
+          pod_target.dependent_targets.map(&:name).sort.should == %w(a base_testing)
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(a b base base_testing c e)
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == []
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'b' }
+          pod_target.dependent_targets.map(&:name).sort.should == ['c']
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(base c e)
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['b/Tests', []]]
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == []
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'base' }
+          pod_target.dependent_targets.map(&:name).sort.should == []
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == []
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == []
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'c' }
+          pod_target.dependent_targets.map(&:name).sort.should == ['e']
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(base e)
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['a_testing']]]
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == %w(a a_testing b base base_testing c e)
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'd' }
+          pod_target.dependent_targets.map(&:name).sort.should == ['a']
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(a b base c e)
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['d/Tests', ['b']]]
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == %w(b base c e)
+
+          pod_target = result.pod_targets.find { |pt| pt.name == 'e' }
+          pod_target.dependent_targets.map(&:name).sort.should == ['base']
+          pod_target.recursive_dependent_targets.map(&:name).sort.should == ['base']
+          pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
+          pod_target.recursive_test_dependent_targets.map(&:name).sort.should == []
+        end
+
         it 'picks the right variants up when there are multiple' do
           @podfile = Pod::Podfile.new do
             source SpecHelper.test_repo_url

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -226,7 +226,6 @@ module Pod
             @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
               'CoconutLib-iOS',
               'CoconutLib-iOS-CoconutLibTestResourcesBundle',
-              'OrangeFramework',
             ]
             @generator.project.targets.find { |t| t.name == 'CoconutLib-macOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
               'CoconutLib-macOS',
@@ -241,7 +240,6 @@ module Pod
             @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
               'AppHost-iOS-Unit-Tests',
               'CoconutLib-iOS',
-              'OrangeFramework',
             ]
             @generator.project.targets.find { |t| t.name == 'CoconutLib-macOS-Unit-Tests' }.dependencies.map(&:name).should == [
               'CoconutLib-macOS',

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -13,68 +13,6 @@ end
 
 module Pod
   describe Resolver do
-    class MockSource < Source
-      attr_reader :name
-
-      def initialize(name, &blk)
-        @name = name
-        @_pods_by_name = Hash.new { |h, k| h[k] = [] }
-        @_current_pod = nil
-        instance_eval(&blk)
-        super('/mock/repo')
-      end
-
-      def pod(name, version = nil, platform: [[:ios, '9.0']], test_spec: false, &_blk)
-        cp = @_current_pod
-        Pod::Specification.new(cp, name, test_spec) do |spec|
-          @_current_pod = spec
-          if cp
-            cp.subspecs << spec
-          else
-            spec.version = version
-          end
-          platform.each { |pl, dt| spec.send(pl).deployment_target = dt }
-          yield spec if block_given?
-        end
-        @_pods_by_name[name] << @_current_pod if cp.nil?
-      ensure
-        @_current_pod = cp
-      end
-
-      def test_spec(name: 'Tests', &blk)
-        pod(name, :test_spec => true, &blk)
-      end
-
-      def all_specs
-        @_pods_by_name.values.flatten(1)
-      end
-
-      def pods
-        @_pods_by_name.keys
-      end
-
-      def search(query)
-        query = query.root_name if query.is_a?(Dependency)
-        set(query) if @_pods_by_name.key?(query)
-      end
-
-      def specification(name, version)
-        @_pods_by_name[name].find { |s| s.version == Pod::Version.new(version) }
-      end
-
-      def versions(name)
-        @_pods_by_name[name].map(&:version)
-      end
-
-      def specification_path(name, version)
-        pod_path(name).join(version.to_s, "#{name}.podspec")
-      end
-
-      def specs_dir
-        repo
-      end
-    end
-
     describe 'In general' do
       before do
         @podfile = Podfile.new do

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -39,6 +39,7 @@ module Pod
               :requires_frameworks? => true,
               :static_framework? => false,
               :dependent_targets => [],
+              :_add_recursive_dependent_targets => [],
               :recursive_dependent_targets => [],
               :file_accessors => [file_accessor],
               :spec_consumers => [consumer],


### PR DESCRIPTION
Let the build system natively handle transitive dependencies

This will help keep the pods project as compact as possible, and also allow the build system to have an easier time when traversing the build graph