### PR TITLE
One-to-one test spec support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Every test spec will have its own xctest bundle  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)  
+  [Jenn Kaplan](https://github.com/jkap)
+  [#7908](https://github.com/CocoaPods/CocoaPods/pull/7908)
+
 * Add default launch screen storyboard to test app hosts  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7971](https://github.com/CocoaPods/CocoaPods/pull/7971)

--- a/examples/multiple test specs Example/Examples.xcworkspace/contents.xcworkspacedata
+++ b/examples/multiple test specs Example/Examples.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:InstallMultipleTestSpecs.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/multiple test specs Example/Examples.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/multiple test specs Example/Examples.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/project.pbxproj
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/project.pbxproj
@@ -1,0 +1,398 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B879B3CBD34B287EC0F2D1E7 /* Pods_InstallMultipleTestSpecs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44177AEE8E3E99F22F8EC9A6 /* Pods_InstallMultipleTestSpecs.framework */; };
+		CF4250802118CCEA0068701E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF42507F2118CCEA0068701E /* AppDelegate.swift */; };
+		CF4250822118CCEA0068701E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4250812118CCEA0068701E /* ViewController.swift */; };
+		CF4250852118CCEA0068701E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CF4250832118CCEA0068701E /* Main.storyboard */; };
+		CF4250872118CCEC0068701E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CF4250862118CCEC0068701E /* Assets.xcassets */; };
+		CF42508A2118CCEC0068701E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CF4250882118CCEC0068701E /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		44177AEE8E3E99F22F8EC9A6 /* Pods_InstallMultipleTestSpecs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_InstallMultipleTestSpecs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DDF1EC394A604DB5236E71E /* Pods-InstallMultipleTestSpecs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InstallMultipleTestSpecs.debug.xcconfig"; path = "Pods/Target Support Files/Pods-InstallMultipleTestSpecs/Pods-InstallMultipleTestSpecs.debug.xcconfig"; sourceTree = "<group>"; };
+		BAFE6AA205AECA4FFCF85AB2 /* Pods-InstallMultipleTestSpecs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InstallMultipleTestSpecs.release.xcconfig"; path = "Pods/Target Support Files/Pods-InstallMultipleTestSpecs/Pods-InstallMultipleTestSpecs.release.xcconfig"; sourceTree = "<group>"; };
+		CF42507C2118CCEA0068701E /* InstallMultipleTestSpecs.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InstallMultipleTestSpecs.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CF42507F2118CCEA0068701E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		CF4250812118CCEA0068701E /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		CF4250842118CCEA0068701E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		CF4250862118CCEC0068701E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		CF4250892118CCEC0068701E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		CF42508B2118CCEC0068701E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CF4250792118CCEA0068701E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B879B3CBD34B287EC0F2D1E7 /* Pods_InstallMultipleTestSpecs.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		14B54DD6C283C89D8DA0CA1A /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6DDF1EC394A604DB5236E71E /* Pods-InstallMultipleTestSpecs.debug.xcconfig */,
+				BAFE6AA205AECA4FFCF85AB2 /* Pods-InstallMultipleTestSpecs.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		CF4250732118CCEA0068701E = {
+			isa = PBXGroup;
+			children = (
+				CF42507E2118CCEA0068701E /* InstallMultipleTestSpecs */,
+				CF42507D2118CCEA0068701E /* Products */,
+				14B54DD6C283C89D8DA0CA1A /* Pods */,
+				DB4C7A6986CB58AECBE8E96B /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		CF42507D2118CCEA0068701E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CF42507C2118CCEA0068701E /* InstallMultipleTestSpecs.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CF42507E2118CCEA0068701E /* InstallMultipleTestSpecs */ = {
+			isa = PBXGroup;
+			children = (
+				CF42507F2118CCEA0068701E /* AppDelegate.swift */,
+				CF4250812118CCEA0068701E /* ViewController.swift */,
+				CF4250832118CCEA0068701E /* Main.storyboard */,
+				CF4250862118CCEC0068701E /* Assets.xcassets */,
+				CF4250882118CCEC0068701E /* LaunchScreen.storyboard */,
+				CF42508B2118CCEC0068701E /* Info.plist */,
+			);
+			path = InstallMultipleTestSpecs;
+			sourceTree = "<group>";
+		};
+		DB4C7A6986CB58AECBE8E96B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				44177AEE8E3E99F22F8EC9A6 /* Pods_InstallMultipleTestSpecs.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CF42507B2118CCEA0068701E /* InstallMultipleTestSpecs */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CF42508E2118CCEC0068701E /* Build configuration list for PBXNativeTarget "InstallMultipleTestSpecs" */;
+			buildPhases = (
+				177C1304A99BAF33CE8411C0 /* [CP] Check Pods Manifest.lock */,
+				CF4250782118CCEA0068701E /* Sources */,
+				CF4250792118CCEA0068701E /* Frameworks */,
+				CF42507A2118CCEA0068701E /* Resources */,
+				D24992570CC3CD3EE866808F /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InstallMultipleTestSpecs;
+			productName = InstallMultipleTestSpecs;
+			productReference = CF42507C2118CCEA0068701E /* InstallMultipleTestSpecs.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CF4250742118CCEA0068701E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0940;
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = CocoaPods;
+				TargetAttributes = {
+					CF42507B2118CCEA0068701E = {
+						CreatedOnToolsVersion = 9.4.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = CF4250772118CCEA0068701E /* Build configuration list for PBXProject "InstallMultipleTestSpecs" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CF4250732118CCEA0068701E;
+			productRefGroup = CF42507D2118CCEA0068701E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CF42507B2118CCEA0068701E /* InstallMultipleTestSpecs */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CF42507A2118CCEA0068701E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CF42508A2118CCEC0068701E /* LaunchScreen.storyboard in Resources */,
+				CF4250872118CCEC0068701E /* Assets.xcassets in Resources */,
+				CF4250852118CCEA0068701E /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		177C1304A99BAF33CE8411C0 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-InstallMultipleTestSpecs-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D24992570CC3CD3EE866808F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-InstallMultipleTestSpecs/Pods-InstallMultipleTestSpecs-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/TestLib/TestLib.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TestLib.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-InstallMultipleTestSpecs/Pods-InstallMultipleTestSpecs-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CF4250782118CCEA0068701E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CF4250822118CCEA0068701E /* ViewController.swift in Sources */,
+				CF4250802118CCEA0068701E /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		CF4250832118CCEA0068701E /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CF4250842118CCEA0068701E /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		CF4250882118CCEC0068701E /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CF4250892118CCEC0068701E /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		CF42508C2118CCEC0068701E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CF42508D2118CCEC0068701E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CF42508F2118CCEC0068701E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6DDF1EC394A604DB5236E71E /* Pods-InstallMultipleTestSpecs.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = InstallMultipleTestSpecs/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.InstallMultipleTestSpecs;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CF4250902118CCEC0068701E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BAFE6AA205AECA4FFCF85AB2 /* Pods-InstallMultipleTestSpecs.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = InstallMultipleTestSpecs/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.InstallMultipleTestSpecs;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CF4250772118CCEA0068701E /* Build configuration list for PBXProject "InstallMultipleTestSpecs" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CF42508C2118CCEC0068701E /* Debug */,
+				CF42508D2118CCEC0068701E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CF42508E2118CCEC0068701E /* Build configuration list for PBXNativeTarget "InstallMultipleTestSpecs" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CF42508F2118CCEC0068701E /* Debug */,
+				CF4250902118CCEC0068701E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CF4250742118CCEA0068701E /* Project object */;
+}

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/xcshareddata/xcschemes/InstallMultipleTestSpecs.xcscheme
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/xcshareddata/xcschemes/InstallMultipleTestSpecs.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CF42507B2118CCEA0068701E"
+               BuildableName = "InstallMultipleTestSpecs.app"
+               BlueprintName = "InstallMultipleTestSpecs"
+               ReferencedContainer = "container:InstallMultipleTestSpecs.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CF42507B2118CCEA0068701E"
+            BuildableName = "InstallMultipleTestSpecs.app"
+            BlueprintName = "InstallMultipleTestSpecs"
+            ReferencedContainer = "container:InstallMultipleTestSpecs.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CF42507B2118CCEA0068701E"
+            BuildableName = "InstallMultipleTestSpecs.app"
+            BlueprintName = "InstallMultipleTestSpecs"
+            ReferencedContainer = "container:InstallMultipleTestSpecs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CF42507B2118CCEA0068701E"
+            BuildableName = "InstallMultipleTestSpecs.app"
+            BlueprintName = "InstallMultipleTestSpecs"
+            ReferencedContainer = "container:InstallMultipleTestSpecs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/xcshareddata/xcschemes/TestLib.xcscheme
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/xcshareddata/xcschemes/TestLib.xcscheme
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "32328E3245A87C76B61535CFF79937B7"
+               BuildableName = "TestLib.framework"
+               BlueprintName = "TestLib"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7F88B8209C145950A6760F859CA79F25"
+               BuildableName = "TestLib-Unit-UnitTests1.xctest"
+               BlueprintName = "TestLib-Unit-UnitTests1"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CA1257880D5712CC7CCCE797AD9C8298"
+               BuildableName = "TestLib-Unit-UnitTests2.xctest"
+               BlueprintName = "TestLib-Unit-UnitTests2"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32328E3245A87C76B61535CFF79937B7"
+            BuildableName = "TestLib.framework"
+            BlueprintName = "TestLib"
+            ReferencedContainer = "container:Pods/Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32328E3245A87C76B61535CFF79937B7"
+            BuildableName = "TestLib.framework"
+            BlueprintName = "TestLib"
+            ReferencedContainer = "container:Pods/Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32328E3245A87C76B61535CFF79937B7"
+            BuildableName = "TestLib.framework"
+            BlueprintName = "TestLib"
+            ReferencedContainer = "container:Pods/Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/AppDelegate.swift
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  InstallMultipleTestSpecs
+//
+//  Created by Jenn Kaplan on 8/6/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/Assets.xcassets/Contents.json
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/Base.lproj/LaunchScreen.storyboard
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/Base.lproj/Main.storyboard
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/Info.plist
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs/ViewController.swift
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  InstallMultipleTestSpecs
+//
+//  Created by Jenn Kaplan on 8/6/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/examples/multiple test specs Example/Podfile
+++ b/examples/multiple test specs Example/Podfile
@@ -1,0 +1,13 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '10.0'
+
+workspace 'Examples'
+
+target 'InstallMultipleTestSpecs' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for InstallMultipleTestSpecs
+  pod 'TestLib', :path => 'TestLib', :testspecs => %w[UnitTests1 UnitTests2]
+
+end

