### PR TITLE
Small refactoring of pod project generator.

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -206,15 +206,15 @@ module Pod
     #
     def generate_pods_project(generator = create_generator)
       UI.section 'Generating Pods project' do
-        @target_installation_results = generator.generate!
-        @pods_project = generator.project
+        pod_project_generation_result = generator.generate!
+        @target_installation_results = pod_project_generation_result.target_installation_results
+        @pods_project = pod_project_generation_result.project
         run_podfile_post_install_hooks
-        generator.write
-        generator.share_development_pod_schemes
+        generator.write(@pods_project, @target_installation_results)
+        generator.share_development_pod_schemes(@pods_project)
         write_lockfiles
       end
     end
-
     #-------------------------------------------------------------------------#
 
     public

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -11,14 +11,11 @@ module Pod
         require 'cocoapods/installer/xcode/pods_project_generator/pod_target_installer'
         require 'cocoapods/installer/xcode/pods_project_generator/file_references_installer'
         require 'cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer'
+        require 'cocoapods/installer/xcode/pods_project_generator_result'
 
         # @return [Sandbox] The sandbox where the Pods should be installed.
         #
         attr_reader :sandbox
-
-        # @return [Pod::Project] the `Pods/Pods.xcodeproj` project.
-        #
-        attr_reader :project
 
         # @return [Array<AggregateTarget>] The model representations of an
         #         aggregation of pod targets generated for a target definition
@@ -62,15 +59,15 @@ module Pod
         end
 
         def generate!
-          prepare
-          install_file_references
-          @target_installation_results = install_targets
-          integrate_targets(@target_installation_results.pod_target_installation_results)
-          wire_target_dependencies(@target_installation_results)
-          @target_installation_results
+          project = prepare
+          install_file_references(project)
+          target_installation_results = install_targets(project)
+          integrate_targets(target_installation_results.pod_target_installation_results)
+          wire_target_dependencies(project, target_installation_results)
+          PodsProjectGeneratorResult.new(project, target_installation_results)
         end
 
-        def write
+        def write(project, target_installation_results)
           UI.message "- Writing Xcode project file to #{UI.path sandbox.project_path}" do
             project.pods.remove_from_project if project.pods.empty?
             project.development_pods.remove_from_project if project.development_pods.empty?
@@ -80,7 +77,7 @@ module Pod
             end
             library_product_types = [:framework, :dynamic_library, :static_library]
 
-            pod_target_installation_results = @target_installation_results.pod_target_installation_results
+            pod_target_installation_results = target_installation_results.pod_target_installation_results
             results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
               [result.native_target, result]
             end]
@@ -101,7 +98,7 @@ module Pod
         #
         # @return [void]
         #
-        def share_development_pod_schemes
+        def share_development_pod_schemes(project)
           development_pod_targets.select(&:should_build?).each do |pod_target|
             next unless share_scheme_for_development_pod?(pod_target.pod_name)
             Xcodeproj::XCScheme.share_scheme(project.path, pod_target.label)
@@ -127,38 +124,38 @@ module Pod
 
         # Creates the Pods project from scratch if it doesn't exists.
         #
-        # @return [void]
+        # @return [Project]
         #
         # @todo   Clean and modify the project if it exists.
         #
         def prepare
           UI.message '- Creating Pods project' do
-            @project = create_project
+            project = create_project
             analysis_result.all_user_build_configurations.each do |name, type|
-              @project.add_build_configuration(name, type)
+              project.add_build_configuration(name, type)
             end
             # Reset symroot just in case the user has added a new build configuration other than 'Debug' or 'Release'.
-            @project.symroot = Pod::Project::LEGACY_BUILD_ROOT
+            project.symroot = Pod::Project::LEGACY_BUILD_ROOT
 
             pod_names = pod_targets.map(&:pod_name).uniq
             pod_names.each do |pod_name|
               local = sandbox.local?(pod_name)
               path = sandbox.pod_dir(pod_name)
               was_absolute = sandbox.local_path_was_absolute?(pod_name)
-              @project.add_pod_group(pod_name, path, local, was_absolute)
+              project.add_pod_group(pod_name, path, local, was_absolute)
             end
 
             if config.podfile_path
-              @project.add_podfile(config.podfile_path)
+              project.add_podfile(config.podfile_path)
             end
 
