### PR TITLE
Extract app host out of pod target installation

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -4,12 +4,14 @@ module Pod
       # The {PodsProjectGenerator} handles generation of the 'Pods/Pods.xcodeproj'
       #
       class PodsProjectGenerator
+        require 'cocoapods/installer/xcode/pods_project_generator/target_installer_helper'
         require 'cocoapods/installer/xcode/pods_project_generator/pod_target_integrator'
         require 'cocoapods/installer/xcode/pods_project_generator/target_installer'
         require 'cocoapods/installer/xcode/pods_project_generator/target_installation_result'
         require 'cocoapods/installer/xcode/pods_project_generator/pod_target_installer'
         require 'cocoapods/installer/xcode/pods_project_generator/file_references_installer'
         require 'cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer'
+        require 'cocoapods/installer/xcode/pods_project_generator/app_host_installer'
 
         # @return [Sandbox] The sandbox where the Pods should be installed.
         #
@@ -63,9 +65,10 @@ module Pod
         def generate!
           prepare
           install_file_references
-          @target_installation_results = install_libraries
+          @target_installation_results = install_targets
           integrate_targets(@target_installation_results.pod_target_installation_results)
-          wire_target_dependencies(@target_installation_results)
+          app_hosts_by_host_key = install_app_hosts
+          wire_target_dependencies(@target_installation_results, app_hosts_by_host_key)
           @target_installation_results
         end
 
@@ -114,6 +117,7 @@ module Pod
 
         private
 
+        AppHostKey = Struct.new(:test_type, :platform)
         InstallationResults = Struct.new(:pod_target_installation_results, :aggregate_target_installation_results)
 
         def create_project
@@ -175,7 +179,7 @@ module Pod
           installer.install!
         end
 
-        def install_libraries
+        def install_targets
           UI.message '- Installing targets' do
             umbrella_headers_by_dir = pod_targets.map do |pod_target|
               next unless pod_target.should_build? && pod_target.defines_module?
@@ -200,6 +204,36 @@ module Pod
             end]
 
             InstallationResults.new(pod_target_installation_results, aggregate_target_installation_results)
+          end
+        end
+
+        def install_app_hosts
+          pod_target_with_test_specs = pod_targets.reject do |pod_target|
+            pod_target.test_specs.empty? || pod_target.test_spec_consumers.none?(&:requires_app_host?)
+          end
+
+          return if pod_target_with_test_specs.empty?
+
+          UI.message '- Installing app hosts' do
+            app_host_keys = pod_target_with_test_specs.flat_map do |pod_target|
+              pod_target.supported_test_types.flat_map do |test_type|
+                AppHostKey.new(test_type, pod_target.platform)
+              end.uniq
+            end
+
+            app_host_keys_by_test_type = app_host_keys.group_by do |app_host_key|
+              [app_host_key.test_type, app_host_key.platform.symbolic_name]
+            end
+
+            app_host_keys_by_test_type.map do |(test_type, platform_symbol), keys|
+              deployment_target = keys.map { |k| k.platform.deployment_target }.max
+              platform = Platform.new(platform_symbol, deployment_target)
+              AppHostKey.new(test_type, platform)
+            end
+
+            Hash[app_host_keys.map do |app_host_key|
+              [app_host_key, AppHostInstaller.new(sandbox, project, app_host_key.platform, app_host_key.test_type).install!]
+            end]
           end
         end
 
@@ -239,9 +273,12 @@ module Pod
         #         the installation results that were produced when all targets were installed. This includes
         #         pod target installation results and aggregate target installation results.
         #
+        # @param  [Hash{AppHostKey=>Array<PBXNativeTarget>}] app_hosts_by_host_key
+        #         the app hosts by test type that were installed in #install_app_hosts
+        #
         # @return [void]
         #
-        def wire_target_dependencies(target_installation_results)
+        def wire_target_dependencies(target_installation_results, app_hosts_by_host_key)
           frameworks_group = project.frameworks_group
           pod_target_installation_results_hash = target_installation_results.pod_target_installation_results
           aggregate_target_installation_results_hash = target_installation_results.aggregate_target_installation_results
