### PR TITLE
[PodTargetInstaller] Symlink static lib custom modulemaps into the Headers directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Allow `EXPANDED_CODE_SIGN_IDENTITY` to be unset.  
   [Keith Smiley](https://github.com/keith)
   [#7708](https://github.com/CocoaPods/CocoaPods/issues/7708)
+
+* Running `pod install` with static library modules no longer causes pods to
+  be recompiled.  
+  [Samuel Giddins](https://github.com/segiddins)
+
+
 ## 1.5.3 (2018-05-25)
 
 ##### Enhancements

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -196,10 +196,24 @@ module Pod
       module_map_path.parent + "#{label}-umbrella.h"
     end
 
+    def umbrella_header_path_to_write
+      module_map_path_to_write.parent + "#{label}-umbrella.h"
+    end
+
     # @return [Pathname] the absolute path of the LLVM module map file that
     #         defines the module structure for the compiler.
     #
     def module_map_path
+      module_map_path_to_write
+    end
+
+    # @!private
+    #
+    # @return [Pathname] the absolute path of the module map file that
+    #         CocoaPods writes. This can be different from `module_map_path`
+    #         if the module map gets symlinked.
+    #
+    def module_map_path_to_write
       basename = "#{label}.modulemap"
       support_files_dir + basename
     end


### PR DESCRIPTION
This means we wont be overwriting the underlying file, so `pod install` wont cause full recompiles