-            sandbox.project = @project
+            sandbox.project = project
             platforms = aggregate_targets.map(&:platform)
             osx_deployment_target = platforms.select { |p| p.name == :osx }.map(&:deployment_target).min
             ios_deployment_target = platforms.select { |p| p.name == :ios }.map(&:deployment_target).min
             watchos_deployment_target = platforms.select { |p| p.name == :watchos }.map(&:deployment_target).min
             tvos_deployment_target = platforms.select { |p| p.name == :tvos }.map(&:deployment_target).min
-            @project.build_configurations.each do |build_configuration|
+            project.build_configurations.each do |build_configuration|
               build_configuration.build_settings['MACOSX_DEPLOYMENT_TARGET'] = osx_deployment_target.to_s if osx_deployment_target
               build_configuration.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = ios_deployment_target.to_s if ios_deployment_target
               build_configuration.build_settings['WATCHOS_DEPLOYMENT_TARGET'] = watchos_deployment_target.to_s if watchos_deployment_target
@@ -166,15 +163,16 @@ module Pod
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
             end
+            project
           end
         end
 
-        def install_file_references
+        def install_file_references(project)
           installer = FileReferencesInstaller.new(sandbox, pod_targets, project, installation_options.preserve_pod_file_structure)
           installer.install!
         end
 
-        def install_targets
+        def install_targets(project)
           UI.message '- Installing targets' do
             umbrella_headers_by_dir = pod_targets.map do |pod_target|
               next unless pod_target.should_build? && pod_target.defines_module?
@@ -183,7 +181,7 @@ module Pod
 
             pod_target_installation_results = Hash[pod_targets.sort_by(&:name).map do |pod_target|
               umbrella_headers_in_header_dir = umbrella_headers_by_dir[pod_target.module_map_path.dirname]
-              target_installer = PodTargetInstaller.new(sandbox, @project, pod_target, umbrella_headers_in_header_dir)
+              target_installer = PodTargetInstaller.new(sandbox, project, pod_target, umbrella_headers_in_header_dir)
               [pod_target.name, target_installer.install!]
             end]
 
@@ -194,7 +192,7 @@ module Pod
             end
 
             aggregate_target_installation_results = Hash[aggregate_targets.sort_by(&:name).map do |target|
-              target_installer = AggregateTargetInstaller.new(sandbox, @project, target)
+              target_installer = AggregateTargetInstaller.new(sandbox, project, target)
               [target.name, target_installer.install!]
             end]
 
@@ -240,7 +238,7 @@ module Pod
         #
         # @return [void]
         #
-        def wire_target_dependencies(target_installation_results)
+        def wire_target_dependencies(project, target_installation_results)
           frameworks_group = project.frameworks_group
           pod_target_installation_results_hash = target_installation_results.pod_target_installation_results
           aggregate_target_installation_results_hash = target_installation_results.aggregate_target_installation_results

--- a/lib/cocoapods/installer/xcode/pods_project_generator_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator_result.rb
@@ -1,0 +1,29 @@
+module Pod
+  class Installer
+    class Xcode
+      class PodsProjectGenerator
+        # A simple container produced after a pod project generation is completed.
+        #
+        class PodsProjectGeneratorResult
+          # @return [Project] project
+          #
+          attr_reader :project
+
+          # @return [InstallationResults] target installation results
+          #
+          attr_reader :target_installation_results
+
+          # Initialize a new instance
+          #
+          # @param [Project] project @see #project
+          # @param [InstallationResults] target_installation_results @see #target_installation_results
+          #
+          def initialize(project, target_installation_results)
+            @project = project
+            @target_installation_results = target_installation_results
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -85,40 +85,40 @@ module Pod
           end
 
           it "creates build configurations for all of the user's targets" do
-            @generator.generate!
-            @generator.project.build_configurations.map(&:name).sort.should == ['App Store', 'Debug', 'Release', 'Test']
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.build_configurations.map(&:name).sort.should == ['App Store', 'Debug', 'Release', 'Test']
           end
 
           it 'sets STRIP_INSTALLED_PRODUCT to NO for all configurations for the whole project' do
-            @generator.generate!
-            @generator.project.build_settings('Debug')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
-            @generator.project.build_settings('Test')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
-            @generator.project.build_settings('Release')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
-            @generator.project.build_settings('App Store')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.build_settings('Debug')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
+            pod_generator_result.project.build_settings('Test')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
+            pod_generator_result.project.build_settings('Release')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
+            pod_generator_result.project.build_settings('App Store')['STRIP_INSTALLED_PRODUCT'].should == 'NO'
           end
 
           it 'sets the SYMROOT to the default value for all configurations for the whole project' do