@@ -294,10 +331,13 @@ module Pod
                   end
                   test_native_target.add_dependency(dependency_installation_result.native_target)
                   add_framework_file_reference_to_native_target(test_native_target, pod_target, test_dependent_target, frameworks_group)
-                  test_spec_consumers = test_specs.map { |test_spec| test_spec.consumer(pod_target.platform) }
-                  if test_spec_consumers.any?(&:requires_app_host?)
-                    app_host_target = project.targets.find { |t| t.name == pod_target.app_host_label(test_specs.first.test_type) }
-                    test_native_target.add_dependency(app_host_target)
+                  # Wire app host dependencies to test native target
+                  if pod_target.test_spec_consumers.any?(&:requires_app_host?)
+                    pod_target.supported_test_types.each do |test_type|
+                      app_host_target = app_hosts_by_host_key[AppHostKey.new(test_type, pod_target.platform)]
+                      test_native_target.add_dependency(app_host_target)
+                      configure_app_host_to_native_target(app_host_target, test_native_target)
+                    end
                   end
                 end
               end
@@ -357,6 +397,18 @@ module Pod
           native_target.build_configurations.each do |config|
             config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'YES'
           end
+        end
+
+        def configure_app_host_to_native_target(app_host_target, test_native_target)
+          test_native_target.build_configurations.each do |configuration|
+            test_host = "$(BUILT_PRODUCTS_DIR)/#{app_host_target.name}.app/"
+            test_host << 'Contents/MacOS/' if app_host_target.platform_name == :osx
+            test_host << app_host_target.name.to_s
+            configuration.build_settings['TEST_HOST'] = test_host
+          end
+          target_attributes = project.root_object.attributes['TargetAttributes'] || {}
+          target_attributes[test_native_target.uuid.to_s] = { 'TestTargetID' => app_host_target.uuid.to_s }
+          project.root_object.attributes['TargetAttributes'] = target_attributes
         end
       end
     end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
@@ -1,0 +1,84 @@
+module Pod
+  class Installer
+    class Xcode
+      class PodsProjectGenerator
+        # Installs an app host target to a given project.
+        #
+        class AppHostInstaller
+          include TargetInstallerHelper
+
+          # @return [Sandbox] sandbox
+          #         The sandbox used for this installation.
+          #
+          attr_reader :sandbox
+
+          # @return [Pod::Project]
+          #         The `Pods/Pods.xcodeproj` to install the app host into.
+          #
+          attr_reader :project
+
+          # @return [Platform] the platform to use for this app host.
+          #
+          attr_reader :platform
+
+          # @return [Symbol] the test type this app host is going to be used for.
+          #
+          attr_reader :test_type
+
+          # Initialize a new instance
+          #
+          # @param [Sandbox] sandbox @see #sandbox
+          # @param [Pod::Project] project @see #project
+          # @param [Platform] platform @see #platform
+          # @param [Symbol] test_type @see #test_type
+          #
+          def initialize(sandbox, project, platform, test_type)
+            @sandbox = sandbox
+            @project = project
+            @platform = platform
+            @test_type = test_type
+          end
+
+          # @return [PBXNativeTarget] the app host native target that was installed.
+          #
+          def install!
+            name = app_host_label
+            platform_name = platform.name
+            app_host_target = Pod::Generator::AppTargetHelper.add_app_target(project, platform_name, deployment_target,
+                                                                             name)
+            app_host_target.build_configurations.each do |configuration|
+              configuration.build_settings['PRODUCT_NAME'] = name
+              configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+              configuration.build_settings['CODE_SIGN_IDENTITY'] = '' if platform == :osx
+              configuration.build_settings['CURRENT_PROJECT_VERSION'] = '1'
+            end
+            Pod::Generator::AppTargetHelper.add_app_host_main_file(project, app_host_target, platform_name, name)
+            create_info_plist_file_with_sandbox(sandbox, app_host_info_plist_path, app_host_target, '1.0.0', platform, :appl)
+            project[name].new_file(app_host_info_plist_path)
+            app_host_target
+          end
+
+          private
+
+          # @return [Pathname] The absolute path of the Info.plist to use for an app host.
+          #
+          def app_host_info_plist_path
+            project.path.dirname.+("#{app_host_label}/#{app_host_label}-Info.plist")
+          end
+
+          # @return [String] The label of the app host label to use given the platform and test type.
+          #
+          def app_host_label
+            "AppHost-#{Platform.string_name(platform.symbolic_name)}-#{test_type.capitalize}-Tests"
+          end
+
+          # @return [String] The deployment target.
+          #
+          def deployment_target
+            platform.deployment_target.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -33,11 +33,6 @@ module Pod
           #
           attr_reader :test_resource_bundle_targets
 
