### PR TITLE
Validate all generated native targets have source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Print an error that will show up in Xcode's issue navigator upon unexpected
   failures in the copy resources and embed frameworks script phases.  
   [Samuel Giddins](https://github.com/segiddins)
+  
+* Validate that all generated `PBXNativeTarget`s contain source files to build,
+  so specs (including test specs) with no source files won't fail at runtime
+  due to the lack of a generated executable.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
   

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -50,6 +50,7 @@ module Pod
               test_resource_bundle_targets = add_resources_bundle_targets(test_file_accessors)
 
               add_files_to_build_phases(native_target, test_native_targets)
+              validate_targets_contain_sources(test_native_targets + [native_target])
 
               create_xcconfig_file(native_target, resource_bundle_targets)
               create_test_xcconfig_files(test_native_targets, test_resource_bundle_targets)
@@ -819,6 +820,13 @@ module Pod
               ${BUILT_PRODUCTS_DIR}/#{relative_umbrella_header_path.basename}
               ${BUILT_PRODUCTS_DIR}/Swift\ Compatibility\ Header/${PRODUCT_MODULE_NAME}-Swift.h
             )
+          end
+
+          def validate_targets_contain_sources(native_targets)
+            native_targets.each do |native_target|
+              next unless native_target.source_build_phase.files.empty?
+              raise Informative, "Unable to install the `#{target.label}` pod, because the `#{native_target}` target in Xcode would have no sources to compile."
+            end
           end
 
           #-----------------------------------------------------------------------#

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -289,6 +289,13 @@ module Pod
                 installation_result.test_native_targets.count.should == 2
               end
 
+              it 'raises when a test spec has no source files' do
+                @watermelon_pod_target.test_spec_consumers.first.stubs(:source_files).returns([])
+                e = ->() { @installer.install! }.should.raise Informative
+                e.message.should.
+                    include 'Unable to install the `WatermelonLib` pod, because the `WatermelonLib-Unit-Tests` target in Xcode would have no sources to compile.'
+              end
+
               it 'adds swiftSwiftOnoneSupport ld flag to the debug configuration' do
                 @watermelon_pod_target.stubs(:uses_swift?).returns(true)
                 @installer.install!

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -567,6 +567,7 @@ module Pod
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
         PodTarget.any_instance.stubs(:should_build?).returns(true)
+        Installer::Xcode::PodsProjectGenerator::PodTargetInstaller.any_instance.stubs(:validate_targets_contain_sources) # since we skip downloading
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)
@@ -586,7 +587,7 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + Fourflusher::SimControl.new.destination('Apple Watch - 38mm')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
-        validator.validate
+        validator.validate.should == true
       end
 
       it 'runs xcodebuild with correct arguments for code signing' do


### PR DESCRIPTION
Validate that all generated `PBXNativeTarget`s contain source files to build,
  so specs (including test specs) with no source files won't fail at runtime
  due to the lack of a generated executable.  