-            @generator.generate!
-            @generator.project.build_settings('Debug')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
-            @generator.project.build_settings('Test')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
-            @generator.project.build_settings('Release')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
-            @generator.project.build_settings('App Store')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.build_settings('Debug')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+            pod_generator_result.project.build_settings('Test')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+            pod_generator_result.project.build_settings('Release')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
+            pod_generator_result.project.build_settings('App Store')['SYMROOT'].should == Pod::Project::LEGACY_BUILD_ROOT
           end
 
           it 'creates the correct Pods project' do
-            @generator.generate!
-            @generator.project.class.should == Pod::Project
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.class.should == Pod::Project
           end
 
           it 'adds the Podfile to the Pods project' do
             config.stubs(:podfile_path).returns(Pathname.new('/Podfile'))
-            @generator.generate!
-            @generator.project['Podfile'].should.be.not.nil
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project['Podfile'].should.be.not.nil
           end
 
           it 'sets the deployment target for the whole project' do
-            @generator.generate!
-            build_settings = @generator.project.build_configurations.map(&:build_settings)
+            pod_generator_result = @generator.generate!
+            build_settings = pod_generator_result.project.build_configurations.map(&:build_settings)
             build_settings.each do |build_setting|
               build_setting['MACOSX_DEPLOYMENT_TARGET'].should == '10.8'
               build_setting['IPHONEOS_DEPLOYMENT_TARGET'].should == '6.0'
@@ -126,8 +126,8 @@ module Pod
           end
 
           it 'installs file references' do
-            @generator.generate!
-            banana_group = @generator.project.group_for_spec('BananaLib')
+            pod_generator_result = @generator.generate!
+            banana_group = pod_generator_result.project.group_for_spec('BananaLib')
             banana_group.files.map(&:name).sort.should == [
               'Banana.h',
               'Banana.m',
@@ -135,13 +135,13 @@ module Pod
               'BananaTrace.d',
               'MoreBanana.h',
             ]
-            monkey_group = @generator.project.group_for_spec('monkey')
+            monkey_group = pod_generator_result.project.group_for_spec('monkey')
             monkey_group.files.map(&:name).sort.should.be.empty # pre-built pod
-            organge_framework_group = @generator.project.group_for_spec('OrangeFramework')
+            organge_framework_group = pod_generator_result.project.group_for_spec('OrangeFramework')
             organge_framework_group.files.map(&:name).sort.should. == [
               'Juicer.swift',
             ]
-            coconut_group = @generator.project.group_for_spec('CoconutLib')
+            coconut_group = pod_generator_result.project.group_for_spec('CoconutLib')
             coconut_group.files.map(&:name).sort.should == [
               'Coconut.h',
               'Coconut.m',
@@ -149,8 +149,8 @@ module Pod
           end
 
           it 'installs the correct targets in the project' do
-            @generator.generate!
-            @generator.project.targets.map(&:name).sort.should == [
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.map(&:name).sort.should == [
               'AppHost-WatermelonLib-iOS-Unit-Tests',
               'AppHost-WatermelonLib-macOS-Unit-Tests',
               'BananaLib-iOS',
@@ -176,23 +176,23 @@ module Pod
           end
 
           it 'sets the pod and aggregate target dependencies' do
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'BananaLib-iOS' }.dependencies.map(&:name).should.be.empty
-            @generator.project.targets.find { |t| t.name == 'BananaLib-macOS' }.dependencies.map(&:name).should.be.empty
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-macOS' }.dependencies.map(&:name).should.be.empty
-            @generator.project.targets.find { |t| t.name == 'monkey-iOS' }.dependencies.map(&:name).should.be.empty
-            @generator.project.targets.find { |t| t.name == 'monkey-macOS' }.dependencies.map(&:name).should.be.empty
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'BananaLib-iOS' }.dependencies.map(&:name).should.be.empty
+            pod_generator_result.project.targets.find { |t| t.name == 'BananaLib-macOS' }.dependencies.map(&:name).should.be.empty
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-macOS' }.dependencies.map(&:name).should.be.empty
+            pod_generator_result.project.targets.find { |t| t.name == 'monkey-iOS' }.dependencies.map(&:name).should.be.empty
+            pod_generator_result.project.targets.find { |t| t.name == 'monkey-macOS' }.dependencies.map(&:name).should.be.empty
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.dependencies.map(&:name).sort.should == [
               'OrangeFramework',
             ]
-            @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.dependencies.map(&:name).sort.should == [
               'BananaLib-iOS',
               'CoconutLib-iOS',
               'OrangeFramework',
               'WatermelonLib-iOS',
               'monkey-iOS',
             ]
-            @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-macOS' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-macOS' }.dependencies.map(&:name).sort.should == [
               'BananaLib-macOS',
               'CoconutLib-macOS',
               'WatermelonLib-macOS',
@@ -201,14 +201,14 @@ module Pod
           end
 
           it 'adds no system frameworks to static targets' do
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'OrangeFramework' }.frameworks_build_phase.file_display_names.should == []
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'OrangeFramework' }.frameworks_build_phase.file_display_names.should == []
           end
 
           it 'adds system frameworks to dynamic targets' do
             @orangeframework_pod_target.stubs(:requires_frameworks? => true)
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'OrangeFramework' }.frameworks_build_phase.file_display_names.should == %w(
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'OrangeFramework' }.frameworks_build_phase.file_display_names.should == %w(
               Foundation.framework
               UIKit.framework
             )
