### PR TITLE
Cache absolute paths when globbing

### DIFF
--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -88,7 +88,8 @@ module Pod
       # @return [Array<Pathname>]
       #
       def glob(patterns, options = {})
-        relative_glob(patterns, options).map { |p| root.join(p) }
+        cache_key = options.merge(:patterns => patterns)
+        @glob_cache[cache_key] ||= relative_glob(patterns, options).map { |p| root.join(p) }
       end
 
       # The list of relative paths that are case insensitively matched by a
@@ -114,10 +115,6 @@ module Pod
       #
       def relative_glob(patterns, options = {})
         return [] if patterns.empty?
-
-        cache_key = options.merge(:patterns => patterns)
-        cached_value = @glob_cache[cache_key]
-        return cached_value if cached_value
 
         dir_pattern = options[:dir_pattern]
         exclude_patterns = options[:exclude_patterns]
@@ -155,7 +152,7 @@ module Pod
           exclude_options = { :dir_pattern => '**/*', :include_dirs => include_dirs }
           list -= relative_glob(exclude_patterns, exclude_options)
         end
-        @glob_cache[cache_key] = list
+        list
       end
 
       #-----------------------------------------------------------------------#


### PR DESCRIPTION
Cache absolute paths when globbing instead of repeatedly joining against the path_list root

In the test project I'm using to benchmark, this reduced the number calls to `Pathname#join` (which itself calls `Pathname.new`) from ~56k to ~11k, which also eliminates the allocation of ~40k Pathname instances.