### PR TITLE
Fix PBXAggregateTargets to include an xcconfig

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -29,6 +29,7 @@ module Pod
           #
           def install!
             UI.message "- Installing target `#{target.name}` #{target.platform}" do
+              create_support_files_dir
               test_file_accessors, file_accessors = target.file_accessors.partition { |fa| fa.spec.test_specification? }
 
               unless target.should_build?
@@ -36,10 +37,9 @@ module Pod
                 # PBXAggregateTarget that will be used to wire up dependencies later.
                 native_target = add_placeholder_target
                 resource_bundle_targets = add_resources_bundle_targets(file_accessors).values.flatten
+                create_xcconfig_file(native_target, resource_bundle_targets)
                 return TargetInstallationResult.new(target, native_target, resource_bundle_targets)
               end
-
-              create_support_files_dir
 
               native_target = add_target
               resource_bundle_targets = add_resources_bundle_targets(file_accessors).values.flatten

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -810,6 +810,14 @@ module Pod
               @project.targets.first.class.should == Xcodeproj::Project::PBXAggregateTarget
             end
 
+            it 'adds xcconfig file reference for the aggregate placeholder native target' do
+              @pod_target.stubs(:should_build?).returns(false)
+              @installer.install!
+              @project.support_files_group
+              group = @project['Pods/BananaLib/Support Files']
+              group.children.map(&:display_name).sort.should == ['BananaLib.xcconfig']
+            end
+
             #--------------------------------------------------------------------------------#
 
             describe 'concerning header_mappings_dirs' do


### PR DESCRIPTION
This is a master only issue.

In 1.6.0 we changed it so targets that `should_build?` return `false` will now integrate a PBXAggregateTarget and return early.

By returning early we no longer create an xcconfig for these targets (which 1.5.3 used to do) which means none of the other variables such as `PODS_TARGET_SRCROOT` are available. If this target includes a script phase then it will not be able to reference this env variable or other `PODS_*` variables

This change fixes this regression and ensures an `xcconfig` is created for these targets.