### PR TITLE
Don't link aggregate target to vendored static libraries (sometimes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Don't link aggregate targets to a pod's vendored static library when the pod
+  providing the library is being built as a dynamic framework.  
+  [Wes Campaigne](https://github.com/Westacular)
+  [#8204](https://github.com/CocoaPods/CocoaPods/issues/8204)
 
 ## 1.6.0.beta.2 (2018-10-17)
 

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -602,7 +602,8 @@ module Pod
         define_build_settings_method :libraries, :memoized => true, :sorted => true, :uniqued => true do
           return [] if (!target.requires_frameworks? || target.static_framework?) && !test_xcconfig?
 
-          libraries = libraries_to_import.dup
+          libraries = vendored_static_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') }
+          libraries.concat dynamic_libraries_to_import
           libraries.concat dependent_targets.flat_map { |pt| pt.build_settings.dynamic_libraries_to_import }
           libraries.concat dependent_targets.flat_map { |pt| pt.build_settings.static_libraries_to_import } if test_xcconfig?
           libraries
@@ -610,7 +611,8 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :static_libraries_to_import, :memoized => true do
-          static_libraries_to_import = vendored_static_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') }
+          static_libraries_to_import = []
+          static_libraries_to_import.concat vendored_static_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') } unless target.should_build? && target.requires_frameworks? && !target.static_framework?
           static_libraries_to_import << target.product_basename if target.should_build? && !target.requires_frameworks?
           static_libraries_to_import
         end

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -482,7 +482,7 @@ module Pod
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target))
             aggregate_target = fixture_aggregate_target([pod_target])
             @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
-            @generator.other_ldflags.should == %w(-ObjC -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "VendoredFramework" -framework "XCTest")
+            @generator.other_ldflags.should == %w(-ObjC -l"VendoredDyld" -framework "PodTarget" -framework "VendoredFramework")
           end
 
           it 'does propagate system frameworks or system libraries from a non test specification to an aggregate target that uses static libraries' do
@@ -566,7 +566,7 @@ module Pod
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target))
             aggregate_target = fixture_aggregate_target([pod_target])
             @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
-            @generator.other_ldflags.should == %w(-ObjC -l"StaticLibrary" -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "StaticFramework" -framework "VendoredFramework" -framework "XCTest")
+            @generator.other_ldflags.should == %w(-ObjC -l"VendoredDyld" -framework "PodTarget" -framework "StaticFramework" -framework "VendoredFramework" -framework "XCTest")
           end
         end
 

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -482,7 +482,7 @@ module Pod
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target))
             aggregate_target = fixture_aggregate_target([pod_target])
             @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
-            @generator.other_ldflags.should == %w(-ObjC -l"StaticLibrary" -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "VendoredFramework" -framework "XCTest")
+            @generator.other_ldflags.should == %w(-ObjC -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "VendoredFramework" -framework "XCTest")
           end
 
           it 'does propagate system frameworks or system libraries from a non test specification to an aggregate target that uses static libraries' do


### PR DESCRIPTION
If a vendored static library is included in a pod that is being compiled as a dynamic framework, link that library in the pod's framework, but do NOT also link it in the aggregate target.

This is meant to address #8204. The change itself is modelled after https://github.com/CocoaPods/CocoaPods/pull/7631/commits/08ea793eb53cb326ccbd027f97f9428269ff63c9 which made a similar change to how framework linking is handled.