### PR TITLE
Don't embed inherited search paths dependencies

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -277,6 +277,7 @@ module Pod
         embedded_aggregate_targets.each do |embedded_aggregate_target|
           # Skip non libraries in library-only mode
           next if libraries_only && !embedded_aggregate_target.library?
+          next if aggregate_target.search_paths_aggregate_targets.include?(embedded_aggregate_target)
           next unless embedded_aggregate_target.user_targets.any? do |embedded_user_target|
             # You have to ask the host target's project for the host targets of
             # the embedded target, as opposed to asking user_project for the
@@ -395,6 +396,12 @@ module Pod
         aggregate_targets = resolver_specs_by_target.keys.map do |target_definition|
           generate_target(target_definition, target_inspections, pod_targets, resolver_specs_by_target)
         end
+        aggregate_targets.each do |target|
+          search_paths_aggregate_targets = aggregate_targets.select do |aggregate_target|
+            target.target_definition.targets_to_inherit_search_paths.include?(aggregate_target.target_definition)
+          end
+          target.search_paths_aggregate_targets.concat(search_paths_aggregate_targets).freeze
+        end
         if installation_options.integrate_targets?
           # Copy embedded target pods that cannot have their pods embedded as frameworks to
           # their host targets, and ensure we properly link library pods to their host targets
@@ -415,11 +422,7 @@ module Pod
             aggregate_target.merge_embedded_pod_targets(embedded_pod_targets)
           end
         end
-        aggregate_targets.each do |target|
-          target.search_paths_aggregate_targets.concat(aggregate_targets.select do |aggregate_target|
-            target.target_definition.targets_to_inherit_search_paths.include?(aggregate_target.target_definition)
-          end).freeze
-        end
+        aggregate_targets
       end
 
       # Setup the aggregate target for a single user target

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -245,10 +245,12 @@ module Pod
           pod_target.should_build? && pod_target.requires_frameworks? && !pod_target.static_framework?
         end
         user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
-          resources_by_config[config] = (relevant_pod_targets & pod_targets_for_build_configuration(config)).flat_map do |pod_target|
+          targets = relevant_pod_targets & pod_targets_for_build_configuration(config)
+          resources_by_config[config] = targets.flat_map do |pod_target|
             non_test_specs = pod_target.non_test_specs.map(&:name)
-            resource_paths = pod_target.resource_paths.values_at(*non_test_specs).flatten.compact
-            (resource_paths + [bridge_support_file].compact).uniq
+            resource_paths = pod_target.resource_paths.values_at(*non_test_specs).flatten
+            resource_paths << bridge_support_file
+            resource_paths.compact.uniq
           end
         end
       end


### PR DESCRIPTION
    Don’t copy embedded targets to the host when the host already inherits search paths from the embedded target’s aggregate target

    Fixes a regression introduced in https://github.com/CocoaPods/CocoaPods/pull/7978