@@ -221,35 +221,35 @@ module Pod
                                                         @ios_target.platform, inherited_target_definition)
             inherited_target.search_paths_aggregate_targets << @ios_target
             @generator.aggregate_targets << inherited_target
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS-Tests' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS-Tests' }.dependencies.map(&:name).sort.should == [
               'Pods-SampleApp-iOS',
             ]
           end
 
           it 'sets resource bundle target dependencies' do
             @banana_spec.resource_bundles = { 'BananaLibResourcesBundle' => '**/*' }
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'BananaLib-iOS-BananaLibResourcesBundle' }.should.not.be.nil
-            @generator.project.targets.find { |t| t.name == 'BananaLib-macOS-BananaLibResourcesBundle' }.should.not.be.nil
-            @generator.project.targets.find { |t| t.name == 'BananaLib-iOS' }.dependencies.map(&:name).should == [
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'BananaLib-iOS-BananaLibResourcesBundle' }.should.not.be.nil
+            pod_generator_result.project.targets.find { |t| t.name == 'BananaLib-macOS-BananaLibResourcesBundle' }.should.not.be.nil
+            pod_generator_result.project.targets.find { |t| t.name == 'BananaLib-iOS' }.dependencies.map(&:name).should == [
               'BananaLib-iOS-BananaLibResourcesBundle',
             ]
-            @generator.project.targets.find { |t| t.name == 'BananaLib-macOS' }.dependencies.map(&:name).should == [
+            pod_generator_result.project.targets.find { |t| t.name == 'BananaLib-macOS' }.dependencies.map(&:name).should == [
               'BananaLib-macOS-BananaLibResourcesBundle',
             ]
           end
 
           it 'sets test resource bundle dependencies' do
             @coconut_test_spec.resource_bundles = { 'CoconutLibTestResourcesBundle' => '**/*' }
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS-CoconutLibTestResourcesBundle' }.should.not.be.nil
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-macOS-CoconutLibTestResourcesBundle' }.should.not.be.nil
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS-CoconutLibTestResourcesBundle' }.should.not.be.nil
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-macOS-CoconutLibTestResourcesBundle' }.should.not.be.nil
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
               'CoconutLib-iOS',
               'CoconutLib-iOS-CoconutLibTestResourcesBundle',
             ]
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-macOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-macOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
               'CoconutLib-macOS',
               'CoconutLib-macOS-CoconutLibTestResourcesBundle',
             ]
@@ -257,14 +257,14 @@ module Pod
 
           it 'sets the app host dependency for the tests that need it' do
             @coconut_test_spec.ios.requires_app_host = true
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'AppHost-CoconutLib-iOS-Unit-Tests' }.should.not.be.nil
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'AppHost-CoconutLib-iOS-Unit-Tests' }.should.not.be.nil
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS-Unit-Tests' }.dependencies.map(&:name).sort.should == [
               'AppHost-CoconutLib-iOS-Unit-Tests',
               'CoconutLib-iOS',
             ]