--- a/examples/multiple test specs Example/TestLib/TestLib.podspec
+++ b/examples/multiple test specs Example/TestLib/TestLib.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name             = 'TestLib'
+  s.version          = '0.1.0'
+  s.summary          = 'A short description of TestLib.'
+  s.ios.deployment_target = '10.0'
+  s.author           = { 'Jeff Overwatch' => 'jeff@overwatch.com' }
+  s.homepage         = "https://github.com/"
+  s.license          = 'MIT'
+  s.source           = { :git => "https://github.com/<GITHUB_USERNAME>/TestLib.git", :tag => s.version.to_s }
+
+  s.source_files = 'TestLib/Classes/**/*'
+
+  s.swift_version = '4'
+
+  s.test_spec 'UnitTests1' do |test_spec|
+    test_spec.source_files = 'TestLib/UnitTests1/**/*'
+  end
+
+  s.test_spec 'UnitTests2' do |test_spec|
+    test_spec.requires_app_host = true
+    test_spec.source_files = 'TestLib/UnitTests2/**/*'
+  end
+end

--- a/examples/multiple test specs Example/TestLib/TestLib/.gitignore
+++ b/examples/multiple test specs Example/TestLib/TestLib/.gitignore
@@ -1,0 +1,37 @@
+# OS X
+.DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# Bundler
+.bundle
+
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+# 
+# Note: if you ignore the Pods directory, make sure to uncomment
+# `pod install` in .travis.yml
+#
+# Pods/

