### PR TITLE
Fix for #7546 Can not strip the frameworks in project with single quote in the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7883](https://github.com/CocoaPods/CocoaPods/pull/7883)
   
+* Can not strip the frameworks in project with single quote in the name   
+  [Paolo Carollo](https://github.com/pcarollo84)
+  [#7546](https://github.com/CocoaPods/CocoaPods/issues/7546)
+
 * Set `CURRENT_PROJECT_VERSION` for generated app host targets  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7825](https://github.com/CocoaPods/CocoaPods/pull/7825)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -152,7 +152,13 @@ module Pod
             if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identitiy
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
-              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements '$1'"
+              # Save the param into a var  
+              local non_escaped_destination=$1
+              # Replace all the occurence of `'` with `'\''` to escape it
+              match="'"
+              replace="'\''"
+              escaped_destination=${non_escaped_destination/$match/$replace}
+              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements '$escaped_destination'"
 
               if [ "${COCOAPODS_PARALLEL_CODE_SIGN}" == "true" ]; then
                 code_sign_cmd="$code_sign_cmd &"

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -194,6 +194,16 @@ describe_cli 'pod' do
                             'install --no-repo-update'
     end
 
+    describe 'Integrates a project with single quoted name with CocoaPods' do
+      behaves_like cli_spec 'install_new_with_single_quoted_project_name',
+                            'install --no-repo-update'
+    end
+
+    describe 'Integrates a project with single quoted name and spaces with CocoaPods' do
+      behaves_like cli_spec 'install_new_with_single_quoted_and_spaces_project_name',
+                            'install --no-repo-update'
+    end
+
     describe 'Adds a Pod to an existing installation' do
       behaves_like cli_spec 'install_add_pod',
                             'install --no-repo-update'


### PR DESCRIPTION
 🌈 
When code signing there wasn't any escaping for the framework path. If the path contained a single quote it fails with the following error
``` bash
.../Pods/Target Support Files/Pods-campusM/Pods-campusM-frameworks.sh: eval: line 113: unexpected EOF while looking for matching `''
```
as mentioned on issue #7546 

I fixed replacing the single quote `'` with `'\''` as mentioned on this answer on [stack overflow](https://stackoverflow.com/questions/32122586/curl-escape-single-quote) directly in the shell script. 
I didn't find any similar unit test available for this PR. 
But if there are please let me know which and I will happily write relevant unit tests. 
 