### PR TITLE
Fix copy resource problem in other xcassets filter

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -213,7 +213,7 @@ then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
   OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)
   while read line; do
-    if [[ $line != "${PODS_ROOT}*" ]]; then
+    if [[ $line != ${PODS_ROOT}* ]]; then
       XCASSET_FILES+=("$line")
     fi
   done <<<"$OTHER_XCASSETS"


### PR DESCRIPTION
I guess from this script context that it should be necessary to add xcassets that don't start with `${PODS_ROOT}`, but the result is to add all the xcassets in the `${PODS_ROOT}` directory.