--- a/examples/multiple test specs Example/TestLib/TestLib/.travis.yml
+++ b/examples/multiple test specs Example/TestLib/TestLib/.travis.yml
@@ -1,0 +1,14 @@
+# references:
+# * https://www.objc.io/issues/6-build-tools/travis-ci/
+# * https://github.com/supermarin/xcpretty#usage
+
+osx_image: xcode7.3
+language: objective-c
+# cache: cocoapods
+# podfile: Example/Podfile
+# before_install:
+# - gem install cocoapods # Since Travis is not always on latest version
+# - pod install --project-directory=Example
+script:
+- set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/TestLib.xcworkspace -scheme TestLib-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
+- pod lib lint

--- a/examples/multiple test specs Example/TestLib/TestLib/Classes/main.swift
+++ b/examples/multiple test specs Example/TestLib/TestLib/Classes/main.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+public class TestLib {
+}

--- a/examples/multiple test specs Example/TestLib/TestLib/UnitTests1/Test1.swift
+++ b/examples/multiple test specs Example/TestLib/TestLib/UnitTests1/Test1.swift
@@ -1,0 +1,14 @@
+//
+//  Test1.swift
+//  TestLib-Unit-Tests
+//
+//  Created by Jenn Kaplan on 8/6/18.
+//
+
+import XCTest
+
+class Test1: XCTestCase {    
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}

