### PR TITLE
Use CP_HOME_DIR as the base for all default directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   as a module when all of the targets it is linked into have opted into it.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Use `CP_HOME_DIR` as the base for all default directories  
+  [mcfedr](https://github.com/mcfedr)
+  [#7917](https://github.com/CocoaPods/CocoaPods/pull/7917)
 
 ## 1.5.3 (2018-05-25)
 

--- a/lib/cocoapods/command/init.rb
+++ b/lib/cocoapods/command/init.rb
@@ -14,7 +14,7 @@ module Pod
         It is possible to specify a list of dependencies which will be used by
         the template in the `Podfile.default` (normal targets) `Podfile.test`
         (test targets) files which should be stored in the
-        `~/.cocoapods/templates` folder.
+        `#{Config.instance.templates_dir}` folder.
       DESC
       self.arguments = [
         CLAide::Argument.new('XCODEPROJ', :false),

--- a/lib/cocoapods/command/repo/add.rb
+++ b/lib/cocoapods/command/repo/add.rb
@@ -5,7 +5,7 @@ module Pod
         self.summary = 'Add a spec repo'
 
         self.description = <<-DESC
-          Clones `URL` in the local spec-repos directory at `~/.cocoapods/repos/`. The
+          Clones `URL` in the local spec-repos directory at `#{Config.instance.repos_dir}`. The
           remote can later be referred to by `NAME`.
         DESC
 

--- a/lib/cocoapods/command/repo/list.rb
+++ b/lib/cocoapods/command/repo/list.rb
@@ -5,7 +5,7 @@ module Pod
         self.summary = 'List repos'
 
         self.description = <<-DESC
-            List the repos from the local spec-repos directory at `~/.cocoapods/repos/.`
+            List the repos from the local spec-repos directory at `#{Config.instance.repos_dir}`.
         DESC
 
         def self.options

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -11,7 +11,7 @@ module Pod
         self.description = <<-DESC
         Validates `NAME.podspec` or `*.podspec` in the current working dir,
         creates a directory and version folder for the pod in the local copy of
-        `REPO` (~/.cocoapods/repos/[REPO]), copies the podspec file into the
+        `REPO` (#{Config.instance.repos_dir}/[REPO]), copies the podspec file into the
         version directory, and finally it pushes `REPO` to its remote.
         DESC
 

--- a/lib/cocoapods/command/repo/remove.rb
+++ b/lib/cocoapods/command/repo/remove.rb
@@ -5,7 +5,7 @@ module Pod
         self.summary = 'Remove a spec repo'
 
         self.description = <<-DESC
-          Deletes the remote named `NAME` from the local spec-repos directory at `~/.cocoapods/repos/.`
+          Deletes the remote named `NAME` from the local spec-repos directory at `#{Config.instance.repos_dir}`.
         DESC
 
         self.arguments = [

--- a/lib/cocoapods/command/repo/update.rb
+++ b/lib/cocoapods/command/repo/update.rb
@@ -6,7 +6,7 @@ module Pod
 
         self.description = <<-DESC
           Updates the local clone of the spec-repo `NAME`. If `NAME` is omitted
-          this will update all spec-repos in `~/.cocoapods/repos`.
+          this will update all spec-repos in `#{Config.instance.repos_dir}`.
         DESC
 
         self.arguments = [

--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -6,7 +6,7 @@ module Pod
       self.summary = 'Setup the CocoaPods environment'
 
       self.description = <<-DESC
-        Creates a directory at `~/.cocoapods/repos` which will hold your spec-repos.
+        Creates a directory at `#{Config.instance.repos_dir}` which will hold your spec-repos.
         This is where it will create a clone of the public `master` spec-repo from:
 
             https://github.com/CocoaPods/Specs

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -100,10 +100,18 @@ module Pod
     def initialize(use_user_settings = true)
       configure_with(DEFAULTS)
 
+      unless ENV['CP_HOME_DIR'].nil?
+        @cache_root = home_dir + 'cache'
+      end
+
       if use_user_settings && user_settings_file.exist?
         require 'yaml'
         user_settings = YAML.load_file(user_settings_file)
         configure_with(user_settings)
+      end
+
+      unless ENV['CP_CACHE_DIR'].nil?
+        @cache_root = Pathname.new(ENV['CP_CACHE_DIR']).expand_path
       end
     end
 

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -127,7 +127,7 @@ module Pod
     # @return [Pathname] the directory where the CocoaPods sources are stored.
     #
     def repos_dir
-      @repos_dir ||= Pathname.new(ENV['CP_REPOS_DIR'] || '~/.cocoapods/repos').expand_path
+      @repos_dir ||= Pathname.new(ENV['CP_REPOS_DIR'] || (home_dir + 'repos')).expand_path
     end
 
     attr_writer :repos_dir
@@ -140,7 +140,7 @@ module Pod
     # @return [Pathname] the directory where the CocoaPods templates are stored.
     #
     def templates_dir
-      @templates_dir ||= Pathname.new(ENV['CP_TEMPLATES_DIR'] || '~/.cocoapods/templates').expand_path
+      @templates_dir ||= Pathname.new(ENV['CP_TEMPLATES_DIR'] || (home_dir + 'templates')).expand_path
     end
 
     # @return [Pathname] the root of the CocoaPods installation where the

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -276,6 +276,9 @@ module Pod
     def configure_with(values_by_key)
       return unless values_by_key
       values_by_key.each do |key, value|
+        if key == :cache_root
+          value = Pathname.new(value).expand_path
+        end
         instance_variable_set("@#{key}", value)
       end
     end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -31,7 +31,7 @@ module Pod
               "named `#{name}`.\n"
             message << "(#{e})\n" if Config.instance.verbose?
             message << 'You can try adding it manually in ' \
-              '`~/.cocoapods/repos` or via `pod repo add`.'
+              "`#{Config.instance.repos_dir}` or via `pod repo add`."
             raise Informative, message
           ensure
             UI.title_level = previous_title_level

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -33,6 +33,8 @@ module Pod
       it 'allows to specify the home dir with an environment variable' do
         ENV['CP_HOME_DIR'] = '~/custom_home_dir'
         @config.home_dir.should == Pathname.new('~/custom_home_dir').expand_path
+        @config.repos_dir.should == Pathname.new('~/custom_home_dir/repos').expand_path
+        @config.templates_dir.should == Pathname.new('~/custom_home_dir/templates').expand_path
         ENV.delete('CP_HOME_DIR')
       end
 
@@ -40,6 +42,14 @@ module Pod
         ENV['CP_REPOS_DIR'] = '~/custom_repos_dir'
         @config.repos_dir.should == Pathname.new('~/custom_repos_dir').expand_path
         ENV.delete('CP_REPOS_DIR')
+      end
+
+      it 'allows to specify the repos dir with an environment variable that overrides home dir variable' do
+        ENV['CP_HOME_DIR'] = '~/custom_home_dir'
+        ENV['CP_REPOS_DIR'] = '~/custom_repos_dir'
+        @config.repos_dir.should == Pathname.new('~/custom_repos_dir').expand_path
+        ENV.delete('CP_REPOS_DIR')
+        ENV.delete('CP_HOME_DIR')
       end
     end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -60,6 +60,28 @@ module Pod
         @config.cache_root.should == (SpecHelper.temporary_directory + 'custom_cache_dir').expand_path
         ENV.delete('CP_CACHE_DIR')
       end
+
+      it 'allows to specify the cache dir with a config file' do
+        ENV['CP_HOME_DIR'] = SpecHelper.temporary_directory.to_s
+        config = { :cache_root => 'config_cache_dir' }
+        File.write(SpecHelper.temporary_directory + 'config.yaml', config.to_yaml)
+        @config = Config.new
+        @config.cache_root.should == Pathname.new('config_cache_dir').expand_path
+        File.delete(SpecHelper.temporary_directory + 'config.yaml')
+        ENV.delete('CP_HOME_DIR')
+      end
+
+      it 'allows cache dir environment variable to override the config file' do
+        ENV['CP_HOME_DIR'] = SpecHelper.temporary_directory.to_s
+        config = { :cache_root => 'config_cache_dir' }
+        File.write(SpecHelper.temporary_directory + 'config.yaml', config.to_yaml)
+        ENV['CP_CACHE_DIR'] = (SpecHelper.temporary_directory + 'custom_cache_dir').to_s
+        @config = Config.new
+        @config.cache_root.should == (SpecHelper.temporary_directory + 'custom_cache_dir').expand_path
+        File.delete(SpecHelper.temporary_directory + 'config.yaml')
+        ENV.delete('CP_CACHE_DIR')
+        ENV.delete('CP_HOME_DIR')
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -31,10 +31,12 @@ module Pod
       end
 
       it 'allows to specify the home dir with an environment variable' do
-        ENV['CP_HOME_DIR'] = '~/custom_home_dir'
-        @config.home_dir.should == Pathname.new('~/custom_home_dir').expand_path
-        @config.repos_dir.should == Pathname.new('~/custom_home_dir/repos').expand_path
-        @config.templates_dir.should == Pathname.new('~/custom_home_dir/templates').expand_path
+        ENV['CP_HOME_DIR'] = (SpecHelper.temporary_directory + 'custom_home_dir').to_s
+        @config = Config.new(false)
+        @config.home_dir.should == (SpecHelper.temporary_directory + 'custom_home_dir').expand_path
+        @config.repos_dir.should == (SpecHelper.temporary_directory + 'custom_home_dir/repos').expand_path
+        @config.templates_dir.should == (SpecHelper.temporary_directory + 'custom_home_dir/templates').expand_path
+        @config.cache_root.should == (SpecHelper.temporary_directory + 'custom_home_dir/cache').expand_path
         ENV.delete('CP_HOME_DIR')
       end
 
@@ -50,6 +52,13 @@ module Pod
         @config.repos_dir.should == Pathname.new('~/custom_repos_dir').expand_path
         ENV.delete('CP_REPOS_DIR')
         ENV.delete('CP_HOME_DIR')
+      end
+
+      it 'allows to specify the cache dir with an environment variable' do
+        ENV['CP_CACHE_DIR'] = (SpecHelper.temporary_directory + 'custom_cache_dir').to_s
+        @config = Config.new(false)
+        @config.cache_root.should == (SpecHelper.temporary_directory + 'custom_cache_dir').expand_path
+        ENV.delete('CP_CACHE_DIR')
       end
     end
 


### PR DESCRIPTION
Currently if you want to change the folders used by Cocoapods you have to set 3 separate envvars.

This is completely non-obvious and not really very helpful. It wasn't until I search though the code that I worked out why setting `CP_HOME_DIR` apparently did nothing.

I have also updated the help messages to use these global variables, as before they would be misleading in an environment where the dirs have been changed.

This has the potential for being a breaking changing for some people, but given that `CP_HOME_DIR` isn't documented anywhere, its probably not very widely used. I would expect that 99% of people using `CP_HOME_DIR` are also setting `CP_REPOS_DIR` and `CP_TEMPLATES_DIR`, and so they would be unaffected by this change.

Also, 🌈