-          # @return [Array<PBXNativeTarget>] test_app_host_targets
-          #         The test app host native targets that were produced for this target. Can be empty.
-          #
-          attr_reader :test_app_host_targets
-
           # Initialize a new instance
           #
           # @param [Target] target @see #target
@@ -45,16 +40,14 @@ module Pod
           # @param [Array<PBXNativeTarget>] resource_bundle_targets @see #resource_bundle_targets
           # @param [Array<PBXNativeTarget>] test_native_targets @see #test_native_targets
           # @param [Hash{String=>Array<PBXNativeTarget>}] test_resource_bundle_targets @see #test_resource_bundle_targets
-          # @param [Array<PBXNativeTarget>] test_app_host_targets @see #test_app_host_targets
           #
           def initialize(target, native_target, resource_bundle_targets = [], test_native_targets = [],
-                         test_resource_bundle_targets = {}, test_app_host_targets = [])
+                         test_resource_bundle_targets = {})
             @target = target
             @native_target = native_target
             @resource_bundle_targets = resource_bundle_targets
             @test_native_targets = test_native_targets
             @test_resource_bundle_targets = test_resource_bundle_targets
-            @test_app_host_targets = test_app_host_targets
           end
 
           # Returns the corresponding native target to use based on the provided specification.

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer_helper.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer_helper.rb
@@ -1,0 +1,68 @@
+module Pod
+  class Installer
+    class Xcode
+      class PodsProjectGenerator
+        module TargetInstallerHelper
+          # @param [Generator] generator
+          #        the generator to use for generating the content.
+          #
+          # @param [Pathname] path
+          #        the pathname to save the content into.
+          #
+          # Saves the content the provided path unless the path exists and the contents are exactly the same.
+          #
+          def update_changed_file(generator, path)
+            if path.exist?
+              contents = generator.generate.to_s
+              content_stream = StringIO.new(contents)
+              identical = File.open(path, 'rb') { |f| FileUtils.compare_stream(f, content_stream) }
+              return if identical
+
+              File.open(path, 'w') { |f| f.write(contents) }
+            else
+              path.dirname.mkpath
+              generator.save_as(path)
+            end
+          end
+
+          # Creates the Info.plist file which sets public framework attributes
+          #
+          # @param  [Sandbox] sandbox @see #sandbox
+          #         The sandbox where the generated Info.plist file should be saved.
+          #
+          # @param  [Pathname] path
+          #         the path to save the generated Info.plist file.
+          #
+          # @param  [PBXNativeTarget] native_target
+          #         the native target to link the generated Info.plist file into.
+          #
+          # @param  [Version] version
+          #         the version to use for when generating this Info.plist file.
+          #
+          # @param  [Platform] platform
+          #         the platform to use for when generating this Info.plist file.
+          #
+          # @param  [Symbol] bundle_package_type
+          #         the CFBundlePackageType of the target this Info.plist file is for.
+          #
+          # @return [void]
+          #
+          def create_info_plist_file_with_sandbox(sandbox, path, native_target, version, platform, bundle_package_type = :fmwk)
+            UI.message "- Generating Info.plist file at #{UI.path(path)}" do
+              generator = Generator::InfoPlistFile.new(version, platform, bundle_package_type)
+              update_changed_file(generator, path)
+
+              relative_path_string = path.relative_path_from(sandbox.root).to_s
+              native_target.build_configurations.each do |c|
+                c.build_settings['INFOPLIST_FILE'] = relative_path_string
+              end
+            end
+          end
+
+          module_function :update_changed_file
+          module_function :create_info_plist_file_with_sandbox
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -53,7 +53,7 @@ module Pod
     # @param [Boolean] host_requires_frameworks @see Target#host_requires_frameworks
     # @param [Hash{String=>Symbol}] user_build_configurations @see Target#user_build_configurations
     # @param [Array<String>] archs @see Target#archs