--- a/examples/multiple test specs Example/TestLib/TestLib/UnitTests2/Test2.swift
+++ b/examples/multiple test specs Example/TestLib/TestLib/UnitTests2/Test2.swift
@@ -1,0 +1,14 @@
+//
+//  Test2.swift
+//  TestLib-Unit-Tests
+//
+//  Created by Jenn Kaplan on 8/6/18.
+//
+
+import XCTest
+
+class Test2: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -108,8 +108,8 @@ module Pod
             next unless share_scheme_for_development_pod?(pod_target.pod_name)
             Xcodeproj::XCScheme.share_scheme(project.path, pod_target.label)
             if pod_target.contains_test_specifications?
-              pod_target.supported_test_types.each do |test_type|
-                Xcodeproj::XCScheme.share_scheme(project.path, pod_target.test_target_label(test_type))
+              pod_target.test_specs.each do |test_spec|
+                Xcodeproj::XCScheme.share_scheme(project.path, pod_target.test_target_label(test_spec))
               end
             end
           end
@@ -208,32 +208,32 @@ module Pod
         end
 
         def install_app_hosts
-          pod_target_with_test_specs = pod_targets.reject do |pod_target|
+          pod_targets_with_app_hosts = pod_targets.reject do |pod_target|
             pod_target.test_specs.empty? || pod_target.test_spec_consumers.none?(&:requires_app_host?)
           end
 
-          return if pod_target_with_test_specs.empty?
+          return if pod_targets_with_app_hosts.empty?
 
           UI.message '- Installing app hosts' do
-            app_host_keys = pod_target_with_test_specs.flat_map do |pod_target|
-              pod_target.supported_test_types.flat_map do |test_type|
-                AppHostKey.new(test_type, pod_target.platform)
+            pod_targets_with_app_hosts.reduce({}) do |app_hosts_by_host_key, pod_target|
+              app_host_keys = pod_target.test_spec_consumers.select(&:requires_app_host?).map do |test_spec_consumer|
+                AppHostKey.new(test_spec_consumer.test_type, pod_target.platform)
               end.uniq
-            end
 
-            app_host_keys_by_test_type = app_host_keys.group_by do |app_host_key|
-              [app_host_key.test_type, app_host_key.platform.symbolic_name]
-            end
+              app_host_keys_by_test_type = app_host_keys.group_by do |app_host_key|
+                [app_host_key.test_type, app_host_key.platform.symbolic_name]
+              end
 
-            app_host_keys_by_test_type.map do |(test_type, platform_symbol), keys|
-              deployment_target = keys.map { |k| k.platform.deployment_target }.max
-              platform = Platform.new(platform_symbol, deployment_target)
-              AppHostKey.new(test_type, platform)
-            end
+              app_host_keys_by_test_type.map do |(test_type, platform_symbol), keys|
+                deployment_target = keys.map { |k| k.platform.deployment_target }.max
+                platform = Platform.new(platform_symbol, deployment_target)
+                AppHostKey.new(test_type, platform)
+              end
 
-            Hash[app_host_keys.map do |app_host_key|
-              [app_host_key, AppHostInstaller.new(sandbox, project, app_host_key.platform, app_host_key.test_type).install!]
-            end]
+              app_hosts_by_host_key.merge Hash[app_host_keys.map do |app_host_key|
+                [app_host_key, AppHostInstaller.new(sandbox, project, app_host_key.platform, app_host_key.test_type).install!]
+              end]
+            end
           end
         end
 
@@ -326,18 +326,20 @@ module Pod
                 test_dependent_targets = test_specs.flat_map { |s| pod_target.test_dependent_targets_by_spec_name[s.name] }.compact.unshift(pod_target).uniq
                 test_dependent_targets.each do |test_dependent_target|
                   dependency_installation_result = pod_target_installation_results_hash[test_dependent_target.name]
