### PR TITLE
[WIP] Do not setup the master spec repo automatically

### DIFF
--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -92,13 +92,19 @@ module Pod
       end
     end
 
-    # Ensure that the master spec repo exists
+    # Ensure that at least one repo exists
     #
     # @return [void]
     #
-    def ensure_master_spec_repo_exists!
-      unless config.sources_manager.master_repo_functional?
-        Setup.new(CLAide::ARGV.new([])).run
+    def ensure_source_repo_available(source_urls)
+      if source_urls.empty? && config.sources_manager.all.empty?
+        raise Informative, <<-EOS
+          There are no source repositories available. Either:
+
+            a.) Setup the master repo by running `pod init`
+            b.) Specify a list of private source repos with the `--sources` option
+            c.) If the master repo exists but is incompatibile with this version of CocoaPods, run `pod repo update master`
+        EOS
       end
     end
 

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -41,7 +41,7 @@ module Pod
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
           @use_modular_headers = argv.flag?('use-modular-headers')
-          @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @source_urls     = argv.option('sources', '').split(',')
           @platforms       = argv.option('platforms', '').split(',')
           @private         = argv.flag?('private', false)
           @swift_version   = argv.option('swift-version', nil)
@@ -57,6 +57,7 @@ module Pod
 
         def run
           UI.puts
+          ensure_source_repo_available(@source_urls)
           podspecs_to_lint.each do |podspec|
             validator                = Validator.new(podspec, @source_urls, @platforms)
             validator.local          = true

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -47,7 +47,7 @@ module Pod
           @only_subspec    = argv.option('subspec')
           @use_frameworks  = !argv.flag?('use-libraries')
           @use_modular_headers = argv.flag?('use-modular-headers')
-          @source_urls     = argv.option('sources', 'https://github.com/CocoaPods/Specs.git').split(',')
+          @source_urls     = argv.option('sources', '').split(',')
           @platforms       = argv.option('platforms', '').split(',')
           @private         = argv.flag?('private', false)
           @swift_version   = argv.option('swift-version', nil)
@@ -59,6 +59,7 @@ module Pod
 
         def run
           UI.puts
+          ensure_source_repo_available(@source_urls)
           failure_reasons = []
           podspecs_to_lint.each do |podspec|
             validator                = Validator.new(podspec, @source_urls, @platforms)

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -140,6 +140,8 @@ module Pod
 
     attr_writer :repos_dir
 
+    # @return [Source::Manager]
+    #
     def sources_manager
       return @sources_manager if @sources_manager && @sources_manager.repos_dir == repos_dir
       @sources_manager = Source::Manager.new(repos_dir)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -155,7 +155,15 @@ module Pod
           if all_dependencies_have_sources
             sources = dependency_sources
           elsif has_dependencies? && sources.empty? && plugin_sources.empty?
-            sources = ['https://github.com/CocoaPods/Specs.git']
+            raise Informative, <<-EOS.strip_heredoc
+            There are no sources specified in your Podfile. Either: 
+              
+              a.) Add the master repo to your Podfile, ex. `source "master"`
+              b.) Add a private private repo at the source of your choosing, ex. `source "https://github.com/artsy/Specs"`
+
+            Note: The master repo is no longer included by default.
+
+            EOS
           else
             sources += dependency_sources
           end

--- a/spec/spec_helper/fixture.rb
+++ b/spec/spec_helper/fixture.rb
@@ -13,6 +13,10 @@ module SpecHelper
     'https://github.com/CocoaPods/test_repo.git'
   end
 
+  def self.test_master_repo_url
+    'https://github.com/CocoaPods/Specs.git'
+  end
+
   module Fixture
     ROOT = ::ROOT + 'spec/fixtures'
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -4,13 +4,15 @@ module Pod
   describe Installer::Analyzer do
     describe 'Analysis' do
       before do
-        repos = [Source.new(fixture('spec-repos/test_repo')), MasterSource.new(fixture('spec-repos/master'))]
+        @master_repo = MasterSource.new(fixture('spec-repos/master'))
+        repos = [Source.new(fixture('spec-repos/test_repo')), @master_repo]
         aggregate = Pod::Source::Aggregate.new(repos)
         config.sources_manager.stubs(:aggregate).returns(aggregate)
         aggregate.sources.first.stubs(:url).returns(SpecHelper.test_repo_url)
 
         @podfile = Pod::Podfile.new do
           platform :ios, '6.0'
+          source SpecHelper.test_master_repo_url
           project 'SampleProject/SampleProject'
 
           target 'SampleProject' do
@@ -27,7 +29,6 @@ module Pod
             end
           end
         end
-
         hash = {}
         hash['PODS'] = ['JSONKit (1.5pre)', 'NUI (0.2.0)', 'SVPullToRefresh (0.4)']
         hash['DEPENDENCIES'] = %w(JSONKit NUI SVPullToRefresh)
@@ -166,6 +167,7 @@ module Pod
         it 'correctly determines when a platform requires 64-bit architectures' do
           @podfile = Pod::Podfile.new do
             project 'SampleProject/SampleProject'
