### PR TITLE
Allow duplicate dependencies when they have no conflict

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -794,7 +794,7 @@ module Pod
 
       def verify_no_pods_with_different_sources!
         deps_with_different_sources = podfile_dependencies.group_by(&:root_name).
-          select { |_root_name, dependencies| dependencies.map(&:external_source).uniq.count > 1 }
+          select { |_root_name, dependencies| dependencies.map(&:external_source).compact.uniq.count > 1 }
         deps_with_different_sources.each do |root_name, dependencies|
           raise Informative, 'There are multiple dependencies with different ' \
           "sources for `#{root_name}` in #{UI.path podfile.defined_in_file}:" \
@@ -884,7 +884,7 @@ module Pod
       #
       def resolve_dependencies(locked_dependencies)
         duplicate_dependencies = podfile_dependencies.group_by(&:name).
-          select { |_name, dependencies| dependencies.count > 1 }
+          select { |_name, dependencies| dependencies.count(&:external_source) > 1 }
         duplicate_dependencies.each do |name, dependencies|
           UI.warn "There are duplicate dependencies on `#{name}` in #{UI.path podfile.defined_in_file}:\n\n" \
            "- #{dependencies.map(&:to_s).join("\n- ")}"
@@ -892,7 +892,7 @@ module Pod
 
         resolver_specs_by_target = nil
         UI.section "Resolving dependencies of #{UI.path(podfile.defined_in_file) || 'Podfile'}" do
-          resolver = Pod::Resolver.new(sandbox, podfile, locked_dependencies, sources, @specs_updated)
+          resolver = Pod::Resolver.new(sandbox, podfile, locked_dependencies, sources, @specs_updated, @podfile_dependency_cache)
           resolver_specs_by_target = resolver.resolve
           resolver_specs_by_target.values.flatten(1).map(&:spec).each(&:validate_cocoapods_version)
         end

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -244,6 +244,26 @@ describe_cli 'pod' do
       Bacon::ErrorLog << "[!] Skipping test due to missing `hg` executable: #{description}".red << "\n\n"
     end
 
+    description = 'Installs a Pod with an external source and version'
+    if has_mercurial
+      describe description do
+        behaves_like cli_spec 'install_external_source_with_version',
+                              'install --no-repo-update'
+      end
+    else
+      Bacon::ErrorLog << "[!] Skipping test due to missing `hg` executable: #{description}".red << "\n\n"
+    end
+
+    describe 'Installs multiple duplicate pods in Podfile' do
+      behaves_like cli_spec 'install_podspec_for_sdk',
+                            'install --no-repo-update'
+    end
+
+    describe 'Re-installs multiple duplicate pods in Podfile' do
+      behaves_like cli_spec 'reinstall_podspec_for_sdk',
+                            'install --no-repo-update'
+    end
+
     describe 'Installs a Pod given the podspec' do
       behaves_like cli_spec 'install_podspec',
                             'install --no-repo-update'

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -795,7 +795,7 @@ module Pod
         sandbox = config.sandbox
         podfile = generate_podfile
         lockfile = generate_lockfile
-        lockfile.internal_data['DEPENDENCIES'] = podfile.dependencies.map(&:to_s)
+        lockfile.internal_data['PODS'] = podfile.dependencies.map(&:to_s)
 
         should.raise Informative do
           Installer.targets_from_sandbox(sandbox, podfile, lockfile)

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -325,7 +325,7 @@ module Pod
             fss.subspec 'SecondSubSpec'
           end
         end
-        config.sandbox.expects(:specification).with('MainSpec').returns(spec)
+        config.sandbox.stubs(:specification).with('MainSpec').returns(spec)
         resolver = create_resolver
         specs = resolver.resolve.values.flatten.map(&:name).sort
         specs.should == %w(
@@ -347,7 +347,7 @@ module Pod
             tss.source_files = 'some/file'
           end
         end
-        config.sandbox.expects(:specification).with('MainSpec').returns(spec)
+        config.sandbox.stubs(:specification).with('MainSpec').returns(spec)
         resolver = create_resolver
         resolved_specs = resolver.resolve.values.flatten
         spec_names = resolved_specs.map(&:name).sort
@@ -373,7 +373,7 @@ module Pod
             tss.dependency 'Expecta'
           end
         end
-        config.sandbox.expects(:specification).with('MainSpec').returns(spec)
+        config.sandbox.stubs(:specification).with('MainSpec').returns(spec)
         resolver = create_resolver
         resolved_specs = resolver.resolve.values.flatten
         spec_names = resolved_specs.map(&:name).sort
@@ -401,7 +401,7 @@ module Pod
             tss.dependency 'Expecta'
           end
         end
-        config.sandbox.expects(:specification).with('MainSpec').returns(spec)
+        config.sandbox.stubs(:specification).with('MainSpec').returns(spec)
         resolver = create_resolver
         resolved_specs = resolver.resolve.values.flatten
         spec_names = resolved_specs.map(&:name).sort
@@ -438,7 +438,7 @@ module Pod
             tss.dependency 'OCMock'
           end
         end
-        config.sandbox.expects(:specification).with('MainSpec').returns(spec)
+        config.sandbox.stubs(:specification).with('MainSpec').returns(spec)
         resolver = create_resolver
         resolved_specs = resolver.resolve
 
@@ -468,7 +468,7 @@ module Pod
           s.version      = '1.2.3-pre'
           s.platform     = :ios
         end
-        config.sandbox.expects(:specification).with('MainSpec').returns(spec)
+        config.sandbox.stubs(:specification).with('MainSpec').returns(spec)
         resolver = create_resolver
         specs = resolver.resolve.values.flatten.map(&:spec).map(&:to_s).sort
         specs.should == [


### PR DESCRIPTION
I have some cases. 

## case 1:
Podfile:
```
target :A do
    pod 'SDK'
end
target :B do
    pod 'SDK', '> 1.0'
end
target :C do
    pod 'SDK', '2.0'
end
```
I think the Podfile is allowed and the `SDK` should be `2.0`. But the CocoaPods will have some warning and some error.

## case 2
A `SDK/SDK.podspec` :
```
s.name = 'SDK'
s.version = '2.0'
s.dependency 'AFNetworking', '> 1.0'
```
A `AFNetworking/AFNetworking.podspec`:
```
s.name = 'AFNetworking'
s.version = '2.0'
```

The `Podfile`:
```
target :A do
    pod 'SDK', :path=>'../SDK'
end
target :B do
    pod 'AFNetworking', :path=>'../AFNetworking'
end
target :C do
    pod 'AFNetworking', '2.0'
end
```
I think it is allowed, too. But the CocoaPods will failed.

## case 3
`SDK.podspec`:
```
s.name = 'SDK'
s.version = '2.0'
s.dependency 'AFNetworking', '> 1.0'
```
`Podfile`:
```
target :SDK do
    podspec
end
target :B do
    pod 'AFNetworking', :path=>'../AFNetworking'
end
```
It likes the case 2. It should have nothing warning and error.

## Idea
I want to allow the duplicate dependencies if they have no conflict.
In case 1, the `SDK` will use the `2.0`. Becasue the `2.0` satisfies `>1.0` and `=2.0`.
In case 2, the  `AFNetworking` will use the `:path`. Because the external source will be used first. And the `AFNetworking` in the `../AFNetworking` is `2.0`, it satisfies `> 1.0` and `=2.0`.

So, If the pod has external source, I will use it and use the version.
If the pod has many version conditions, I will use them to make a version arbitration.