### PR TITLE
Don't generate scripts if they will not be added to the user project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   told not to fetch them.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Don't generate framework or resource scripts if they will not be used  
+  [Eric Amorde](https://github.com/amorde)
+
 ## 1.5.3 (2018-05-25)
 
 ##### Enhancements

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -30,9 +30,9 @@ module Pod
               # cause an App Store rejection because frameworks cannot be
               # embedded in embedded targets.
               #
-              create_embed_frameworks_script unless target.requires_host_target?
+              create_embed_frameworks_script if target.includes_frameworks? && !target.requires_host_target?
               create_bridge_support_file(native_target)
-              create_copy_resources_script
+              create_copy_resources_script if target.includes_resources?
               create_acknowledgements
               create_dummy_source(native_target)
               clean_support_files_temp_dir

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -62,7 +62,7 @@ module Pod
             test_native_target_from_spec(spec)
           end
 
-          # @return [Hash{Array => Specification}] a hash where the keys are the test native targets and the value
+          # @return [Hash{PBXNativeTarget => Specification}] a hash where the keys are the test native targets and the value
           #         an array of all the test specs associated with this native target.
           #
           def test_specs_by_native_target

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -191,6 +191,19 @@ module Pod
       pod_targets.any?(&:uses_swift?)
     end
 
+    # @return [Boolean] Whether the target contains any resources
+    #
+    def includes_resources?
+      !resource_paths_by_config.values.all?(&:empty?)
+    end
+
+    # @return [Boolean] Whether the target contains framework to be embedded into
+    #         the user target
+    #
+    def includes_frameworks?
+      !framework_paths_by_config.values.all?(&:empty?)
+    end
+
     # @return [Hash{String => Array<Hash{Symbol => [String]}>}] The vendored dynamic artifacts and framework target
     #         input and output paths grouped by config
     #

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -49,16 +49,6 @@ module Pod
           @target_integrator.integrate!
         end
 
-        it 'fixes the copy resource scripts of legacy installations' do
-          @target_integrator.integrate!
-          target = @target_integrator.send(:native_targets).first
-          phase_name = @copy_pods_resources_phase_name
-          phase = target.shell_script_build_phases.find { |bp| bp.name == phase_name }
-          phase.shell_script = %("${PODS_ROOT}/Pods-resources.sh"\n)
-          @target_integrator.integrate!
-          phase.shell_script.strip.should == '"${PODS_ROOT}/Target Support Files/Pods/Pods-resources.sh"'
-        end
-
         it 'adds references to the Pods static libraries to the Frameworks group' do
           @target_integrator.integrate!
           @target_integrator.send(:user_project)['Frameworks/libPods.a'].should.not.be.nil

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -37,6 +37,24 @@ module Pod
         targets.count.should == 1
         targets.first.class.should == Xcodeproj::Project::PBXNativeTarget
       end
+
+      it 'returns whether it has frameworks to embed' do
+        @target.stubs(:framework_paths_by_config).returns(
+          'DEBUG' => [{  :name => 'BananaLib.framework',
+                         :input_path => '${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework',
+                         :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BananaLib.framework' }],
+        )
+        @target.includes_frameworks?.should.be.true
+        @target.stubs(:framework_paths_by_config).returns('DEBUG' => [], 'RELEASE' => [])
+        @target.includes_frameworks?.should.be.false
+      end
+
+      it 'returns whether it has resources' do
+        @target.stubs(:resource_paths_by_config).returns('DEBUG' => %w(path/to/image.png banana/lib.png))
+        @target.includes_resources?.should.be.true
+        @target.stubs(:resource_paths_by_config).returns('DEBUG' => [], 'RELEASE' => [])
+        @target.includes_resources?.should.be.false
+      end
     end
 
     describe 'Support files' do


### PR DESCRIPTION
Follow up to #7181 - if we aren't going to add the scripts to the user project, don't generate the files at all and don't write them to disk.

cc @keith 