### PR TITLE
Ensure platform and deployment target is set for placeholder targets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: c6c0dbb0f977367c32fceea514c372dc9f8ab13f
+  revision: 23127d054d0c3e80983d06b34af50cafbd648adc
   branch: master
   specs:
     xcodeproj (1.5.9)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -723,8 +723,7 @@ module Pod
           # @return [PBXAggregateTarget] the native target that was added.
           #
           def add_placeholder_target
-            native_target = project.new_aggregate_target(target.label)
-            native_target.deployment_target = deployment_target
+            native_target = project.new_aggregate_target(target.label, [], target.platform.name, deployment_target)
             target.user_build_configurations.each do |bc_name, type|
               native_target.add_build_configuration(bc_name, type)
             end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -801,6 +801,9 @@ module Pod
               @installer.install!
               @project.targets.map(&:name).should == ['BananaLib']
               @project.targets.first.class.should == Xcodeproj::Project::PBXAggregateTarget
+              @project.targets.first.build_configurations.each do |config|
+                config.build_settings['SDKROOT'].should == 'iphoneos'
+              end
             end
 
             it 'adds xcconfig file reference for the aggregate placeholder native target' do


### PR DESCRIPTION
requires https://github.com/CocoaPods/Xcodeproj/pull/593/files

Fixes a case where placeholder targets do not have `SDKROOT` set and therefore allow users to build for "macOS" even though all of the pods they consume are for iOS only and vice versa.