### PR TITLE
Fixes the double .xcasset folder compilation issue

### DIFF
--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -218,9 +218,7 @@ then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
   OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)
   while read line; do
-    LOWER_LINE="$(echo $line | tr '[:upper:]' '[:lower:]')"
-    LOWER_PODS_ROOT="$(echo $PODS_ROOT | tr '[:upper:]' '[:lower:]')"
-    if [[ $LOWER_LINE != ${LOWER_PODS_ROOT}* ]]; then
+    if [[ $line != ${PODS_ROOT}* ]]; then
       XCASSET_FILES+=("$line")
     fi
   done <<<"$OTHER_XCASSETS"

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -218,7 +218,9 @@ then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
   OTHER_XCASSETS=$(find "$PWD" -iname "*.xcassets" -type d)
   while read line; do
-    if [[ $line != "${PODS_ROOT}*" ]]; then
+    LOWER_LINE="$(echo $line | tr '[:upper:]' '[:lower:]')"
+    LOWER_PODS_ROOT="$(echo $PODS_ROOT | tr '[:upper:]' '[:lower:]')"
+    if [[ $LOWER_LINE != ${LOWER_PODS_ROOT}* ]]; then
       XCASSET_FILES+=("$line")
     fi
   done <<<"$OTHER_XCASSETS"


### PR DESCRIPTION
The old code compares a **lowercase** part of a string ( of`$line`) with an uppercase part of a string (of `${PODS_ROOT}`)?
My dev directory lives in `/Users/<username>/Documents/...`.

The `find` command seems to ignore the **uppercase** `Documents` and prints it **lowercase**.
The problem is `$POD_ROOT` contains `Documents` as **uppercase**.

Thus `[[ $line != "${PODS_ROOT}*" ]]` can never be true in my case, am I right?

These changes fix the problem. Any suggestions?

Seems to fix:
#6159

Related issues:
#7745
#7779
#7617
#7785