### PR TITLE
Set 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' to YES in Debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   with the same dependencies.  
   [Samuel Giddins]
 
+* Set 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' to YES in Debug mode  
+  [icecrystal23](https://github.com/icecrystal23)
+
 ##### Bug Fixes
 
 * Don't generate unencrypted source warnings for localhost.  

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -68,6 +68,13 @@ module Pod
 
             native_target.build_configurations.each do |configuration|
               configuration.build_settings.merge!(custom_build_settings)
+
+              # This works around a unit test issue introduced in Xcode 10 where swift libraries
+              # required by embedded frameworks are not always added to unit test targets
+              require_xcode10_hack = configuration.debug? && target.product_type == :framework
+              if require_xcode10_hack
+                configuration.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
+              end
             end
 
             native_target

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -62,6 +62,16 @@ module Pod
               'AppStore' => 'staticlib',
             }
           end
+
+          it 'embeds swift libraries in Debug mode' do
+            @target.stubs(:product_type).returns(:framework)
+            @installer.send(:add_target).resolved_build_setting('ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES').should == {
+              'Release' => nil,
+              'Debug' => 'YES',
+              'Test' => nil,
+              'AppStore' => nil,
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
This works around a bug in Xcode 10 where unit test targets don't correctly embed the necessary Swift libraries into unit test targets.