-            @generator.project.targets.find { |t| t.name == 'AppHost-CoconutLib-macOS-Unit-Tests' }.should.be.nil
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-macOS-Unit-Tests' }.dependencies.map(&:name).should == [
+            pod_generator_result.project.targets.find { |t| t.name == 'AppHost-CoconutLib-macOS-Unit-Tests' }.should.be.nil
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-macOS-Unit-Tests' }.dependencies.map(&:name).should == [
               'CoconutLib-macOS',
             ]
           end
@@ -273,8 +273,8 @@ module Pod
             @orangeframework_pod_target.stubs(:requires_frameworks?).returns(true)
             @coconut_ios_pod_target.stubs(:requires_frameworks?).returns(true)
             @coconut_ios_pod_target.stubs(:should_build?).returns(true)
-            @generator.generate!
-            native_target = @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS' }
+            pod_generator_result = @generator.generate!
+            native_target = pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS' }
             native_target.isa.should == 'PBXNativeTarget'
             native_target.frameworks_build_phase.file_display_names.sort.should == [
               'Foundation.framework',
@@ -286,36 +286,36 @@ module Pod
             @orangeframework_pod_target.stubs(:requires_frameworks?).returns(true)
             @coconut_ios_pod_target.stubs(:requires_frameworks?).returns(true)
             @coconut_ios_pod_target.stubs(:should_build?).returns(false)
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.isa.should == 'PBXAggregateTarget'
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.isa.should == 'PBXAggregateTarget'
           end
 
           it 'creates and links app host with an iOS test native target' do
-            @generator.generate!
-            app_host_target = @generator.project.targets.find { |t| t.name == 'AppHost-WatermelonLib-iOS-Unit-Tests' }
+            pod_generator_result = @generator.generate!
+            app_host_target = pod_generator_result.project.targets.find { |t| t.name == 'AppHost-WatermelonLib-iOS-Unit-Tests' }
             app_host_target.name.should.not.be.nil
             app_host_target.symbol_type.should == :application
-            test_native_target = @generator.project.targets.find { |t| t.name == 'WatermelonLib-iOS-Unit-SnapshotTests' }
+            test_native_target = pod_generator_result.project.targets.find { |t| t.name == 'WatermelonLib-iOS-Unit-SnapshotTests' }
             test_native_target.should.not.be.nil
             test_native_target.build_configurations.each do |bc|
               bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-WatermelonLib-iOS-Unit-Tests.app/AppHost-WatermelonLib-iOS-Unit-Tests'
             end
-            @generator.project.root_object.attributes['TargetAttributes'][test_native_target.uuid.to_s].should == {
+            pod_generator_result.project.root_object.attributes['TargetAttributes'][test_native_target.uuid.to_s].should == {
               'TestTargetID' => app_host_target.uuid.to_s,
             }
           end
 
           it 'creates and links app host with an OSX test native target' do
-            @generator.generate!
-            app_host_target = @generator.project.targets.find { |t| t.name == 'AppHost-WatermelonLib-macOS-Unit-Tests' }
+            pod_generator_result = @generator.generate!
+            app_host_target = pod_generator_result.project.targets.find { |t| t.name == 'AppHost-WatermelonLib-macOS-Unit-Tests' }
             app_host_target.name.should.not.be.nil
             app_host_target.symbol_type.should == :application
-            test_native_target = @generator.project.targets.find { |t| t.name == 'WatermelonLib-macOS-Unit-SnapshotTests' }
+            test_native_target = pod_generator_result.project.targets.find { |t| t.name == 'WatermelonLib-macOS-Unit-SnapshotTests' }
             test_native_target.should.not.be.nil
             test_native_target.build_configurations.each do |bc|
               bc.build_settings['TEST_HOST'].should == '$(BUILT_PRODUCTS_DIR)/AppHost-WatermelonLib-macOS-Unit-Tests.app/Contents/MacOS/AppHost-WatermelonLib-macOS-Unit-Tests'
             end
-            @generator.project.root_object.attributes['TargetAttributes'][test_native_target.uuid.to_s].should == {
+            pod_generator_result.project.root_object.attributes['TargetAttributes'][test_native_target.uuid.to_s].should == {
               'TestTargetID' => app_host_target.uuid.to_s,
             }
           end
@@ -323,9 +323,9 @@ module Pod
           it 'configures APPLICATION_EXTENSION_API_ONLY for pod targets of an aggregate target' do
             user_target = stub('SampleApp-iOS-User-Target', :symbol_type => :app_extension)
             @ios_target.stubs(:user_targets).returns([user_target])
-            @generator.generate!
-            @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.dependencies.each do |dependency|
-              build_settings = @generator.project.targets.find { |t| t.name == dependency.name }.build_configurations.map(&:build_settings)
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.dependencies.each do |dependency|
+              build_settings = pod_generator_result.project.targets.find { |t| t.name == dependency.name }.build_configurations.map(&:build_settings)
               build_settings.each do |build_setting|
                 build_setting['APPLICATION_EXTENSION_API_ONLY'].should == 'YES'
               end
@@ -335,8 +335,8 @@ module Pod
           it 'configures APPLICATION_EXTENSION_API_ONLY for app extension targets' do
             user_target = stub('SampleApp-iOS-User-Target', :symbol_type => :app_extension)
             @ios_target.stubs(:user_targets).returns([user_target])
-            @generator.generate!
-            build_settings = @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
+            pod_generator_result = @generator.generate!
+            build_settings = pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
             build_settings.each do |build_setting|
               build_setting['APPLICATION_EXTENSION_API_ONLY'].should == 'YES'
             end
@@ -345,8 +345,8 @@ module Pod
           it 'configures APPLICATION_EXTENSION_API_ONLY for watch2 extension targets' do
             user_target = stub('SampleApp-iOS-User-Target', :symbol_type => :watch2_extension)
             @ios_target.stubs(:user_targets).returns([user_target])
-            @generator.generate!
-            build_settings = @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
+            pod_generator_result = @generator.generate!
+            build_settings = pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
             build_settings.each do |build_setting|
               build_setting['APPLICATION_EXTENSION_API_ONLY'].should == 'YES'
             end
@@ -355,8 +355,8 @@ module Pod
           it 'configures APPLICATION_EXTENSION_API_ONLY for tvOS extension targets' do
             user_target = stub('SampleApp-iOS-User-Target', :symbol_type => :tv_extension)
             @ios_target.stubs(:user_targets).returns([user_target])
-            @generator.generate!
-            build_settings = @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
+            pod_generator_result = @generator.generate!
+            build_settings = pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
             build_settings.each do |build_setting|
               build_setting['APPLICATION_EXTENSION_API_ONLY'].should == 'YES'
             end
@@ -365,8 +365,8 @@ module Pod
           it 'configures APPLICATION_EXTENSION_API_ONLY for Messages extension targets' do
             user_target = stub('SampleApp-iOS-User-Target', :symbol_type => :messages_extension)
             @ios_target.stubs(:user_targets).returns([user_target])
-            @generator.generate!
-            build_settings = @generator.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
+            pod_generator_result = @generator.generate!
+            build_settings = pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.build_configurations.map(&:build_settings)
             build_settings.each do |build_setting|
               build_setting['APPLICATION_EXTENSION_API_ONLY'].should == 'YES'
             end
@@ -390,33 +390,33 @@ module Pod
 
             @generator = PodsProjectGenerator.new(config.sandbox, [target], [],
                                                   @analysis_result, @installation_options, config)
-            @generator.generate!
-            @generator.project.object_version.should == '1'
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.object_version.should == '1'
 
             FileUtils.rm_rf(tmp_directory)
           end
 
           describe '#write' do
             it 'recursively sorts the project' do
-              @generator.generate!
-              @generator.project.main_group.expects(:sort)
+              pod_generator_result = @generator.generate!
+              pod_generator_result.project.main_group.expects(:sort)
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
-              @generator.write
+              @generator.write(pod_generator_result.project, pod_generator_result.target_installation_results)
             end
 
             it 'saves the project to the given path' do
-              @generator.generate!
+              pod_generator_result = @generator.generate!
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
               temporary_directory + 'Pods/Pods.xcodeproj'
-              @generator.project.expects(:save)
-              @generator.write
+              pod_generator_result.project.expects(:save)
+              @generator.write(pod_generator_result.project, pod_generator_result.target_installation_results)
             end
           end
 
           describe '#share_development_pod_schemes' do
             it 'does not share by default' do
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              @generator.share_development_pod_schemes
+              @generator.share_development_pod_schemes(nil)
             end
 
             it 'can share all schemes' do
@@ -424,18 +424,18 @@ module Pod
                   stubs(:share_schemes_for_development_pods).
                   returns(true)
 
-              @generator.generate!
+              pod_generator_result = @generator.generate!
               @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
 
               Xcodeproj::XCScheme.expects(:share_scheme).with(
-                @generator.project.path,
+                pod_generator_result.project.path,
                 'BananaLib-iOS')
 
               Xcodeproj::XCScheme.expects(:share_scheme).with(
-                @generator.project.path,
+                pod_generator_result.project.path,
                 'BananaLib-macOS')
 
-              @generator.share_development_pod_schemes
+              @generator.share_development_pod_schemes(pod_generator_result.project)
             end
           end
 
@@ -445,25 +445,25 @@ module Pod
                 returns(true)
             @generator.sandbox.stubs(:development_pods).returns('CoconutLib' => fixture('CoconutLib'))
 
-            @generator.generate!
+            pod_generator_result = @generator.generate!
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'CoconutLib-iOS')
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'CoconutLib-iOS-Unit-Tests')
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'CoconutLib-macOS')
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'CoconutLib-macOS-Unit-Tests')
 
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(pod_generator_result.project)
           end
 
           it 'allows opting out' do