-    # @param [Platform] platform @see #platform
+    # @param [Platform] platform @see Target#platform
     # @param [Array<TargetDefinition>] target_definitions @see #target_definitions
     # @param [Array<Sandbox::FileAccessor>] file_accessors @see #file_accessors
     # @param [String] scope_suffix @see #scope_suffix
@@ -157,6 +157,13 @@ module Pod
     #
     def spec_consumers
       specs.map { |spec| spec.consumer(platform) }
+    end
+
+    # @return [Array<Specification::Consumer>] the test specification consumers for
+    #         the target.
+    #
+    def test_spec_consumers
+      test_specs.map { |test_spec| test_spec.consumer(platform) }
     end
 
     # @return [Boolean] Whether the target uses Swift code.
@@ -356,15 +363,6 @@ module Pod
     #
     def test_target_label(test_type)
       "#{label}-#{test_type.capitalize}-Tests"
-    end
-
-    # @param  [Symbol] test_type
-    #         The test type to use for producing the test label.
-    #
-    # @return [String] The label of the app host label to use given the platform and test type.
-    #
-    def app_host_label(test_type)
-      "AppHost-#{Platform.string_name(platform.symbolic_name)}-#{test_type.capitalize}-Tests"
     end
 
     # @param  [Symbol] test_type

--- a/spec/fixtures/watermelon-lib/WatermelonLib.podspec
+++ b/spec/fixtures/watermelon-lib/WatermelonLib.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   }
   
   s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.11'
 
   s.source_files        = 'Classes/*.{h,m}'
 
@@ -22,6 +23,7 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'SnapshotTests' do |test_spec|
+    test_spec.requires_app_host = true
     test_spec.source_files = 'SnapshotTests/*.{h,m}'
     test_spec.dependency 'iOSSnapshotTestCase/Core'
   end

--- a/spec/unit/installer/xcode/pods_project_generator/app_host_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/app_host_installer_spec.rb
@@ -1,0 +1,52 @@
+require File.expand_path('../../../../../spec_helper', __FILE__)
+
+module Pod
+  class Installer
+    class Xcode
+      class PodsProjectGenerator
+        describe AppHostInstaller do
+          before do
+            @project = Project.new(config.sandbox.project_path)
+            config.sandbox.project = @project
+          end
+
+          it 'correctly installs an iOS app host target to the project' do
+            installer = AppHostInstaller.new(config.sandbox, @project, Platform.ios, :unit)
+            installer.install!
+            @project.targets.map(&:name).sort.should == ['AppHost-iOS-Unit-Tests']
+          end
+
+          it 'correctly installs an OSX app host target to the project' do
+            installer = AppHostInstaller.new(config.sandbox, @project, Platform.osx, :unit)
+            installer.install!
+            @project.targets.map(&:name).sort.should == ['AppHost-macOS-Unit-Tests']
+          end
+
+          it 'sets the correct build settings for an iOS app host target' do
+            installer = AppHostInstaller.new(config.sandbox, @project, Platform.ios, :unit)
+            app_host_target = installer.install!
+            build_settings = app_host_target.build_configurations.map(&:build_settings)
+            build_settings.each do |build_setting|
+              build_setting['PRODUCT_NAME'].should == 'AppHost-iOS-Unit-Tests'
+              build_setting['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+              build_setting['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
+              build_setting['CURRENT_PROJECT_VERSION'].should == '1'
+            end
+          end
+
+          it 'sets the correct build settings for an OSX app host target' do
+            installer = AppHostInstaller.new(config.sandbox, @project, Platform.osx, :unit)
+            app_host_target = installer.install!
+            build_settings = app_host_target.build_configurations.map(&:build_settings)
+            build_settings.each do |build_setting|
+              build_setting['PRODUCT_NAME'].should == 'AppHost-macOS-Unit-Tests'
+              build_setting['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+              build_setting['CODE_SIGN_IDENTITY'].should.be.empty
+              build_setting['CURRENT_PROJECT_VERSION'].should == '1'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -30,7 +30,8 @@ module Pod
               end
 
               user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
-              @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '4.3'), [@spec], [@target_definition], [file_accessor])
+              @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [],
+                                          Platform.new(:ios, '4.3'), [@spec], [@target_definition], [file_accessor])
               @installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
               @spec.prefix_header_contents = '#import "BlocksKit.h"'
