### PR TITLE
Use Relative Symbolic links

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -665,7 +665,8 @@ module Pod
               linked_path = target.module_map_path
               if path != linked_path
                 linked_path.dirname.mkpath
-                FileUtils.ln_sf(path, linked_path)
+                source = path.relative_path_from(linked_path.dirname)
+                FileUtils.ln_sf(source, linked_path)
               end
 
               relative_path = target.module_map_path.relative_path_from(sandbox.root).to_s

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -163,7 +163,8 @@ module Pod
               linked_path = target.module_map_path
               if path != linked_path
                 linked_path.dirname.mkpath
-                FileUtils.ln_sf(path, linked_path)
+                source = path.relative_path_from(linked_path.dirname)
+                FileUtils.ln_sf(source, linked_path)
               end
 
               relative_path_string = target.module_map_path.relative_path_from(sandbox.root).to_s
@@ -199,7 +200,8 @@ module Pod
               linked_path = target.umbrella_header_path
               if path != linked_path
                 linked_path.dirname.mkpath
-                FileUtils.ln_sf(path, linked_path)
+                source = path.relative_path_from(linked_path.dirname)
+                FileUtils.ln_sf(source, linked_path)
               end
 
               acl = target.requires_frameworks? ? 'Public' : 'Project'

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -883,6 +883,29 @@ module Pod
 
             #--------------------------------------------------------------------------------#
 
+            describe '#create_module_map' do
+              it 'uses relative paths when linking umbrella headers' do
+                @installer.stubs(:update_changed_file)
+                @installer.stubs(:add_file_to_support_group)
+                write_path = Pathname.new('/Pods/Target Support Files/MyPod/MyPod.modulemap')
+                target_module_path = Pathname.new('/Pods/Headers/Public/MyPod/MyPod.modulemap')
+                relative_path = Pathname.new('../../../Target Support Files/MyPod/MyPod.modulemap')
+
+
+                @pod_target.stubs(:module_map_path_to_write).returns(write_path)
+                @pod_target.stubs(:module_map_path).returns(target_module_path)
+                custom_module_map = mock(:read => '')
+                @installer.stubs(:custom_module_map).returns(custom_module_map)
+                Pathname.any_instance.stubs(:mkpath)
+
+                FileUtils.expects(:ln_sf).with(relative_path, target_module_path)
+                native_target = mock(:build_configurations => [])
+                @installer.send(:create_module_map, native_target)
+              end
+            end
+
+            #--------------------------------------------------------------------------------#
+
             describe 'concerning header_mappings_dirs' do
               before do
                 @project.add_pod_group('snake', fixture('snake'))

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -891,7 +891,6 @@ module Pod
                 target_module_path = Pathname.new('/Pods/Headers/Public/MyPod/MyPod.modulemap')
                 relative_path = Pathname.new('../../../Target Support Files/MyPod/MyPod.modulemap')
 
-
                 @pod_target.stubs(:module_map_path_to_write).returns(write_path)
                 @pod_target.stubs(:module_map_path).returns(target_module_path)
                 custom_module_map = mock(:read => '')

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -86,7 +86,7 @@ module Pod
               @installer.stubs(:update_changed_file)
               @installer.stubs(:add_file_to_support_group)
               write_path = Pathname.new('/Pods/Target Support Files/MyPod/MyPod-Umbrella.h')
-              target_header_path= Pathname.new('/Pods/Headers/Public/MyPod/MyPod-Umbrella.h')
+              target_header_path = Pathname.new('/Pods/Headers/Public/MyPod/MyPod-Umbrella.h')
               relative_path = Pathname.new('../../../Target Support Files/MyPod/MyPod-Umbrella.h')
 
               @target.stubs(:umbrella_header_path_to_write).returns(write_path)
@@ -94,10 +94,10 @@ module Pod
               Pathname.any_instance.stubs(:mkpath)
 
               mock_build_file = Struct.new(:settings).new
-              mock_build_phase = mock()
+              mock_build_phase = mock
               mock_build_phase.stubs(:add_file_reference).returns(mock_build_file)
 
-              native_target = mock()
+              native_target = mock
               native_target.stubs(:headers_build_phase).returns(mock_build_phase)
 
               FileUtils.expects(:ln_sf).with(relative_path, target_header_path)

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -62,6 +62,49 @@ module Pod
               'AppStore' => 'staticlib',
             }
           end
+
+          describe '#create_module_map' do
+            it 'uses relative paths when linking umbrella headers' do
+              @installer.stubs(:update_changed_file)
+              @installer.stubs(:add_file_to_support_group)
+              write_path = Pathname.new('/Pods/Target Support Files/MyPod/MyPod.modulemap')
+              target_module_path = Pathname.new('/Pods/Headers/Public/MyPod/MyPod.modulemap')
+              relative_path = Pathname.new('../../../Target Support Files/MyPod/MyPod.modulemap')
+
+              @target.stubs(:module_map_path_to_write).returns(write_path)
+              @target.stubs(:module_map_path).returns(target_module_path)
+              Pathname.any_instance.stubs(:mkpath)
+
+              FileUtils.expects(:ln_sf).with(relative_path, target_module_path)
+              native_target = mock(:build_configurations => [])
+              @installer.send(:create_module_map, native_target)
+            end
+          end
+
+          describe '#create_umbrella_header' do
+            it 'uses relative paths when linking umbrella headers' do
+              @installer.stubs(:update_changed_file)
+              @installer.stubs(:add_file_to_support_group)
+              write_path = Pathname.new('/Pods/Target Support Files/MyPod/MyPod-Umbrella.h')
+              target_header_path= Pathname.new('/Pods/Headers/Public/MyPod/MyPod-Umbrella.h')
+              relative_path = Pathname.new('../../../Target Support Files/MyPod/MyPod-Umbrella.h')
+
+              @target.stubs(:umbrella_header_path_to_write).returns(write_path)
+              @target.stubs(:umbrella_header_path).returns(target_header_path)
+              Pathname.any_instance.stubs(:mkpath)
+
+              mock_build_file = Struct.new(:settings).new
+              mock_build_phase = mock()
+              mock_build_phase.stubs(:add_file_reference).returns(mock_build_file)
+
+              native_target = mock()
+              native_target.stubs(:headers_build_phase).returns(mock_build_phase)
+
+              FileUtils.expects(:ln_sf).with(relative_path, target_header_path)
+
+              @installer.send(:create_umbrella_header, native_target)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Make symbolic links to module maps and umbrella files relative instead of absolute. See #8174.

Without this change, its much harder to share a workspace that includes a pods project because everyone has to check out files to the same root folder. Otherwise the absolute symbolic paths are invalid and you get compile errors.

This was tested with Xcode 10 with a project that uses both Swift and ObjectiveC static libraries.