+            source SpecHelper.test_master_repo_url
             platform :ios, '11.0'
             use_frameworks!
             target 'TestRunner' do
@@ -185,6 +187,7 @@ module Pod
         it 'forces 64-bit architectures when required' do
           @podfile = Pod::Podfile.new do
             project 'SampleProject/SampleProject'
+            source SpecHelper.test_master_repo_url
             platform :ios, '11.0'
             use_frameworks!
             target 'TestRunner' do
@@ -205,6 +208,7 @@ module Pod
             use_frameworks!
             target 'SampleProject' do
               platform :ios, '10.0'
+              source SpecHelper.test_master_repo_url
               pod 'AFNetworking'
               target 'TestRunner' do
                 platform :ios, '11.0'
@@ -225,6 +229,7 @@ module Pod
         it 'does not specify archs value unless required' do
           @podfile = Pod::Podfile.new do
             project 'SampleProject/SampleProject'
+            source SpecHelper.test_master_repo_url
             platform :ios, '10.0'
             use_frameworks!
             target 'TestRunner' do
@@ -242,6 +247,7 @@ module Pod
       describe 'abstract targets' do
         it 'resolves' do
           @podfile = Pod::Podfile.new do
+            source SpecHelper.test_master_repo_url
             project 'SampleProject/SampleProject'
             use_frameworks!
             abstract_target 'Alpha' do
@@ -269,6 +275,7 @@ module Pod
       describe 'dependent pod targets' do
         it 'picks transitive dependencies up' do
           @podfile = Pod::Podfile.new do
+            source SpecHelper.test_master_repo_url
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
             pod 'RestKit', '~> 0.23.0'
@@ -310,6 +317,7 @@ module Pod
 
         it 'does not mark transitive dependencies as dependent targets' do
           @podfile = Pod::Podfile.new do
+            source SpecHelper.test_master_repo_url
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
             target 'SampleProject'
@@ -342,6 +350,7 @@ module Pod
 
         it 'does not mark transitive dependencies as dependent targets' do
           @podfile = Pod::Podfile.new do
+            source SpecHelper.test_master_repo_url
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
             target 'SampleProject'
@@ -374,6 +383,7 @@ module Pod
 
         it 'does not mark transitive dependencies as dependent targets' do
           @podfile = Pod::Podfile.new do
+            source SpecHelper.test_master_repo_url
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
             target 'SampleProject'
@@ -805,6 +815,7 @@ module Pod
 
       it 'unlocks all dependencies with the same root name in update mode' do
         podfile = Podfile.new do
+          source SpecHelper.test_master_repo_url
           platform :ios, '8.0'
           project 'SampleProject/SampleProject'
           target 'SampleProject' do
@@ -839,6 +850,7 @@ module Pod
         local_spec = Specification.from_hash('name' => 'LocalPod', 'version' => '1.1', 'dependencies' => { 'Expecta' => ['~> 0.0'] })
         sandbox.stubs(:specification).with('LocalPod').returns(local_spec)
         podfile = Podfile.new do
+          source SpecHelper.test_master_repo_url
           platform :ios, '8.0'
           project 'SampleProject/SampleProject'
           target 'SampleProject' do
@@ -866,6 +878,7 @@ module Pod
         local_spec = Specification.from_hash('name' => 'LocalPod', 'version' => '1.0', 'dependencies' => { 'Expecta' => ['0.2.2'] })
         sandbox.stubs(:specification).with('LocalPod').returns(local_spec)
         podfile = Podfile.new do
+          source SpecHelper.test_master_repo_url
           platform :ios, '8.0'
           project 'SampleProject/SampleProject'
           target 'SampleProject' do
@@ -888,6 +901,7 @@ module Pod
       it 'raises if dependencies need to be fetched but fetching is not allowed' do
         sandbox = config.sandbox
         podfile = Podfile.new do
+          source SpecHelper.test_master_repo_url
           platform :ios, '8.0'
           project 'SampleProject/SampleProject'
           target 'SampleProject' do
@@ -915,6 +929,7 @@ module Pod
 
       it 'takes into account locked implicit dependencies' do
         podfile = Podfile.new do
+          source SpecHelper.test_master_repo_url
           platform :ios, '8.0'
           project 'SampleProject/SampleProject'
           target 'SampleProject' do
@@ -1102,6 +1117,7 @@ module Pod
 
         it 'allows a pod that is a dependency for other pods to be whitelisted' do
           @podfile = Podfile.new do
+            source SpecHelper.test_master_repo_url
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
             target 'SampleProject' do
@@ -1121,6 +1137,7 @@ module Pod
 
         it 'raises if a Pod is whitelisted for different build configurations' do
           @podfile = Podfile.new do
+            source SpecHelper.test_master_repo_url
             platform :ios, '8.0'
             project 'SampleProject/SampleProject'
             target 'SampleProject' do
@@ -1440,11 +1457,11 @@ module Pod
 
       describe 'Private helpers' do
         describe '#sources' do