-                  dependency_installation_result.test_resource_bundle_targets.values.flatten.each do |test_resource_bundle_target|
-                    test_native_target.add_dependency(test_resource_bundle_target)
+                  resource_bundle_native_targets = dependency_installation_result.test_resource_bundle_targets[test_specs.first.name]
+                  unless resource_bundle_native_targets.nil?
+                    resource_bundle_native_targets.each do |test_resource_bundle_target|
+                      test_native_target.add_dependency(test_resource_bundle_target)
+                    end
                   end
                   test_native_target.add_dependency(dependency_installation_result.native_target)
                   add_framework_file_reference_to_native_target(test_native_target, pod_target, test_dependent_target, frameworks_group)
                   # Wire app host dependencies to test native target
-                  if pod_target.test_spec_consumers.any?(&:requires_app_host?)
-                    pod_target.supported_test_types.each do |test_type|
-                      app_host_target = app_hosts_by_host_key[AppHostKey.new(test_type, pod_target.platform)]
-                      test_native_target.add_dependency(app_host_target)
-                      configure_app_host_to_native_target(app_host_target, test_native_target)
-                    end
+                  test_spec_consumers = test_specs.map { |test_spec| test_spec.consumer(pod_target.platform) }
+                  test_spec_consumers.select(&:requires_app_host?).each do |test_spec_consumer|
+                    app_host_target = app_hosts_by_host_key[AppHostKey.new(test_spec_consumer.test_type, pod_target.platform)]
+                    test_native_target.add_dependency(app_host_target)
+                    configure_app_host_to_native_target(app_host_target, test_native_target)
                   end
                 end
               end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -90,8 +90,8 @@ module Pod
                 create_prefix_header(path, file_accessors, target.platform, [native_target])
               end
               unless skip_pch?(target.test_specs)
-                target.supported_test_types.each do |test_type|
-                  path = target.prefix_header_path_for_test_type(test_type)
+                target.test_specs.each do |test_spec|
+                  path = target.prefix_header_path_for_test_spec(test_spec)
                   create_prefix_header(path, test_file_accessors, target.platform, test_native_targets)
                 end
               end
@@ -259,9 +259,11 @@ module Pod
           # @return [Array<PBXNativeTarget>] the test native targets created.
           #
           def add_test_targets
-            target.supported_test_types.map do |test_type|
+            target.test_specs.map do |test_spec|
+              spec_consumer = test_spec.consumer(target.platform)
+              test_type = spec_consumer.test_type
               product_type = target.product_type_for_test_type(test_type)
-              name = target.test_target_label(test_type)
+              name = target.test_target_label(test_spec)
               platform_name = target.platform.name
               language = target.uses_swift_for_test_type?(test_type) ? :swift : :objc
               test_native_target = project.new_target(product_type, name, platform_name, deployment_target, nil, language)
@@ -294,13 +296,13 @@ module Pod
               end
 
               # Test native targets also need frameworks and resources to be copied over to their xctest bundle.
-              create_test_target_embed_frameworks_script(test_type)
-              create_test_target_copy_resources_script(test_type)
+              create_test_target_embed_frameworks_script(test_spec)
+              create_test_target_copy_resources_script(test_spec)
 
               # Generate vanilla Info.plist for test target similar to the one Xcode generates for new test target.
               # This creates valid test bundle accessible at the runtime, allowing tests to load bundle resources
               # defined in podspec.
-              create_info_plist_file(target.info_plist_path_for_test_type(test_type), test_native_target, '1.0', target.platform, :bndl)
+              create_info_plist_file(target.info_plist_path_for_test_spec(test_spec), test_native_target, '1.0', target.platform, :bndl)
 
               test_native_target
             end
@@ -414,13 +416,13 @@ module Pod
             target.test_specs.each do |test_spec|
               spec_consumer = test_spec.consumer(target.platform)
               test_type = spec_consumer.test_type
-              path = target.xcconfig_path(test_type.to_s)
+              path = target.xcconfig_path("#{test_type.capitalize}-#{test_spec.name.split('/')[1..-1].join('-')}")
               update_changed_file(Target::BuildSettings::PodTargetSettings.new(target, test_spec), path)
               xcconfig_file_ref = add_file_to_support_group(path)
 
               test_native_targets.each do |test_target|
                 test_target.build_configurations.each do |test_target_bc|
-                  test_target_swift_debug_hack(test_target_bc)
+                  test_target_swift_debug_hack(test_spec, test_target_bc)
                   test_target_bc.base_configuration_reference = xcconfig_file_ref
                 end
               end
@@ -432,17 +434,18 @@ module Pod
 
           # Creates a script that copies the resources to the bundle of the test target.
           #
