### PR TITLE
Provide an installation option to disable usage of input/output paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [#8064](https://github.com/CocoaPods/CocoaPods/issues/8064)
 
 ##### Bug Fixes
-  
+
+* Provide an installation option to disable usage of input/output paths.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8073](https://github.com/CocoaPods/CocoaPods/issues/8073)
+
 * Scope prefix header setting to each test spec.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8046](https://github.com/CocoaPods/CocoaPods/pull/8046)

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -108,6 +108,7 @@ module Pod
       option :lock_pod_sources, true
       option :warn_for_multiple_pod_sources, true
       option :share_schemes_for_development_pods, false
+      option :disable_input_output_paths, false
 
       module Mixin
         module ClassMethods

--- a/lib/cocoapods/installer/user_project_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator.rb
@@ -13,6 +13,10 @@ module Pod
     class UserProjectIntegrator
       autoload :TargetIntegrator, 'cocoapods/installer/user_project_integrator/target_integrator'
 
+      include InstallationOptions::Mixin
+
+      delegate_installation_options { podfile }
+
       # @return [Podfile] the podfile that should be integrated with the user
       #         projects.
       #
@@ -42,7 +46,7 @@ module Pod
       # @param  [Podfile]  podfile @see #podfile
       # @param  [Sandbox]  sandbox @see #sandbox
       # @param  [Pathname] installation_root @see #installation_root
-      # @param  [Array<AggregateTarget>]  targets @see #targets
+      # @param  [Array<AggregateTarget>] targets @see #targets
       #
       def initialize(podfile, sandbox, installation_root, targets)
         @podfile = podfile
@@ -111,7 +115,7 @@ module Pod
       #
       def integrate_user_targets
         target_integrators = targets_to_integrate.sort_by(&:name).map do |target|
-          TargetIntegrator.new(target)
+          TargetIntegrator.new(target, installation_options)
         end
 
         Config.instance.with_changes(:silent => true) do

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -210,7 +210,7 @@ module Pod
           unless pod_installations_to_integrate.empty?
             UI.message '- Integrating targets' do
               pod_installations_to_integrate.each do |pod_target_installation_result|
-                PodTargetIntegrator.new(pod_target_installation_result).integrate!
+                PodTargetIntegrator.new(pod_target_installation_result, installation_options).integrate!
               end
             end
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
@@ -10,12 +10,18 @@ module Pod
           #
           attr_reader :target_installation_result
 
+          # @return [InstallationOptions] the installation options from the Podfile.
+          #
+          attr_reader :installation_options
+
           # Initialize a new instance
           #
           # @param  [TargetInstallationResult] target_installation_result @see #target_installation_result
+          # @param  [InstallationOptions] installation_options @see #installation_options
           #
-          def initialize(target_installation_result)
+          def initialize(target_installation_result, installation_options)
             @target_installation_result = target_installation_result
+            @installation_options = installation_options
           end
 
           # Integrates the pod target.
@@ -53,17 +59,19 @@ module Pod
           #
           def add_copy_resources_script_phase(native_target, test_spec)
             script_path = "${PODS_ROOT}/#{target.copy_resources_script_path_for_test_spec(test_spec).relative_path_from(target.sandbox.root)}"
-            resource_paths = target.dependent_targets_for_test_spec(test_spec).flat_map do |dependent_target|
-              spec_paths_to_include = dependent_target.non_test_specs.map(&:name)
-              spec_paths_to_include << test_spec.name if dependent_target == target
-              dependent_target.resource_paths.values_at(*spec_paths_to_include).flatten.compact
-            end
             input_paths = []
             output_paths = []
-            unless resource_paths.empty?
-              resource_paths_flattened = resource_paths.flatten.uniq
-              input_paths = [script_path, *resource_paths_flattened]
-              output_paths = UserProjectIntegrator::TargetIntegrator.resource_output_paths(resource_paths_flattened)
+            unless installation_options.disable_input_output_paths?
+              resource_paths = target.dependent_targets_for_test_spec(test_spec).flat_map do |dependent_target|
+                spec_paths_to_include = dependent_target.non_test_specs.map(&:name)
+                spec_paths_to_include << test_spec.name if dependent_target == target
+                dependent_target.resource_paths.values_at(*spec_paths_to_include).flatten.compact
+              end
+              unless resource_paths.empty?
+                resource_paths_flattened = resource_paths.flatten.uniq
+                input_paths = [script_path, *resource_paths_flattened]
+                output_paths = UserProjectIntegrator::TargetIntegrator.resource_output_paths(resource_paths_flattened)
+              end
             end
             UserProjectIntegrator::TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
             UserProjectIntegrator::TargetIntegrator.create_or_update_copy_resources_script_phase_to_target(native_target, script_path, input_paths, output_paths)
@@ -75,16 +83,18 @@ module Pod
           #
           def add_embed_frameworks_script_phase(native_target, test_spec)
             script_path = "${PODS_ROOT}/#{target.embed_frameworks_script_path_for_test_spec(test_spec).relative_path_from(target.sandbox.root)}"
-            framework_paths = target.dependent_targets_for_test_spec(test_spec).flat_map do |dependent_target|
-              spec_paths_to_include = dependent_target.non_test_specs.map(&:name)
-              spec_paths_to_include << test_spec.name if dependent_target == target
-              dependent_target.framework_paths.values_at(*spec_paths_to_include).flatten.compact.uniq
-            end
             input_paths = []
             output_paths = []
-            unless framework_paths.empty?
-              input_paths = [script_path, *framework_paths.flat_map { |fw| [fw[:input_path], fw[:dsym_input_path]] }.compact]
-              output_paths = framework_paths.flat_map { |fw| [fw[:output_path], fw[:dsym_output_path]] }.compact
+            unless installation_options.disable_input_output_paths?
+              framework_paths = target.dependent_targets_for_test_spec(test_spec).flat_map do |dependent_target|
+                spec_paths_to_include = dependent_target.non_test_specs.map(&:name)
+                spec_paths_to_include << test_spec.name if dependent_target == target
+                dependent_target.framework_paths.values_at(*spec_paths_to_include).flatten.compact.uniq
+              end
+              unless framework_paths.empty?
+                input_paths = [script_path, *framework_paths.flat_map { |fw| [fw[:input_path], fw[:dsym_input_path]] }.compact]
+                output_paths = framework_paths.flat_map { |fw| [fw[:output_path], fw[:dsym_output_path]] }.compact
+              end
             end
             UserProjectIntegrator::TargetIntegrator.validate_input_output_path_limit(input_paths, output_paths)
             UserProjectIntegrator::TargetIntegrator.create_or_update_embed_frameworks_script_phase_to_target(native_target, script_path, input_paths, output_paths)

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -65,6 +65,7 @@ module Pod
           'lock_pod_sources' => true,
           'warn_for_multiple_pod_sources' => true,
           'share_schemes_for_development_pods' => false,
+          'disable_input_output_paths' => false,
         }
       end
 

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -23,7 +23,10 @@ module Pod
         )
         @pod_bundle.xcconfigs['Debug'] = configuration
         @pod_bundle.xcconfigs['Release'] = configuration
