### PR TITLE
fix a same name issue under different ruby

### DIFF
--- a/lib/cocoapods/generator/acknowledgements/plist.rb
+++ b/lib/cocoapods/generator/acknowledgements/plist.rb
@@ -8,19 +8,19 @@ module Pod
       end
 
       def save_as(path)
-        Xcodeproj::Plist.write_to_path(plist, path)
+        Xcodeproj::Plist.write_to_path(plist_hash, path)
       end
 
       # @return [String] The contents of the plist
       #
       def generate
-        plist = Nanaimo::Plist.new(plist, :xml)
+        plist = Nanaimo::Plist.new(plist_hash, :xml)
         contents = StringIO.new
         Nanaimo::Writer::XMLWriter.new(plist, :pretty => true, :output => contents, :strict => false).write
         contents.string
       end
 
-      def plist
+      def plist_hash
         {
           :Title => plist_title,
           :StringsTable => plist_title,

--- a/spec/unit/generator/acknowledgements/plist_spec.rb
+++ b/spec/unit/generator/acknowledgements/plist_spec.rb
@@ -55,7 +55,7 @@ describe Pod::Generator::Plist do
   end
 
   it 'returns a plist containg the licenses' do
-    @generator.plist.should == {
+    @generator.plist_hash.should == {
       :Title => 'Acknowledgements',
       :StringsTable => 'Acknowledgements',
       :PreferenceSpecifiers => @generator.licenses,
@@ -66,7 +66,7 @@ describe Pod::Generator::Plist do
     basepath = config.sandbox.root + 'Pods-acknowledgements'
     given_path = @generator.class.path_from_basepath(basepath)
     expected_path = config.sandbox.root + 'Pods-acknowledgements.plist'
-    Xcodeproj::Plist.expects(:write_to_path).with(equals(@generator.plist), equals(expected_path))
+    Xcodeproj::Plist.expects(:write_to_path).with(equals(@generator.plist_hash), equals(expected_path))
     @generator.save_as(given_path)
   end
 end


### PR DESCRIPTION
First, I don't know why it cause a issue. CocoaPods could not call the `plist` method and cause the plist file to not be generated. I try to put some logs in the `plist` method and output nothing. And the log in `generate` method is normal.

I check everything, but could not find the reason. I try to rename the `plist` name to other name, everything is OK. It maybe the method name conflicts with local var name ( I am not sure.)