### PR TITLE
Generate -ObjC in OTHER_LDFLAGS for apps with static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Generate -ObjC in OTHER_LDFLAGS for apps with static frameworks  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#7946](https://github.com/CocoaPods/CocoaPods/pull/7946)
+
 * Do not display a source was changed if it uses different casing  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7883](https://github.com/CocoaPods/CocoaPods/pull/7883)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -992,8 +992,9 @@ module Pod
 
         # @return [Boolean]
         define_build_settings_method :requires_objc_linker_flag?, :memoized => true do
-          includes_static_libs = !target.requires_frameworks?
-          includes_static_libs || pod_targets.flat_map(&:file_accessors).any? { |fa| !fa.vendored_static_artifacts.empty? }
+          !target.requires_frameworks? ||
+            pod_targets.any?(&:static_framework?) ||
+            pod_targets.flat_map(&:file_accessors).any? { |fa| !fa.vendored_static_artifacts.empty? }
         end
 
         # @return [Boolean]

--- a/spec/unit/target/build_settings_spec.rb
+++ b/spec/unit/target/build_settings_spec.rb
@@ -126,6 +126,72 @@ module Pod
         end
       end
 
+      describe 'concerning other_ld_flags' do
+        it 'other_ld_flags should not include -ObjC when there are not static frameworks' do
+          target_definition = stub('target_definition', :inheritance => 'complete', :abstract? => false, :podfile => Podfile.new)
+          spec = stub('spec', :test_specification? => true)
+          consumer = stub('consumer',
+                          :libraries => ['xml2'],
+                          :frameworks => ['XCTest'],
+                          :weak_frameworks => [],
+                          :spec => spec,
+                         )
+          file_accessor = stub('file_accessor',
+                               :spec => spec,
+                               :spec_consumer => consumer,
+                               :vendored_static_artifacts => [],
+                              )
+          pod_target = stub('pod_target',
+                            :file_accessors => [file_accessor],
+                            :requires_frameworks? => true,
+                            :dependent_targets => [],
+                            :recursive_dependent_targets => [],
+                            :sandbox => config.sandbox,
+                            :include_in_build_config? => true,
+                            :should_build? => false,
+                            :spec_consumers => [consumer],
+                            :static_framework? => false,
+                            :product_basename => 'PodTarget',
+                            :target_definitions => [target_definition],
+                           )
+          pod_target.stubs(:build_settings => pod(pod_target))
+          aggregate_target = fixture_aggregate_target([pod_target], true)
+          aggregate(aggregate_target).other_ldflags.should.not.include '-ObjC'
+        end
+
+        it 'other_ld_flags should include -ObjC when linking static frameworks' do
+          target_definition = stub('target_definition', :inheritance => 'complete', :abstract? => false, :podfile => Podfile.new)
+          spec = stub('spec', :test_specification? => true)
+          consumer = stub('consumer',
+                          :libraries => ['xml2'],
+                          :frameworks => ['XCTest'],
+                          :weak_frameworks => [],
+                          :spec => spec,
+                         )
+          file_accessor = stub('file_accessor',
+                               :spec => spec,
+                               :spec_consumer => consumer,
+                               :vendored_static_artifacts => [],
+                              )
+          pod_target = stub('pod_target',
+                            :file_accessors => [file_accessor],
+                            :requires_frameworks? => true,
+                            :dependent_targets => [],
+                            :recursive_dependent_targets => [],
+                            :sandbox => config.sandbox,
+                            :include_in_build_config? => true,
+                            :should_build? => false,
+                            :spec_consumers => [consumer],
+                            :static_framework? => true,
+                            :product_basename => 'PodTarget',
+                            :target_definitions => [target_definition],
+                           )
+          pod_target.stubs(:build_settings => pod(pod_target))
+          aggregate_target = fixture_aggregate_target([pod_target], true)
+          aggregate(aggregate_target).other_ldflags.should.include '-ObjC'
+        end
+      end
+
       #---------------------------------------------------------------------#
     end
   end


### PR DESCRIPTION
-ObjC was not getting generated for apps linking static frameworks that were accessing podspec's other than via spec repo's. 

This PR makes the static framework linking behavior consistent with static libraries.

More details and an example at https://github.com/firebase/firebase-ios-sdk/issues/1341