@@ -165,7 +166,8 @@ module Pod
                 @coconut_spec = fixture_spec('coconut-lib/CoconutLib.podspec')
 
                 # Add sources to the project.
-                file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('coconut-lib')), @coconut_spec.consumer(:ios))
+                file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('coconut-lib')),
+                                                          @coconut_spec.consumer(:ios))
                 @project.add_pod_group('CoconutLib', fixture('coconut-lib'))
                 group = @project.group_for_spec('CoconutLib')
                 file_accessor.source_files.each do |file|
@@ -176,7 +178,8 @@ module Pod
                 end
 
                 # Add test sources to the project.
-                test_file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('coconut-lib')), @coconut_spec.test_specs.first.consumer(:ios))
+                test_file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('coconut-lib')),
+                                                               @coconut_spec.test_specs.first.consumer(:ios))
                 @project.add_pod_group('CoconutLibTests', fixture('coconut-lib'))
                 group = @project.group_for_spec('CoconutLibTests')
                 test_file_accessor.source_files.each do |file|
@@ -189,9 +192,13 @@ module Pod
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
                 all_specs = [@coconut_spec, *@coconut_spec.recursive_subspecs]
                 file_accessors = [file_accessor, test_file_accessor]
-                @coconut_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:ios, '6.0'), all_specs, [@target_definition], file_accessors)
+                @coconut_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [],
+                                                    Platform.new(:ios, '6.0'), all_specs, [@target_definition],
+                                                    file_accessors)
                 @installer = PodTargetInstaller.new(config.sandbox, @project, @coconut_pod_target)
-                @coconut_pod_target2 = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.new(:osx, '10.8'), all_specs, [@target_definition2], file_accessors)
+                @coconut_pod_target2 = PodTarget.new(config.sandbox, false, user_build_configurations, [],
+                                                     Platform.new(:osx, '10.8'), all_specs, [@target_definition2],
+                                                     file_accessors)
                 @installer2 = PodTargetInstaller.new(config.sandbox, @project, @coconut_pod_target2)
               end
 
@@ -344,61 +351,6 @@ module Pod
                   eos
                 end
               end
-
-              describe 'app host generation' do
-                before do
-                  @coconut_spec.test_specs.first.requires_app_host = true
-                end
-
-                it 'creates and links app host with an iOS test native target' do
-                  @installer.install!
-                  @project.targets.count.should == 3
-                  app_host_target = @project.targets[2]
-                  app_host_target.name.should == 'AppHost-iOS-Unit-Tests'
-                  app_host_target.symbol_type.should == :application
-                  app_host_target.build_configurations.each do |bc|
-                    bc.build_settings['PRODUCT_NAME'].should == 'AppHost-iOS-Unit-Tests'
-                    bc.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
-                    bc.build_settings['CURRENT_PROJECT_VERSION'].should == '1'
-                  end
-                  test_native_target = @project.targets[1]
-                  test_native_target.build_configurations.each do |bc|
-                    bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-iOS-Unit-Tests.app/AppHost-iOS-Unit-Tests'
-                  end
-                  @project.root_object.attributes['TargetAttributes'].should == {
-                    test_native_target.uuid.to_s => {
-                      'TestTargetID' => app_host_target.uuid.to_s,
-                    },
-                  }
-                end
-
-                it 'creates and links app host with an OSX test native target' do
-                  @installer2.install!
-                  @project.targets.count.should == 3
-                  app_host_target = @project.targets[2]
-                  app_host_target.name.should == 'AppHost-macOS-Unit-Tests'
-                  app_host_target.symbol_type.should == :application
-                  app_host_target.build_configurations.each do |bc|
-                    bc.build_settings['PRODUCT_NAME'].should == 'AppHost-macOS-Unit-Tests'
-                    bc.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
-                    bc.build_settings['CURRENT_PROJECT_VERSION'].should == '1'
-                  end
-                  test_native_target = @project.targets[1]
-                  test_native_target.build_configurations.each do |bc|
-                    bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-macOS-Unit-Tests.app/Contents/MacOS/AppHost-macOS-Unit-Tests'
-                  end
-                  @project.root_object.attributes['TargetAttributes'].should == {
-                    test_native_target.uuid.to_s => {
-                      'TestTargetID' => app_host_target.uuid.to_s,
-                    },
-                  }
-                end
-
-                it 'returns correct app host info plist path for test type' do
-                  expected = 'Pods/AppHost/AppHost-iOS-Unit-Tests-Info.plist'
-                  @installer.send(:app_host_info_plist_path_for_test_type, 'AppHost', :unit).to_s.should.include expected
-                end
-              end
             end
 
             describe 'test other files under sources' do