-          describe 'when there are no explicit sources' do
-            it 'defaults to the master spec repository' do
-              @analyzer.send(:sources).map(&:url).should ==
-                ['https://github.com/CocoaPods/Specs.git']
-            end
+          it 'raises when there are no explicit sources' do
+            @podfile.stubs(:sources).returns([])
+            should.raise Informative do
+              @analyzer.send(:sources)
+            end.message.should.match /There are no sources specified in your Podfile/
           end
 
           describe 'when there are explicit sources' do

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -45,6 +45,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               platform :ios, '8.0'
               project 'SampleProject/SampleProject'
               pod 'BananaLib', :path => (fixture_path + 'banana-lib').to_s
@@ -64,6 +65,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               platform :ios, '8.0'
               project 'SampleProject/SampleProject'
               pod 'BananaLib',       :path => (fixture_path + 'banana-lib').to_s
@@ -84,6 +86,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               platform :ios, '8.0'
               project 'SampleProject/SampleProject'
               use_frameworks!
@@ -101,6 +104,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               platform :ios, '9.3'
               project 'Sample Extensions Project/Sample Extensions Project'
               use_frameworks!
@@ -128,6 +132,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             @podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               install! 'cocoapods', 'integrate_targets' => false
               platform :ios, '8.0'
               project 'SampleProject/SampleProject'
@@ -181,6 +186,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             @podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               install! 'cocoapods', 'integrate_targets' => false
               platform :ios, '8.0'
               project 'SampleProject/SampleProject'
@@ -241,6 +247,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             @podfile = Pod::Podfile.new do
+              source SpecHelper.test_master_repo_url
               install! 'cocoapods', 'integrate_targets' => false
               platform :ios, '8.0'
               project 'SampleProject/SampleProject'
@@ -268,6 +275,7 @@ module Pod
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Podfile.new do
+              source SpecHelper.test_master_repo_url
               project 'SampleProject/SampleProject'
               platform :ios, '8.0'
               use_frameworks!

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -17,6 +17,7 @@ end
 #
 def generate_podfile(pods = ['JSONKit'])
   Pod::Podfile.new do
+    source SpecHelper.test_master_repo_url
     platform :ios
     project SpecHelper.fixture('SampleProject/SampleProject'), 'Test' => :debug, 'App Store' => :release
     target 'SampleProject' do
@@ -32,6 +33,7 @@ end
 #
 def generate_local_podfile
   Pod::Podfile.new do
+    source SpecHelper.test_master_repo_url
     platform :ios
     project SpecHelper.fixture('SampleProject/SampleProject'), 'Test' => :debug, 'App Store' => :release
     target 'SampleProject' do
@@ -156,6 +158,7 @@ module Pod
 
           test_source_name = 'https://github.com/artsy/CustomSpecs.git'
           plugins_hash = Installer::DEFAULT_PLUGINS.merge(plugin_name => { 'sources' => [test_source_name] })
+          @installer.podfile.stubs(:sources).returns([])
           @installer.podfile.stubs(:plugins).returns(plugins_hash)
           @installer.unstub(:resolve_dependencies)
           @installer.stubs(:validate_build_configurations)
@@ -248,6 +251,7 @@ module Pod
         fixture_path = ROOT + 'spec/fixtures'
         config.repos_dir = fixture_path + 'spec-repos'
         podfile = Pod::Podfile.new do
+          source SpecHelper.test_master_repo_url
           platform :ios, '8.0'
           project 'SampleProject/SampleProject'
           use_frameworks!


### PR DESCRIPTION
## Background

Currently, CocoaPods will automatically setup the master repo if it has not been setup already. Given that the repo has grown to be quite large (see #7046), this can be a problem. Going forward, we should only initialize the master repo if explicitly requested to do so.

## Changes

With this PR, CocoaPods will no longer automatically checkout the master repo, and instead will emit an error when there are no spec repos available.

The current implementation in this PR will emit this error on `pod spec lint` and `pod lib lint` if
there are no source repos available:

```
 There are no source repositories available. Either:

    a.) Setup the master repo by running `pod init`
    b.) Specify a list of private source repos with the `--sources` option
    c.) If the master repo exists but is incompatibile with this version of CocoaPods, run `pod repo update master`
```

When running `pod install`, the error will be as follows:

```
There are no sources specified in your Podfile. Either: 
              
    a.) Add the master repo to your Podfile, ex. `source "master"`
    b.) Add a private private repo at the source of your choosing, ex. `source "https://github.com/artsy/Specs"`

Note: The master repo is no longer included by default.
```

## Notes

I'm looking for a review on my basic approach, and since this is a (very) breaking change this won't go out with 1.6.0. Maybe it will land in 1.7.0, or 2.0.0, or if we decide this isn't something we want to do then we can just scrap it.

## Todo

- [ ] Integration specs
- [ ] Finalize error text
- [ ] Update cocoapods-core
- [ ] Update integration specs
- [ ] Update `pod init` template to include an explicit source
- [ ] Update example projects to include explicit sources