@@ -472,14 +472,14 @@ module Pod
                 returns(false)
 
             Xcodeproj::XCScheme.expects(:share_scheme).never
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(nil)
 
             @generator.installation_options.
                 stubs(:share_schemes_for_development_pods).
                 returns(nil)
 
             Xcodeproj::XCScheme.expects(:share_scheme).never
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(nil)
           end
 
           it 'allows specifying strings of pods to share' do
@@ -487,25 +487,25 @@ module Pod
                 stubs(:share_schemes_for_development_pods).
                 returns(%w(BananaLib))
 
-            @generator.generate!
+            pod_generator_result = @generator.generate!
             @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'BananaLib-iOS')
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'BananaLib-macOS')
 
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(pod_generator_result.project)
 
             @generator.installation_options.
                 stubs(:share_schemes_for_development_pods).
                 returns(%w(orange-framework))
 
             Xcodeproj::XCScheme.expects(:share_scheme).never
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(pod_generator_result.project)
           end
 
           it 'allows specifying regular expressions of pods to share' do
@@ -513,25 +513,25 @@ module Pod
                 stubs(:share_schemes_for_development_pods).
                 returns([/bAnaNalIb/i, /B*/])
 
-            @generator.generate!
+            pod_generator_result = @generator.generate!
             @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'BananaLib-iOS')
 
             Xcodeproj::XCScheme.expects(:share_scheme).with(
-              @generator.project.path,
+              pod_generator_result.project.path,
               'BananaLib-macOS')
 
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(pod_generator_result.project)
 
             @generator.installation_options.
                 stubs(:share_schemes_for_development_pods).
                 returns([/banana$/, /[^\A]BananaLib/])
 
             Xcodeproj::XCScheme.expects(:share_scheme).never