@@ -424,7 +376,9 @@ module Pod
                 end
 
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
-                @minions_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, [@minions_spec, *@minions_spec.recursive_subspecs], [@target_definition], [file_accessor])
+                @minions_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios,
+                                                    [@minions_spec, *@minions_spec.recursive_subspecs],
+                                                    [@target_definition], [file_accessor])
                 @installer = PodTargetInstaller.new(config.sandbox, @project, @minions_pod_target)
 
                 @first_json_file = file_accessor.source_files.find { |sf| sf.extname == '.json' }
@@ -534,7 +488,8 @@ module Pod
                 end
 
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
-                @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, [@spec], [@target_definition], [file_accessor])
+                @pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios,
+                                            [@spec], [@target_definition], [file_accessor])
                 @installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
               end
 
@@ -829,7 +784,8 @@ module Pod
               before do
                 @project.add_pod_group('snake', fixture('snake'))
 
-                @pod_target = fixture_pod_target('snake/snake.podspec', false, { 'Debug' => :debug, 'Release' => :release }, [@target_definition])
+                @pod_target = fixture_pod_target('snake/snake.podspec', false,
+                                                 { 'Debug' => :debug, 'Release' => :release }, [@target_definition])
                 @pod_target.stubs(:requires_frameworks? => true)
                 group = @project.group_for_spec('snake')
                 @pod_target.file_accessors.first.source_files.each do |file|
@@ -1013,7 +969,9 @@ module Pod
                 target_installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
                 # Use a file references installer to add the files so that the correct ones are added.
-                file_ref_installer = Installer::Xcode::PodsProjectGenerator::FileReferencesInstaller.new(config.sandbox, [@pod_target], @project)
+                file_ref_installer = Installer::Xcode::PodsProjectGenerator::FileReferencesInstaller.new(config.sandbox,
+                                                                                                         [@pod_target],
+                                                                                                         @project)
                 file_ref_installer.install!
 
                 target_installer.install!
@@ -1071,7 +1029,9 @@ module Pod
                 target_installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
                 # Use a file references installer to add the files so that the correct ones are added.
-                file_ref_installer = Installer::Xcode::PodsProjectGenerator::FileReferencesInstaller.new(config.sandbox, [@pod_target], @project)
+                file_ref_installer = Installer::Xcode::PodsProjectGenerator::FileReferencesInstaller.new(config.sandbox,
+                                                                                                         [@pod_target],
+                                                                                                         @project)
                 file_ref_installer.install!
 
                 target_installer.install!

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -517,10 +517,6 @@ module Pod
           @test_pod_target.test_target_label(:unit).should == 'CoconutLib-Unit-Tests'
         end
 
-        it 'returns app host label based on test type' do
-          @test_pod_target.app_host_label(:unit).should == 'AppHost-iOS-Unit-Tests'
-        end
-
         it 'returns the correct product type for test type' do
           @test_pod_target.product_type_for_test_type(:unit).should == :unit_test_bundle
         end


### PR DESCRIPTION
`pod_target_installer.rb` is becoming too big and since we are using only one app host per test type it does not make sense to keep it within `pod_target_installer`. We also had to debounce to prevent adding an app host many times.