-        @target_integrator = TargetIntegrator.new(@pod_bundle)
+
+        @installation_options = Pod::Installer::InstallationOptions.new
+
+        @target_integrator = TargetIntegrator.new(@pod_bundle, @installation_options)
         @target_integrator.private_methods.grep(/^update_to_cocoapods_/).each do |method|
           @target_integrator.stubs(method)
         end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
@@ -24,13 +24,15 @@ module Pod
               @test_native_target = stub('TestNativeTarget', :symbol_type => :unit_test_bundle, :build_phases => [],
                                                              :shell_script_build_phases => [], :project => @project, :name => 'CoconutLib-Unit-Tests')
 
+              @installation_options = Pod::Installer::InstallationOptions.new
+
               @target_installation_result = TargetInstallationResult.new(@coconut_pod_target, @native_target, [],
                                                                          [@test_native_target])
             end
 
             describe '#integrate!' do
               it 'integrates test native targets with frameworks and resources script phases' do
-                PodTargetIntegrator.new(@target_installation_result).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
                 @test_native_target.build_phases.count.should == 2
                 @test_native_target.build_phases.map(&:display_name).should == [
                   '[CP] Embed Pods Frameworks',
@@ -47,7 +49,7 @@ module Pod
                   "${PODS_CONFIGURATION_BUILD_DIR}/DebugLib/DebugLibPng#{i}.png"
                 end
                 @coconut_pod_target.stubs(:resource_paths).returns('CoconutLib' => resource_paths)
-                PodTargetIntegrator.new(@target_installation_result).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
                 @test_native_target.build_phases.map(&:display_name).should == [
                   '[CP] Embed Pods Frameworks',
                   '[CP] Copy Pods Resources',
@@ -63,7 +65,7 @@ module Pod
                 resource_paths = ['${PODS_CONFIGURATION_BUILD_DIR}/TestResourceBundle.bundle']
                 @coconut_pod_target.stubs(:framework_paths).returns('CoconutLib' => framework_paths)
                 @coconut_pod_target.stubs(:resource_paths).returns('CoconutLib' => resource_paths)
-                PodTargetIntegrator.new(@target_installation_result).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
                 @test_native_target.build_phases.count.should == 2
                 @test_native_target.build_phases.map(&:display_name).should == [
                   '[CP] Embed Pods Frameworks',
@@ -85,9 +87,30 @@ module Pod
                 ]
               end
 
+              it 'does not include input output paths if disabled by installation options' do
+                framework_paths = [{ :name => 'Vendored.framework',
+                                     :input_path => '${PODS_ROOT}/Vendored/Vendored.framework',
+                                     :output_path => '${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vendored.framework' }]
+                resource_paths = ['${PODS_CONFIGURATION_BUILD_DIR}/TestResourceBundle.bundle']
+                @coconut_pod_target.stubs(:framework_paths).returns('CoconutLib' => framework_paths)
+                @coconut_pod_target.stubs(:resource_paths).returns('CoconutLib' => resource_paths)
+                @installation_options.disable_input_output_paths = true
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
+                @test_native_target.build_phases.count.should == 2
+                @test_native_target.build_phases.map(&:display_name).should == [
+                  '[CP] Embed Pods Frameworks',
+                  '[CP] Copy Pods Resources',
+                ]
+                @test_native_target.build_phases[0].input_paths.should.be.empty
+                @test_native_target.build_phases[0].output_paths.should.be.empty
+                @test_native_target.build_phases[1].input_paths.should.be.empty
+                @test_native_target.build_phases[1].output_paths.should.be.empty
+              end
+
               it 'excludes test framework and resource paths from dependent targets' do
                 @coconut_pod_target.stubs(:dependent_targets).returns([@watermelon_pod_target])
-                PodTargetIntegrator.new(@target_installation_result).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
                 @test_native_target.build_phases.count.should == 2
                 @test_native_target.build_phases.map(&:display_name).should == [
                   '[CP] Embed Pods Frameworks',
@@ -102,7 +125,7 @@ module Pod
               it 'integrates test native target with shell script phases' do
                 @coconut_spec.test_specs.first.script_phase = { :name => 'Hello World',
                                                                 :script => 'echo "Hello World"' }
-                PodTargetIntegrator.new(@target_installation_result).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
                 @test_native_target.build_phases.count.should == 3
                 @test_native_target.build_phases[2].display_name.should == '[CP-User] Hello World'
                 @test_native_target.build_phases[2].shell_script.should == 'echo "Hello World"'
@@ -110,7 +133,7 @@ module Pod
 
               it 'integrates native target with shell script phases' do
                 @coconut_spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
-                PodTargetIntegrator.new(@target_installation_result).integrate!
+                PodTargetIntegrator.new(@target_installation_result, @installation_options).integrate!
                 @native_target.build_phases.count.should == 1
                 @native_target.build_phases[0].display_name.should == '[CP-User] Hello World'
                 @native_target.build_phases[0].shell_script.should == 'echo "Hello World"'


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/8073

We cannot do anything about this until Apple resolves the issue with Xcode 10, dynamic frameworks and script phases not being re-run due to a change in the folder. 

In the meantime we provide users the option to disable input/output paths so the script phase will always run. 

For those who opt in to use this option, it mean slower but correct incremental builds. 