### PR TITLE
Don't generate unencrypted source warnings for localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Don't generate unencrypted source warnings for localhost.  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#8156](https://github.com/CocoaPods/CocoaPods/issues/8156)
+
 * Provide an installation option to disable usage of input/output paths.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8073](https://github.com/CocoaPods/CocoaPods/issues/8073)

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -123,7 +123,7 @@ module Pod
                    return unless git_source =~ /^#{URI.regexp}$/
                    URI(git_source)
                  end
-        if UNENCRYPTED_PROTOCOLS.include?(source.scheme)
+        if UNENCRYPTED_PROTOCOLS.include?(source.scheme) && source.host != 'localhost'
           UI.warn "'#{root_spec.name}' uses the unencrypted '#{source.scheme}' protocol to transfer the Pod. " \
                 'Please be sure you\'re in a safe network with only trusted hosts. ' \
                 'Otherwise, please reach out to the library author to notify them of this security issue.'

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -54,6 +54,14 @@ module Pod
         UI.warnings.should.include 'uses the unencrypted \'http\' protocol'
       end
 
+      it 'does not show a warning if the source is http://localhost' do
+        @spec.source = { :http => 'http://localhost:123/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @installer.install!
+        UI.warnings.length.should.equal(0)
+      end
+
       it 'shows a warning if the source is unencrypted with git://' do
         @spec.source = { :git => 'git://git.orta.io/orta.git' }
         dummy_response = Pod::Downloader::Response.new


### PR DESCRIPTION
Fix #8156