-          # @param [Symbol] test_type
-          #        The test type to create the script for.
+          # @param [Specification] test_spec
+          #        The test spec to create the copy resources script for.
           #
           # @return [void]
           #
-          def create_test_target_copy_resources_script(test_type)
-            path = target.copy_resources_script_path_for_test_type(test_type)
-            pod_targets = target.all_dependent_targets
+          def create_test_target_copy_resources_script(test_spec)
+            path = target.copy_resources_script_path_for_test_spec(test_spec)
+            pod_targets = target.dependent_targets_for_test_spec(test_spec)
             resource_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
               resources_by_config[config] = pod_targets.flat_map do |pod_target|
-                spec_paths_to_include = pod_target == target ? pod_target.specs.map(&:name) : pod_target.non_test_specs.map(&:name)
+                spec_paths_to_include = pod_target.non_test_specs.map(&:name)
+                spec_paths_to_include << test_spec.name if pod_target == target
                 pod_target.resource_paths.values_at(*spec_paths_to_include).flatten.compact
               end
             end
@@ -453,17 +456,18 @@ module Pod
 
           # Creates a script that embeds the frameworks to the bundle of the test target.
           #
-          # @param [Symbol] test_type
-          #        The test type to create the script for.
+          # @param [Specification] test_spec
+          #        The test spec to create the embed frameworks script for.
           #
           # @return [void]
           #
-          def create_test_target_embed_frameworks_script(test_type)
-            path = target.embed_frameworks_script_path_for_test_type(test_type)
-            pod_targets = target.all_dependent_targets
+          def create_test_target_embed_frameworks_script(test_spec)
+            path = target.embed_frameworks_script_path_for_test_spec(test_spec)
+            pod_targets = target.dependent_targets_for_test_spec(test_spec)
             framework_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, paths_by_config|
               paths_by_config[config] = pod_targets.flat_map do |pod_target|
-                spec_paths_to_include = pod_target == target ? pod_target.specs.map(&:name) : pod_target.non_test_specs.map(&:name)
+                spec_paths_to_include = pod_target.non_test_specs.map(&:name)
+                spec_paths_to_include << test_spec.name if pod_target == target
                 pod_target.framework_paths.values_at(*spec_paths_to_include).flatten.compact.uniq
               end
             end
@@ -477,9 +481,9 @@ module Pod
           #
           # @return [void]
           #
-          def test_target_swift_debug_hack(test_target_bc)
+          def test_target_swift_debug_hack(test_spec, test_target_bc)
             return unless test_target_bc.debug?
-            return unless target.all_dependent_targets.any?(&:uses_swift?)
+            return unless target.dependent_targets_for_test_spec(test_spec).any?(&:uses_swift?)
             ldflags = test_target_bc.build_settings['OTHER_LDFLAGS'] ||= '$(inherited)'
             ldflags << ' -lswiftSwiftOnoneSupport'
           end
@@ -712,8 +716,8 @@ module Pod
           end
 
           def test_native_target_from_spec_consumer(spec_consumer, test_native_targets)
-            test_native_targets.find do |native_target|
-              native_target.symbol_type == target.product_type_for_test_type(spec_consumer.test_type)
+            test_native_targets.find do |test_native_target|
+              test_native_target.name == target.test_target_label(spec_consumer.spec)
             end
           end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -76,7 +76,7 @@ module Pod
 
           def test_native_target_from_spec(spec)
             test_native_targets.find do |test_native_target|
