### PR TITLE
Allow podspec specification of SDKROOT.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Fix line spacing for Swift error message.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8024](https://github.com/CocoaPods/CocoaPods/pull/8024)
+  
+* Allow specification of SDKROOT in podspec.
+  [Ron Bendor](https://github.com/RonstaMonsta)
+  [#8058](https://github.com/CocoaPods/CocoaPods/pull/8058)
 
 
 ## 1.6.0.beta.1 (2018-08-16)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -98,10 +98,10 @@ module Pod
             else
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end
-                   
-            if target.build_settings.generate.attributes.key?("SDKROOT")
-              puts "For target: #{target.name}, SDKROOT being set to #{target.build_settings.generate.attributes["SDKROOT"]}"
-              settings["SDKROOT"] = target.build_settings.generate.attributes["SDKROOT"]
+
+            if target.build_settings.generate.attributes.key?('SDKROOT')
+              puts "For target: #{target.name}, SDKROOT being set to #{target.build_settings.generate.attributes['SDKROOT']}"
+              settings['SDKROOT'] = target.build_settings.generate.attributes['SDKROOT']
             end
 
             settings

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -98,6 +98,11 @@ module Pod
             else
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end
+                   
+            if target.build_settings.generate.attributes.key?("SDKROOT")
+              puts "For target: #{target.name}, SDKROOT being set to #{target.build_settings.generate.attributes["SDKROOT"]}"
+              settings["SDKROOT"] = target.build_settings.generate.attributes["SDKROOT"]
+            end
 
             settings
           end


### PR DESCRIPTION
When building our native target build settings, we check if SDKROOT is defined in the user's build settings, and set it accordingly.

This is a fix for https://github.com/CocoaPods/CocoaPods/issues/7972. This should not affect any projects that are not attempting to override the SDKROOT.

Unit tests are incoming, but I'm getting this PR started to see if this approach is even acceptable.