### PR TITLE
[Gemspec] Bump ruby-macho to '~> 2.1'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.6.6)
       nap (~> 1.0)
-      ruby-macho (~> 1.2)
+      ruby-macho (~> 1.3, >= 1.3.1)
       xcodeproj (>= 1.6.0, < 2.0)
 
 GEM
@@ -236,7 +236,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
     ruby-graphviz (1.2.2)
-    ruby-macho (1.2.0)
+    ruby-macho (1.3.1)
     ruby-prof (0.15.2)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
@@ -297,4 +297,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '~> 2.0.1'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '~> 1.2'
+  s.add_runtime_dependency 'ruby-macho',    '~> 1.3', '>= 1.3.1'
 
   s.add_development_dependency 'bacon', '~> 1.1'
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
See https://github.com/Homebrew/ruby-macho/pull/113 and https://github.com/Homebrew/ruby-macho/pull/114.