-              test_native_target.symbol_type == target.product_type_for_test_type(spec.test_type)
+              test_native_target.name == target.test_target_label(spec)
             end
           end
         end

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -772,7 +772,7 @@ module Pod
         define_build_settings_method :dependent_targets, :memoized => true do
           select_maximal_pod_targets(
             if test_xcconfig?
-              target.all_dependent_targets
+              target.dependent_targets_for_test_spec(test_spec)
             else
               target.recursive_dependent_targets
             end,

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -229,6 +229,11 @@ describe_cli 'pod' do
                             'install --no-repo-update'
     end
 
+    describe 'Installs a pod with multiple test specs' do
+      behaves_like cli_spec 'install_multiple_test_specs',
+                            'install --no-repo-update'
+    end
+
     description = 'Installs a Pod with an external source'
     if has_mercurial
       describe description do

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -273,7 +273,7 @@ module Pod
                 @installer.install!
                 @project.support_files_group
                 group = @project['Pods/CoconutLib/Support Files']
-                group.children.map(&:display_name).sort.should.include 'CoconutLib.unit.xcconfig'
+                group.children.map(&:display_name).sort.should.include 'CoconutLib.unit-tests.xcconfig'
               end
 
               it 'does not add test header imports to umbrella header' do
@@ -319,7 +319,7 @@ module Pod
                 installation_result.test_resource_bundle_targets.count.should == 1
                 test_resource_bundle_target = @project.targets.find { |t| t.name == 'CoconutLib-CoconutLibTestResources' }
                 test_resource_bundle_target.build_configurations.each do |bc|
-                  bc.base_configuration_reference.real_path.basename.to_s.should == 'CoconutLib.unit.xcconfig'
+                  bc.base_configuration_reference.real_path.basename.to_s.should == 'CoconutLib.unit-tests.xcconfig'
                   bc.build_settings['CONFIGURATION_BUILD_DIR'].should.be.nil
                 end
               end
@@ -327,7 +327,7 @@ module Pod
               it 'creates embed frameworks script for test target' do
                 @coconut_pod_target.stubs(:requires_frameworks? => true)
                 @installer.install!
-                script_path = @coconut_pod_target.embed_frameworks_script_path_for_test_type(:unit)
+                script_path = @coconut_pod_target.embed_frameworks_script_path_for_test_spec(@coconut_pod_target.test_specs.first)
                 script = script_path.read
                 @coconut_pod_target.user_build_configurations.keys.each do |configuration|
                   script.should.include <<-eos.strip_heredoc
@@ -341,7 +341,7 @@ module Pod
               it 'adds the resources bundles for to the copy resources script for test target' do
                 @coconut_spec.test_specs.first.resource_bundle = { 'CoconutLibTestResources' => ['Tests/*.xib'] }
                 @installer.install!
-                script_path = @coconut_pod_target.copy_resources_script_path_for_test_type(:unit)
+                script_path = @coconut_pod_target.copy_resources_script_path_for_test_spec(@coconut_spec.test_specs.first)
                 script = script_path.read
                 @coconut_pod_target.user_build_configurations.keys.each do |configuration|
                   script.should.include <<-eos.strip_heredoc

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
@@ -22,7 +22,7 @@ module Pod
               @native_target = stub('NativeTarget', :shell_script_build_phases => [], :build_phases => [],
                                                     :project => @project)
               @test_native_target = stub('TestNativeTarget', :symbol_type => :unit_test_bundle, :build_phases => [],
-                                                             :shell_script_build_phases => [], :project => @project)
+                                                             :shell_script_build_phases => [], :project => @project, :name => 'CoconutLib-Unit-Tests')
 
               @target_installation_result = TargetInstallationResult.new(@coconut_pod_target, @native_target, [],
                                                                          [@test_native_target])

--- a/spec/unit/installer/xcode/pods_project_generator/target_installation_result_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installation_result_spec.rb
@@ -14,7 +14,7 @@ module Pod
 
             it 'groups test specs by the native target they are part of' do
               native_target = stub('native_target')
-              test_native_target = stub('test_native_target', :symbol_type => :unit_test_bundle)
+              test_native_target = stub('test_native_target', :symbol_type => :unit_test_bundle, :name => 'CoconutLib-Unit-Tests')
               result = TargetInstallationResult.new(@pod_target, native_target, [], [test_native_target])
               result.test_specs_by_native_target.should == { test_native_target => [@coconut_test_spec] }
             end

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -163,9 +163,11 @@ module Pod
               'Pods-SampleApp-iOS',
               'Pods-SampleApp-macOS',
               'WatermelonLib-iOS',
+              'WatermelonLib-iOS-Unit-SnapshotTests',
               'WatermelonLib-iOS-Unit-Tests',
               'WatermelonLib-iOS-WatermelonLibTestResources',
               'WatermelonLib-macOS',
+              'WatermelonLib-macOS-Unit-SnapshotTests',
               'WatermelonLib-macOS-Unit-Tests',
               'WatermelonLib-macOS-WatermelonLibTestResources',
               'monkey-iOS',
@@ -293,7 +295,7 @@ module Pod
             app_host_target = @generator.project.targets.find { |t| t.name == 'AppHost-iOS-Unit-Tests' }
             app_host_target.name.should.not.be.nil
             app_host_target.symbol_type.should == :application
