### PR TITLE
Add --use-modular-headers to lint and push commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Add a `--deployment` flag to `pod install` that errors if there are any
   changes to the Podfile or Lockfile.  
   [Samuel Giddins](https://github.com/segiddins)
+  
+* Add `--use-modular-headers` flag to `pod spec lint`, `pod lib lint`, and `pod repo push` commands  
+  [Eric Amorde](https://github.com/amorde)
+  [#7683](https://github.com/CocoaPods/CocoaPods/issues/7683)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -17,6 +17,7 @@ module Pod
             ['--no-clean', 'Lint leaves the build directory intact for inspection'],
             ['--fail-fast', 'Lint stops on the first failing platform or subspec'],
             ['--use-libraries', 'Lint uses static libraries to install the spec'],
+            ['--use-modular-headers', 'Lint uses modular headers during installation'],
             ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependent pods ' \
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
@@ -39,6 +40,7 @@ module Pod
           @subspecs        = argv.flag?('subspecs', true)
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
+          @use_modular_headers = argv.flag?('use-modular-headers')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
           @platforms       = argv.option('platforms', '').split(',')
           @private         = argv.flag?('private', false)
@@ -65,6 +67,7 @@ module Pod
             validator.no_subspecs    = !@subspecs || @only_subspec
             validator.only_subspec   = @only_subspec
             validator.use_frameworks = @use_frameworks
+            validator.use_modular_headers = @use_modular_headers
             validator.ignore_public_only_results = @private
             validator.swift_version = @swift_version
             validator.skip_import_validation = @skip_import_validation

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -24,6 +24,7 @@ module Pod
           [
             ['--allow-warnings', 'Allows pushing even if there are warnings'],
             ['--use-libraries', 'Linter uses static libraries to install the spec'],
+            ['--use-modular-headers', 'Lint uses modular headers during installation'],
             ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependent pods ' \
              '(defaults to all available repos). ' \
              'Multiple sources must be comma-delimited.'],
@@ -48,6 +49,7 @@ module Pod
           @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).join(',')).split(',')
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
+          @use_modular_headers = argv.flag?('use-modular-headers', false)
           @private = argv.flag?('private', true)
           @message = argv.option('commit-message')
           @commit_message = argv.flag?('commit-message', false)
@@ -131,6 +133,7 @@ module Pod
             validator = Validator.new(podspec, @source_urls)
             validator.allow_warnings = @allow_warnings
             validator.use_frameworks = @use_frameworks
+            validator.use_modular_headers = @use_modular_headers
             validator.ignore_public_only_results = @private
             validator.swift_version = @swift_version
             validator.skip_import_validation = @skip_import_validation

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -23,6 +23,7 @@ module Pod
             ['--no-clean', 'Lint leaves the build directory intact for inspection'],
             ['--fail-fast', 'Lint stops on the first failing platform or subspec'],
             ['--use-libraries', 'Lint uses static libraries to install the spec'],
+            ['--use-modular-headers', 'Lint uses modular headers during installation'],
             ['--sources=https://github.com/artsy/Specs,master', 'The sources from which to pull dependent pods ' \
              '(defaults to https://github.com/CocoaPods/Specs.git). ' \
              'Multiple sources must be comma-delimited.'],
@@ -45,6 +46,7 @@ module Pod
           @subspecs        = argv.flag?('subspecs', true)
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
+          @use_modular_headers = argv.flag?('use-modular-headers')
           @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
           @platforms       = argv.option('platforms', '').split(',')
           @private         = argv.flag?('private', false)
@@ -67,6 +69,7 @@ module Pod
             validator.no_subspecs    = !@subspecs || @only_subspec
             validator.only_subspec   = @only_subspec
             validator.use_frameworks = @use_frameworks
+            validator.use_modular_headers = @use_modular_headers
             validator.ignore_public_only_results = @private
             validator.swift_version = @swift_version
             validator.skip_import_validation = @skip_import_validation

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -243,6 +243,10 @@ module Pod
     #
     attr_accessor :use_frameworks
 
+    # @return [Boolean] Whether modular headers should be used for the installation.
+    #
+    attr_accessor :use_modular_headers
+
     # @return [Boolean] Whether attributes that affect only public sources
     #         Bool be skipped.
     #
@@ -507,7 +511,7 @@ module Pod
     end
 
     def download_pod
-      podfile = podfile_from_spec(consumer.platform_name, deployment_target, use_frameworks, consumer.spec.test_specs.map(&:name))
+      podfile = podfile_from_spec(consumer.platform_name, deployment_target, use_frameworks, consumer.spec.test_specs.map(&:name), use_modular_headers)
       sandbox = Sandbox.new(config.sandbox_root)
       @installer = Installer.new(sandbox, podfile)
       @installer.use_default_plugins = false
@@ -847,7 +851,7 @@ module Pod
     # @note   The generated podfile takes into account whether the linter is
     #         in local mode.
     #
-    def podfile_from_spec(platform_name, deployment_target, use_frameworks = true, test_spec_names = [])
+    def podfile_from_spec(platform_name, deployment_target, use_frameworks = true, test_spec_names = [], use_modular_headers = false)
       name     = subspec_name || spec.name
       podspec  = file.realpath
       local    = local?
@@ -859,6 +863,7 @@ module Pod
         urls.each { |u| source(u) }
         target 'App' do
           use_frameworks!(use_frameworks)
+          use_modular_headers! if use_modular_headers
           platform(platform_name, deployment_target)
           if local
             pod name, :path => podspec.dirname.to_s, :inhibit_warnings => false

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -194,10 +194,10 @@ module Pod
     end
 
     it 'validates specs as frameworks by default' do
-      Validator.any_instance.expects(:podfile_from_spec).with(:ios, '8.0', true, []).times(3).returns(stub('Podfile'))
-      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, true, []).twice.returns(stub('Podfile'))
-      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, true, []).twice.returns(stub('Podfile'))
-      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, true, []).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:ios, '8.0', true, [], false).times(3).returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, true, [], false).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, true, [], false).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, true, [], false).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
@@ -208,12 +208,26 @@ module Pod
     end
 
     it 'validates specs as libraries if requested' do
