### PR TITLE
Add the [system] attribute to modulemaps of Pods with inhibit_warnings

### DIFF
--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -92,7 +92,11 @@ module Pod
       # The suffix attributes to `module`.
       #
       def module_declaration_attributes
-        ''
+        if (defined? target.inhibit_warnings?) && target.inhibit_warnings?
+          ' [system]'
+        else
+          ''
+        end
       end
     end
   end

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -51,5 +51,24 @@ module Pod
         }
       EOS
     end
+
+    describe 'with a pod target inhibiting warnings' do
+      before do
+        @pod_target.stubs(:inhibit_warnings?).returns(true)
+      end
+
+      it 'add the [system] attribute to the module definition' do
+        path = temporary_directory + 'BananaLib.modulemap'
+        @gen.save_as(path)
+        path.read.should == <<-EOS.strip_heredoc
+          module BananaLib [system] {
+            umbrella header "BananaLib-umbrella.h"
+
+            export *
+            module * { export * }
+          }
+        EOS
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes the problem encountered by some users in beta 1.6.0.beta.2, where the warnings in the headers of Pods using module maps were not silenced.

See discussion starting from https://github.com/CocoaPods/CocoaPods/pull/6401#issuecomment-431348062.

What this does is add the `[system]` attributes to the module definition of Pods targets inhibiting warnings. I added a unit test covering the case.