### PR TITLE
Reduce memory allocation in TargetInstaller#update_changed_file

### DIFF
--- a/lib/cocoapods/generator/acknowledgements/markdown.rb
+++ b/lib/cocoapods/generator/acknowledgements/markdown.rb
@@ -11,6 +11,12 @@ module Pod
         file.close
       end
 
+      # @return [String] The contents of the acknowledgements in Markdown format.
+      #
+      def generate
+        licenses
+      end
+
       def title_from_string(string, level)
         unless string.empty?
           '#' * level << " #{string}"

--- a/lib/cocoapods/generator/acknowledgements/plist.rb
+++ b/lib/cocoapods/generator/acknowledgements/plist.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 module Pod
   module Generator
     class Plist < Acknowledgements
@@ -7,6 +9,15 @@ module Pod
 
       def save_as(path)
         Xcodeproj::Plist.write_to_path(plist, path)
+      end
+
+      # @return [String] The contents of the plist
+      #
+      def generate
+        plist = Nanaimo::Plist.new(plist, :xml)
+        contents = StringIO.new
+        Nanaimo::Writer::XMLWriter.new(plist, :pretty => true, :output => contents, :strict => false).write
+        contents.string
       end
 
       def plist

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -38,6 +38,12 @@ module Pod
         File.chmod(0755, pathname.to_s)
       end
 
+      # @return [String] The contents of the copy resources script.
+      #
+      def generate
+        script
+      end
+
       private
 
       # @!group Private Helpers

--- a/lib/cocoapods/generator/dummy_source.rb
+++ b/lib/cocoapods/generator/dummy_source.rb
@@ -11,12 +11,13 @@ module Pod
       # @return [String] the string contents of the dummy source file.
       #
       def generate
-        result = ''
-        result << "#import <Foundation/Foundation.h>\n"
-        result << "@interface #{class_name} : NSObject\n"
-        result << "@end\n"
-        result << "@implementation #{class_name}\n"
-        result << "@end\n"
+        result = <<-source.strip_heredoc
+          #import <Foundation/Foundation.h>
+          @interface #{class_name} : NSObject
+          @end
+          @implementation #{class_name}
+          @end
+        source
         result
       end
 

--- a/lib/cocoapods/generator/dummy_source.rb
+++ b/lib/cocoapods/generator/dummy_source.rb
@@ -8,13 +8,21 @@ module Pod
         @class_name = "PodsDummy_#{validated_class_name_identifier}"
       end
 
+      # @return [String] the string contents of the dummy source file.
+      #
+      def generate
+        result = ''
+        result << "#import <Foundation/Foundation.h>\n"
+        result << "@interface #{class_name} : NSObject\n"
+        result << "@end\n"
+        result << "@implementation #{class_name}\n"
+        result << "@end\n"
+        result
+      end
+
       def save_as(pathname)
         pathname.open('w') do |source|
-          source.puts '#import <Foundation/Foundation.h>'
-          source.puts "@interface #{class_name} : NSObject"
-          source.puts '@end'
-          source.puts "@implementation #{class_name}"
-          source.puts '@end'
+          source.write(generate)
         end
       end
     end

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -27,6 +27,12 @@ module Pod
         File.chmod(0755, pathname.to_s)
       end
 
+      # @return [String] The contents of the embed frameworks script.
+      #
+      def generate
+        script
+      end
+
       private
 
       # @!group Private Helpers

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -110,21 +110,12 @@ module Pod
           #
           def update_changed_file(generator, path)
             if path.exist?
-              if !generator.respond_to?(:generate)
-                # the generator doesn't support generating string contents, so write it to a tmp file and compare
-                # it with the existing file
-                generator.save_as(support_files_temp_dir)
-                unless FileUtils.identical?(support_files_temp_dir, path)
-                  FileUtils.mv(support_files_temp_dir, path)
-                end
-              else
-                contents = generator.generate.to_s
-                content_stream = StringIO.new(contents)
-                identical = File.open(path, 'rb') { |f| FileUtils.compare_stream(f, content_stream) }
-                return if identical
+              contents = generator.generate.to_s
+              content_stream = StringIO.new(contents)
+              identical = File.open(path, 'rb') { |f| FileUtils.compare_stream(f, content_stream) }
+              return if identical
 
-                File.open(path, 'w') { |f| f.write(contents) }
-              end
+              File.open(path, 'w') { |f| f.write(contents) }
             else
               path.dirname.mkpath
               generator.save_as(path)


### PR DESCRIPTION
Currently `update_changed_file` writes the new file to disk, checks if they are the same with `FileUtils#identical?` (which then loads both files into memory) and then moves the new file over if the contents have changed.

By avoiding reloading the file that we just wrote back into memory, we can save a large amount of memory allocation. Since garbage collection accounts for a major portion of `pod install` times, this should hopefully help.

### Memory Allocation during `pod install`
Tested using the `memory_profiler` gem

(note: this was tested on a test project meant to stress CocoaPods, and may not be representative of the average project that utilizes CocoaPods)

#### Before

Total allocated: 12547967800 bytes (**11.69 GB**)
Total retained:  14801813 bytes  (**14.8 MB**)

#### After

Total allocated: 6329712267 bytes (12363884 objects) (**5.9 GB**)
Total retained:  14801970 bytes (171337 objects) (**14.8 MB**)

##

Although total retained remains the same, total allocated was cut almost in half

cc @segiddins 