-            @generator.share_development_pod_schemes
+            @generator.share_development_pod_schemes(nil)
           end
 
           it 'raises when an invalid type is set' do
@@ -539,11 +539,11 @@ module Pod
                 stubs(:share_schemes_for_development_pods).
                 returns(Pathname('foo'))
 
-            @generator.generate!
+            pod_generator_result = @generator.generate!
             @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
 
             Xcodeproj::XCScheme.expects(:share_scheme).never
-            e = should.raise(Informative) { @generator.share_development_pod_schemes }
+            e = should.raise(Informative) { @generator.share_development_pod_schemes(pod_generator_result.project) }
             e.message.should.match /share_schemes_for_development_pods.*set it to true, false, or an array of pods to share schemes for/
           end
         end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -92,7 +92,8 @@ module Pod
         @installer.unstub(:generate_pods_project)
         generator = @installer.send(:create_generator)
         @installer.stubs(:create_generator).returns(generator)
-        generator.stubs(:generate!)
+        generator_result = Installer::Xcode::PodsProjectGenerator::PodsProjectGeneratorResult.new(nil, [])
+        generator.stubs(:generate!).returns(generator_result)
         generator.stubs(:share_development_pod_schemes)
 
         hooks = sequence('hooks')


### PR DESCRIPTION
Functions in this class now rely less on the assumption that a project object will be created by the time the function is ran and requires a `project` parameter to be passed into itself. Since the `generate!` function is responsible for actually creating the Pods project file, we return it wrapped inside a `PodsProjectGeneratorResult` object alongside the `target_installation_results` that is also returned from `generate!`.