### PR TITLE
Don't set architectures for placeholder aggregate targets

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -728,8 +728,10 @@ module Pod
             target.user_build_configurations.each do |bc_name, type|
               native_target.add_build_configuration(bc_name, type)
             end
-            native_target.build_configurations.each do |configuration|
-              configuration.build_settings['ARCHS'] = target.archs
+            unless target.archs.empty?
+              native_target.build_configurations.each do |configuration|
+                configuration.build_settings['ARCHS'] = target.archs
+              end
             end
             native_target
           end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -811,6 +811,15 @@ module Pod
               group.children.map(&:display_name).sort.should == ['BananaLib.xcconfig']
             end
 
+            it 'does not set architectures for targets that should not build' do
+              @pod_target.stubs(:should_build?).returns(false)
+              result = @installer.install!
+              target = result.native_target
+              target.build_configurations.each do |config|
+                config.build_settings['ARCHS'].should.be.nil
+              end
+            end
+
             #--------------------------------------------------------------------------------#
 
             describe 'concerning header_mappings_dirs' do


### PR DESCRIPTION
Fixes a bug introduced in #7932 

Architectures were being set for placeholder aggregate targets (ex. pre-built vendored frameworks) and introduced an Xcode warning with a Fix-It. 

