### PR TITLE
Add a deployment mode for installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Whirlwind](https://github.com/Whirlwind)
   [#7878](https://github.com/CocoaPods/CocoaPods/pull/7878)
 
+* Add a `--deployment` flag to `pod install` that errors if there are any
+  changes to the Podfile or Lockfile.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Do not display a source was changed if it uses different casing  

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -30,7 +30,13 @@ module Pod
       def self.options
         [
           ['--repo-update', 'Force running `pod repo update` before install'],
+          ['--deployment', 'Dissallow any changes to the Podfile or the Podfile.lock during installation'],
         ].concat(super).reject { |(name, _)| name == '--no-repo-update' }
+      end
+
+      def initialize(argv)
+        super
+        @deployment = argv.flag?('deployment', false)
       end
 
       def run
@@ -38,6 +44,7 @@ module Pod
         installer = installer_for_config
         installer.repo_update = repo_update?(:default => false)
         installer.update = false
+        installer.deployment = @deployment
         installer.install!
       end
     end

--- a/lib/cocoapods/command/install.rb
+++ b/lib/cocoapods/command/install.rb
@@ -30,7 +30,7 @@ module Pod
       def self.options
         [
           ['--repo-update', 'Force running `pod repo update` before install'],
-          ['--deployment', 'Dissallow any changes to the Podfile or the Podfile.lock during installation'],
+          ['--deployment', 'Disallow any changes to the Podfile or the Podfile.lock during installation'],
         ].concat(super).reject { |(name, _)| name == '--no-repo-update' }
       end
 

--- a/lib/cocoapods/installer/analyzer/specs_state.rb
+++ b/lib/cocoapods/installer/analyzer/specs_state.rb
@@ -91,8 +91,8 @@ module Pod
         def lines(states)
           prefixes = {
             :added     => 'A'.green,
-            :deleted   => 'R'.green,
-            :changed   => 'M'.green,
+            :deleted   => 'R'.red,
+            :changed   => 'M'.yellow,
             :unchanged => '-',
           }
 

--- a/lib/cocoapods/installer/analyzer/specs_state.rb
+++ b/lib/cocoapods/installer/analyzer/specs_state.rb
@@ -59,10 +59,14 @@ module Pod
         # @return [void]
         #
         def print
-          added    .sort.each { |pod| UI.message('A'.green + " #{pod}", '', 2) }
-          deleted  .sort.each { |pod| UI.message('R'.red + " #{pod}", '', 2) }
-          changed  .sort.each { |pod| UI.message('M'.yellow + " #{pod}", '', 2) }
-          unchanged.sort.each { |pod| UI.message('-' + " #{pod}", '', 2) }
+          states = %i(added deleted changed unchanged)
+          lines(states).each do |line|
+            UI.message(line, '', 2)
+          end
+        end
+
+        def to_s(states: %i(added deleted changed unchanged))
+          lines(states).join("\n")
         end
 
         # Adds the name of a Pod to the give state.
@@ -77,6 +81,26 @@ module Pod
         #
         def add_name(name, state)
           send(state) << Specification.root_name(name)
+        end
+
+        private
+
+        # @return [Array<String>] A description of changes for the given states,
+        #                         one per line
+        #
+        def lines(states)
+          prefixes = {
+            :added     => 'A'.green,
+            :deleted   => 'R'.green,
+            :changed   => 'M'.green,
+            :unchanged => '-',
+          }
+
+          states.flat_map do |state|
+            send(state).sort.map do |pod|
+              prefixes[state.to_sym] + " #{pod}"
+            end
+          end
         end
       end
     end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -297,6 +297,13 @@ module Pod
           config.sources_manager.expects(:update).once
           @installer.send(:resolve_dependencies)
         end
+
+        it 'raises when in deployment mode and the podfile has changes' do
+          @installer.deployment = true
+          should.raise Informative do
+            @installer.install!
+          end.message.should.include 'There were changes to the podfile in deployment mode'
+        end
       end
 
       #--------------------------------------#


### PR DESCRIPTION
It errors if there are any changes to the podfile or the lockfile, similiar to `bundle install --deployment`.
It would be useful to have for CI.

- [x] Specs