-            test_native_target = @generator.project.targets.find { |t| t.name == 'WatermelonLib-iOS-Unit-Tests' }
+            test_native_target = @generator.project.targets.find { |t| t.name == 'WatermelonLib-iOS-Unit-SnapshotTests' }
             test_native_target.should.not.be.nil
             test_native_target.build_configurations.each do |bc|
               bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-iOS-Unit-Tests.app/AppHost-iOS-Unit-Tests'
@@ -308,7 +310,7 @@ module Pod
             app_host_target = @generator.project.targets.find { |t| t.name == 'AppHost-macOS-Unit-Tests' }
             app_host_target.name.should.not.be.nil
             app_host_target.symbol_type.should == :application
-            test_native_target = @generator.project.targets.find { |t| t.name == 'WatermelonLib-macOS-Unit-Tests' }
+            test_native_target = @generator.project.targets.find { |t| t.name == 'WatermelonLib-macOS-Unit-SnapshotTests' }
             test_native_target.should.not.be.nil
             test_native_target.build_configurations.each do |bc|
               bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-macOS-Unit-Tests.app/Contents/MacOS/AppHost-macOS-Unit-Tests'

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -333,7 +333,7 @@ module Pod
             @coconut_pod_target.sandbox.public_headers.add_search_path('CoconutLib', Platform.ios)
             @coconut_pod_target.test_dependent_targets_by_spec_name = { @coconut_test_spec.name => [@monkey_pod_target] }
             @coconut_pod_target.dependent_targets = [@banana_pod_target]
-            generator = PodTargetSettings.new(@coconut_pod_target, true)
+            generator = PodTargetSettings.new(@coconut_pod_target, @coconut_test_spec)
             xcconfig = generator.generate
             xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == '$(inherited) "${PODS_ROOT}/Headers/Private"' \
               ' "${PODS_ROOT}/Headers/Private/CoconutLib"' \

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -546,7 +546,7 @@ module Pod
         end
 
         it 'returns test label based on test type' do
-          @test_pod_target.test_target_label(:unit).should == 'CoconutLib-Unit-Tests'
+          @test_pod_target.test_target_label(@test_pod_target.test_specs.first).should == 'CoconutLib-Unit-Tests'
         end
 
         it 'returns the correct product type for test type' do
@@ -558,29 +558,20 @@ module Pod
           exception.message.should.include 'Unknown test type `weird_test_type`.'
         end
 
-        it 'returns the correct test type for product type' do
-          @test_pod_target.test_type_for_product_type(:unit_test_bundle).should == :unit
-        end
-
-        it 'raises for unknown product type' do
-          exception = lambda { @test_pod_target.test_type_for_product_type(:weird_product_type) }.should.raise Informative
-          exception.message.should.include 'Unknown product type `weird_product_type`'
-        end
-
         it 'returns correct copy resources script path for test unit test type' do
-          @test_pod_target.copy_resources_script_path_for_test_type(:unit).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-resources.sh'
+          @test_pod_target.copy_resources_script_path_for_test_spec(@test_pod_target.test_specs.first).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-resources.sh'
         end
 
         it 'returns correct embed frameworks script path for test unit test type' do
-          @test_pod_target.embed_frameworks_script_path_for_test_type(:unit).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-frameworks.sh'
+          @test_pod_target.embed_frameworks_script_path_for_test_spec(@test_pod_target.test_specs.first).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-frameworks.sh'
         end
 
         it 'returns correct prefix header path for test unit test type' do
-          @test_pod_target.prefix_header_path_for_test_type(:unit).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-prefix.pch'
+          @test_pod_target.prefix_header_path_for_test_spec(@test_pod_target.test_specs.first).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-prefix.pch'
         end
 
         it 'returns correct path for info plist for unit test type' do
-          @test_pod_target.info_plist_path_for_test_type(:unit).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-Info.plist'
+          @test_pod_target.info_plist_path_for_test_spec(@test_pod_target.test_specs.first).to_s.should.include 'Pods/Target Support Files/CoconutLib/CoconutLib-Unit-Tests-Info.plist'
         end
 
         it 'returns the correct resource path for test resource bundles' do


### PR DESCRIPTION
As of 1.5.x CocoaPods merges all test specs into a single test bundle target. This can cause problems when an author wants have different organization of their test sources but also include different dependencies and different configurations (e.g. one test spec requires an app host while the other doesn't).

closes https://github.com/CocoaPods/CocoaPods/issues/7573

This is an enhancement for 1.6.0 where now each test spec will get its own test bundle.