### PR TITLE
[AggregateTarget] Fix search paths inheritance

### DIFF
--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -91,7 +91,9 @@ module Pod
         (before + after).uniq
       end
       AggregateTarget.new(sandbox, host_requires_frameworks, user_build_configurations, archs, platform,
-                          target_definition, client_root, user_project, user_target_uuids, merged)
+                          target_definition, client_root, user_project, user_target_uuids, merged).tap do |aggregate_target|
+        aggregate_target.search_paths_aggregate_targets.concat(search_paths_aggregate_targets).freeze
+      end
     end
 
     def build_settings(configuration_name = nil)

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -270,6 +270,28 @@ module Pod
         consumer_reps = @target.spec_consumers.map { |consumer| [consumer.spec.name, consumer.platform_name] }
         consumer_reps.should == [['BananaLib', :ios]]
       end
+
+      describe '#merge_embedded_pod_targets' do
+        it 'merges the embedded pod targets with the current pod targets' do
+          other_pod_target = stub('other pod target')
+          embedded_pod_targets_for_build_configuration = {
+            'Debug' => [@pod_target],
+            'Release' => [other_pod_target],
+          }
+
+          merged = @target.merge_embedded_pod_targets(embedded_pod_targets_for_build_configuration)
+          merged.pod_targets_for_build_configuration('Debug').should == [@pod_target]
+          merged.pod_targets_for_build_configuration('Release').should == [@pod_target, other_pod_target]
+        end
+
+        it 'copies over search paths aggregate targets' do
+          search_paths_aggregate_targets = [stub('other aggregate target')]
+          @target.stubs(:search_paths_aggregate_targets => search_paths_aggregate_targets)
+          merged = @target.merge_embedded_pod_targets({})
+          merged.search_paths_aggregate_targets.should == search_paths_aggregate_targets
+          merged.search_paths_aggregate_targets.should.be.frozen
+        end
+      end
     end
 
     describe 'Product type dependent helpers' do


### PR DESCRIPTION
Ensure aggregate targets that merge embedded targets pod targets retain their search paths inheritance

Fixes a regression introduced by https://github.com/CocoaPods/CocoaPods/pull/7992 since there were no tests covering this scenario