-      Validator.any_instance.expects(:podfile_from_spec).with(:ios, nil, false, []).times(3).returns(stub('Podfile'))
-      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, []).twice.returns(stub('Podfile'))
-      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, []).twice.returns(stub('Podfile'))
-      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, []).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:ios, nil, false, [], false).times(3).returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, [], false).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, [], false).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, [], false).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master', '--use-libraries')
+      # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
+      # tests so the exception is swallowed.
+      lambda do
+        Dir.chdir(temporary_directory) { cmd.run }
+      end.should.raise Informative
+    end
+
+    it 'validates specs with modular headers if requested' do
+      Validator.any_instance.expects(:podfile_from_spec).with(:ios, nil, false, [], true).times(3).returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, [], true).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, [], true).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, [], true).twice.returns(stub('Podfile'))
+
+      cmd = command('repo', 'push', 'master', '--use-libraries', '--use-modular-headers')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
       # tests so the exception is swallowed.
       lambda do

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -409,11 +409,11 @@ module Pod
           s.ios.deployment_target = '7.0'
         end
         validator.spec.stubs(:subspecs).returns([subspec])
-        validator.expects(:podfile_from_spec).with(:osx, nil, nil, []).once.returns(stub('Podfile'))
-        validator.expects(:podfile_from_spec).with(:ios, nil, nil, []).once.returns(stub('Podfile'))
-        validator.expects(:podfile_from_spec).with(:ios, '7.0', nil, []).once.returns(stub('Podfile'))
-        validator.expects(:podfile_from_spec).with(:tvos, nil, nil, []).once.returns(stub('Podfile'))
-        validator.expects(:podfile_from_spec).with(:watchos, nil, nil, []).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:osx, nil, nil, [], nil).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:ios, nil, nil, [], nil).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:ios, '7.0', nil, [], nil).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:tvos, nil, nil, [], nil).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:watchos, nil, nil, [], nil).once.returns(stub('Podfile'))
         validator.send(:perform_extensive_analysis, validator.spec)
 
         validator.results_message.strip.should.be.empty
@@ -445,6 +445,12 @@ module Pod
           # rubocop:disable Style/DoubleNegation
           (!!target_definition.uses_frameworks?).should == false
           # rubocop:enable Style/DoubleNegation
+        end
+
+        it 'includes the use_modular_headers! directive' do
+          podfile = @validator.send(:podfile_from_spec, :ios, '5.0', false, [], true)
+          target_definition = podfile.target_definitions['App']
+          target_definition.use_modular_headers_hash['all'].should.be.true
         end
 
         it 'inhibits warnings for all pods except the one being validated' do
@@ -870,10 +876,10 @@ module Pod
 
         setup_validator
 
-        @validator.expects(:podfile_from_spec).with(:osx, nil, true, []).once.returns(stub('Podfile'))
-        @validator.expects(:podfile_from_spec).with(:ios, '8.0', true, []).once.returns(stub('Podfile'))
-        @validator.expects(:podfile_from_spec).with(:tvos, nil, true, []).once.returns(stub('Podfile'))
-        @validator.expects(:podfile_from_spec).with(:watchos, nil, true, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:osx, nil, true, [], nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:ios, '8.0', true, [], nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:tvos, nil, true, [], nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:watchos, nil, true, [], nil).once.returns(stub('Podfile'))
         @validator.send(:perform_extensive_analysis, @validator.spec)
 
         @validator.results_message.strip.should.be.empty
@@ -884,10 +890,10 @@ module Pod
 
         setup_validator
 
-        @validator.expects(:podfile_from_spec).with(:osx, nil, false, []).once.returns(stub('Podfile'))
-        @validator.expects(:podfile_from_spec).with(:ios, nil, false, []).once.returns(stub('Podfile'))
-        @validator.expects(:podfile_from_spec).with(:tvos, nil, false, []).once.returns(stub('Podfile'))
-        @validator.expects(:podfile_from_spec).with(:watchos, nil, false, []).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:osx, nil, false, [], nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:ios, nil, false, [], nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:tvos, nil, false, [], nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:watchos, nil, false, [], nil).once.returns(stub('Podfile'))
         @validator.send(:perform_extensive_analysis, @validator.spec)
 
         @validator.results_message.strip.should.be.empty


### PR DESCRIPTION
Progress towards #7683 

Still need to add the flag to `pod trunk`