### PR TITLE
[InstallationOptions] Reduce reliance on access to InstallationOptions

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/string/inflections'
 require 'fileutils'
+require 'cocoapods/podfile'
 
 module Pod
   # The Installer is responsible of taking a Podfile and transform it in the
@@ -41,9 +42,6 @@ module Pod
     autoload :Xcode,                      'cocoapods/installer/xcode'
 
     include Config::Mixin
-    include InstallationOptions::Mixin
-
-    delegate_installation_options { podfile }
 
     # @return [Sandbox] The sandbox where the Pods should be installed.
     #
@@ -210,11 +208,12 @@ module Pod
         @target_installation_results = pod_project_generation_result.target_installation_results
         @pods_project = pod_project_generation_result.project
         run_podfile_post_install_hooks
-        generator.write(@pods_project, @target_installation_results)
+        Xcode::PodsProjectGenerator.write(@pods_project, target_installation_results, @sandbox.project_path, installation_options.deterministic_uuids?)
         generator.share_development_pod_schemes(@pods_project)
         write_lockfiles
       end
     end
+
     #-------------------------------------------------------------------------#
 
     public
@@ -269,9 +268,7 @@ module Pod
     end
 
     def create_analyzer(plugin_sources = nil)
-      Analyzer.new(sandbox, podfile, lockfile, plugin_sources, has_dependencies?, update).tap do |analyzer|
-        analyzer.installation_options = installation_options
-      end
+      Analyzer.new(sandbox, podfile, lockfile, plugin_sources, has_dependencies?, update)
     end
 
     # Ensures that the white-listed build configurations are known to prevent
@@ -641,7 +638,7 @@ module Pod
     def integrate_user_project
       UI.section "Integrating client #{'project'.pluralize(aggregate_targets.map(&:user_project_path).uniq.count)}" do
         installation_root = config.installation_root
-        integrator = UserProjectIntegrator.new(podfile, sandbox, installation_root, aggregate_targets)
+        integrator = UserProjectIntegrator.new(podfile, sandbox, installation_root, aggregate_targets, :use_input_output_paths => !installation_options.disable_input_output_paths?)
         integrator.integrate!
       end
     end
@@ -735,6 +732,12 @@ module Pod
     #
     def sandbox_state
       analysis_result.sandbox_state
+    end
+
+    # @return [InstallationOptions] the installation options to use during install
+    #
+    def installation_options
+      podfile.installation_options
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -1,3 +1,5 @@
+require 'cocoapods/podfile'
+
 module Pod
   class Installer
     # Analyzes the Podfile, the Lockfile, and the sandbox manifest to generate
@@ -5,9 +7,6 @@ module Pod
     #
     class Analyzer
       include Config::Mixin
-      include InstallationOptions::Mixin
-
-      delegate_installation_options { podfile }
 
       autoload :AnalysisResult,            'cocoapods/installer/analyzer/analysis_result'
       autoload :LockingDependencyAnalyzer, 'cocoapods/installer/analyzer/locking_dependency_analyzer'
@@ -51,6 +50,10 @@ module Pod
       #
       attr_reader :pods_to_update
 
+      # @return [InstallationOptions] the installation options specified by the Podfile
+      #
+      attr_reader :installation_options
+
       # Initialize a new instance
       #
       # @param  [Sandbox] sandbox @see #sandbox
@@ -68,6 +71,7 @@ module Pod
         @plugin_sources = plugin_sources
         @has_dependencies = has_dependencies
         @pods_to_update = pods_to_update
+        @installation_options = podfile.installation_options
         @podfile_dependency_cache = PodfileDependencyCache.from_podfile(podfile)
         @result = nil
       end

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -171,51 +171,6 @@ module Pod
       # `:preserve_pod_file_structure` to `true` will _always_ preserve the file structure.
       #
       option :preserve_pod_file_structure, false
-
-      module Mixin
-        module ClassMethods
-          # Delegates the creation of {#installation_options} to the `Podfile`
-          # returned by the given block.
-          #
-          # @param  blk a block that returns the `Podfile` to create
-          #         installation options from.
-          #
-          # @return [Void]
-          #
-          def delegate_installation_options(&blk)
-            define_method(:installation_options) do
-              @installation_options ||= InstallationOptions.from_podfile(instance_eval(&blk))
-            end
-          end
-
-          # Delegates the installation options attributes directly to
-          # {#installation_options}.
-          #
-          # @return [Void]
-          #
-          def delegate_installation_option_attributes!
-            define_method(:respond_to_missing?) do |name, *args|
-              installation_options.respond_to?(name, *args) || super
-            end
-
-            define_method(:method_missing) do |name, *args, &blk|
-              if installation_options.respond_to?(name)
-                installation_options.send(name, *args, &blk)
-              else
-                super
-              end
-            end
-          end
-        end
-
-        # @return [InstallationOptions] The installation options.
-        #
-        attr_accessor :installation_options
-
-        def self.included(mod)
-          mod.extend(ClassMethods)
-        end
-      end
     end
   end
 end

--- a/lib/cocoapods/installer/user_project_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator.rb
@@ -13,10 +13,6 @@ module Pod
     class UserProjectIntegrator
       autoload :TargetIntegrator, 'cocoapods/installer/user_project_integrator/target_integrator'
 
-      include InstallationOptions::Mixin
-
-      delegate_installation_options { podfile }
-
       # @return [Podfile] the podfile that should be integrated with the user
       #         projects.
       #
@@ -41,6 +37,11 @@ module Pod
       #
       attr_reader :targets
 
+      # @return [Boolean] whether to use input/output paths for build phase scripts
+      #
+      attr_reader :use_input_output_paths
+      alias use_input_output_paths? use_input_output_paths
+
       # Init a new UserProjectIntegrator
       #
       # @param  [Podfile]  podfile @see #podfile
@@ -48,11 +49,12 @@ module Pod
       # @param  [Pathname] installation_root @see #installation_root
       # @param  [Array<AggregateTarget>] targets @see #targets
       #
-      def initialize(podfile, sandbox, installation_root, targets)
+      def initialize(podfile, sandbox, installation_root, targets, use_input_output_paths: true)
         @podfile = podfile
         @sandbox = sandbox
         @installation_root = installation_root
         @targets = targets
+        @use_input_output_paths = use_input_output_paths
       end
 
       # Integrates the user projects associated with the {TargetDefinitions}
@@ -115,7 +117,7 @@ module Pod
       #
       def integrate_user_targets
         target_integrators = targets_to_integrate.sort_by(&:name).map do |target|
-          TargetIntegrator.new(target, installation_options)
+          TargetIntegrator.new(target, :use_input_output_paths => use_input_output_paths?)
         end
 
         Config.instance.with_changes(:silent => true) do

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -49,18 +49,19 @@ module Pod
         #
         attr_reader :target
 
-        # @return [InstallationOptions] the installation options from the Podfile.
+        # @return [Boolean] whether to use input/output paths for build phase scripts
         #
-        attr_reader :installation_options
+        attr_reader :use_input_output_paths
+        alias use_input_output_paths? use_input_output_paths
 
         # Init a new TargetIntegrator
         #
         # @param  [AggregateTarget] target @see #target
-        # @param  [InstallationOptions] installation_options @see #installation_options
+        # @param  [Boolean] use_input_output_paths @see #use_input_output_paths
         #
-        def initialize(target, installation_options)
+        def initialize(target, use_input_output_paths: true)
           @target = target
-          @installation_options = installation_options
+          @use_input_output_paths = use_input_output_paths
         end
 
         class << self
@@ -354,7 +355,7 @@ module Pod
           script_path = target.copy_resources_script_relative_path
           input_paths = []
           output_paths = []
-          unless installation_options.disable_input_output_paths?
+          if use_input_output_paths?
             resource_paths_by_config = target.resource_paths_by_config
             resource_paths_flattened = resource_paths_by_config.values.flatten.uniq
             input_paths = [target.copy_resources_script_relative_path, *resource_paths_flattened]
@@ -397,7 +398,7 @@ module Pod
           script_path = target.embed_frameworks_script_relative_path
           input_paths = []
           output_paths = []
-          unless installation_options.disable_input_output_paths?
+          if use_input_output_paths?
             framework_paths = target.framework_paths_by_config.values.flatten.uniq
             framework_input_paths = framework_paths.flat_map { |path| [path.source_path, path.dsym_path] }.compact
             input_paths = [target.embed_frameworks_script_relative_path, *framework_input_paths]

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -67,12 +67,28 @@ module Pod
           PodsProjectGeneratorResult.new(project, target_installation_results)
         end
 
-        def write(project, target_installation_results)
-          UI.message "- Writing Xcode project file to #{UI.path sandbox.project_path}" do
+        # Writes the project to the provided path, performing any final steps necessary before saving
+        # the project to disk
+        #
+        # @param [Pod::Project] project the project to write
+        #
+        # @param [InstallationResults] target_installation_results
+        #        the installation results to use when creating schemes
+        #
+        # @param [Pathname] destination_path
+        #        the path to which the project will be written
+        #
+        # @param [Boolean] deterministic_uuids
+        #        Whether to use deterministic UUIDs in the project. See {Xcodeproj#predictabilize_uuids}
+        #
+        # @return [void]
+        #
+        def self.write(project, target_installation_results, destination_path, deterministic_uuids)
+          UI.message "- Writing Xcode project file to #{UI.path destination_path}" do
             project.pods.remove_from_project if project.pods.empty?
             project.development_pods.remove_from_project if project.development_pods.empty?
             project.sort(:groups_position => :below)
-            if installation_options.deterministic_uuids?
+            if deterministic_uuids
               UI.message('- Generating deterministic UUIDs') { project.predictabilize_uuids }
             end
             library_product_types = [:framework, :dynamic_library, :static_library]
@@ -94,7 +110,7 @@ module Pod
                 scheme.add_build_target(add_build_target)
               end
             end
-            project.save
+            project.save(destination_path)
           end
         end
 
@@ -103,26 +119,26 @@ module Pod
         # @return [void]
         #
         def share_development_pod_schemes(project)
-          development_pod_targets.select(&:should_build?).each do |pod_target|
-            next unless share_scheme_for_development_pod?(pod_target.pod_name)
+          targets = development_pod_targets.select do |target|
+            target.should_build? && share_scheme_for_development_pod?(target.pod_name)
+          end
+          targets.each do |pod_target|
             Xcodeproj::XCScheme.share_scheme(project.path, pod_target.label)
-            if pod_target.contains_test_specifications?
-              pod_target.test_specs.each do |test_spec|
-                Xcodeproj::XCScheme.share_scheme(project.path, pod_target.test_target_label(test_spec))
-              end
+            pod_target.test_specs.each do |test_spec|
+              Xcodeproj::XCScheme.share_scheme(project.path, pod_target.test_target_label(test_spec))
             end
 
-            if pod_target.contains_app_specifications?
-              pod_target.app_specs.each do |app_spec|
-                Xcodeproj::XCScheme.share_scheme(project.path, pod_target.app_target_label(app_spec))
-              end
+            pod_target.app_specs.each do |app_spec|
+              Xcodeproj::XCScheme.share_scheme(project.path, pod_target.app_target_label(app_spec))
             end
           end
         end
 
-        private
-
+        # @!attribute [Hash{String => TargetInstallationResult}] pod_target_installation_results
+        # @!attribute [Hash{String => TargetInstallationResult}] aggregate_target_installation_results
         InstallationResults = Struct.new(:pod_target_installation_results, :aggregate_target_installation_results)
+
+        private
 
         def create_project
           if object_version = aggregate_targets.map(&:user_project).compact.map { |p| p.object_version.to_i }.min
@@ -210,6 +226,11 @@ module Pod
           end
         end
 
+        # @param [Hash{String => InstallationResult}] pod_target_installation_results
+        #        the installations to integrate
+        #
+        # @return [void]
+        #
         def integrate_targets(pod_target_installation_results)
           pod_installations_to_integrate = pod_target_installation_results.values.select do |pod_target_installation_result|
             pod_target = pod_target_installation_result.target
@@ -217,11 +238,12 @@ module Pod
                 !pod_target_installation_result.app_native_targets.empty? ||
                 pod_target.contains_script_phases?
           end
-          unless pod_installations_to_integrate.empty?
-            UI.message '- Integrating targets' do
-              pod_installations_to_integrate.each do |pod_target_installation_result|
-                PodTargetIntegrator.new(pod_target_installation_result, installation_options).integrate!
-              end
+          return if pod_installations_to_integrate.empty?
+
+          UI.message '- Integrating targets' do
+            use_input_output_paths = !installation_options.disable_input_output_paths
+            pod_installations_to_integrate.each do |pod_target_installation_result|
+              PodTargetIntegrator.new(pod_target_installation_result, :use_input_output_paths => use_input_output_paths).integrate!
             end
           end
         end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_integrator.rb
@@ -10,18 +10,19 @@ module Pod
           #
           attr_reader :target_installation_result
 
-          # @return [InstallationOptions] the installation options from the Podfile.
+          # @return [Boolean] whether to use input/output paths for build phase scripts
           #
-          attr_reader :installation_options
+          attr_reader :use_input_output_paths
+          alias use_input_output_paths? use_input_output_paths
 
           # Initialize a new instance
           #
           # @param  [TargetInstallationResult] target_installation_result @see #target_installation_result
-          # @param  [InstallationOptions] installation_options @see #installation_options
+          # @param  [Boolean] use_input_output_paths @see #use_input_output_paths
           #
-          def initialize(target_installation_result, installation_options)
+          def initialize(target_installation_result, use_input_output_paths: true)
             @target_installation_result = target_installation_result
-            @installation_options = installation_options
+            @use_input_output_paths = use_input_output_paths
           end
 
           # Integrates the pod target.
@@ -73,7 +74,7 @@ module Pod
                           end
             input_paths = []
             output_paths = []
-            unless installation_options.disable_input_output_paths?
+            if use_input_output_paths
               dependent_targets = if spec.test_specification?
                                     target.dependent_targets_for_test_spec(spec)
                                   else
@@ -106,7 +107,7 @@ module Pod
                           end
             input_paths = []
             output_paths = []
-            unless installation_options.disable_input_output_paths?
+            if use_input_output_paths?
               dependent_targets = if spec.test_specification?
                                     target.dependent_targets_for_test_spec(spec)
                                   else
@@ -136,7 +137,7 @@ module Pod
             puts "script_path : #{script_path}"
             input_paths = []
             output_paths = []
-            unless installation_options.disable_input_output_paths?
+            if use_input_output_paths
               framework_paths = target.dependent_targets_for_app_spec(app_spec).flat_map do |dependent_target|
                 spec_paths_to_include = dependent_target.library_specs.map(&:name)
                 spec_paths_to_include << app_spec.name if dependent_target == target

--- a/lib/cocoapods/podfile.rb
+++ b/lib/cocoapods/podfile.rb
@@ -1,0 +1,13 @@
+require 'cocoapods-core/podfile'
+
+module Pod
+  class Podfile
+    autoload :InstallationOptions, 'cocoapods/installer/installation_options'
+
+    # @return [Pod::Installer::InstallationOptions] the installation options specified in the Podfile
+    #
+    def installation_options
+      @installation_options ||= Pod::Installer::InstallationOptions.from_podfile(self)
+    end
+  end
+end

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -1,4 +1,5 @@
 require 'molinillo'
+require 'cocoapods/podfile'
 
 module Pod
   class NoSpecFoundError < Informative
@@ -13,10 +14,6 @@ module Pod
   class Resolver
     require 'cocoapods/resolver/lazy_specification'
     require 'cocoapods/resolver/resolver_specification'
-
-    include Pod::Installer::InstallationOptions::Mixin
-
-    delegate_installation_options { podfile }
 
     # @return [Sandbox] the Sandbox used by the resolver to find external
     #         dependencies.
@@ -333,7 +330,7 @@ module Pod
     def specifications_for_dependency(dependency, additional_requirements = [])
       requirement = Requirement.new(dependency.requirement.as_list + additional_requirements.flat_map(&:as_list))
       find_cached_set(dependency).
-        all_specifications(installation_options.warn_for_multiple_pod_sources).
+        all_specifications(warn_for_multiple_pod_sources).
         select { |s| requirement.satisfied_by? s.version }.
         map { |s| s.subspec_by_name(dependency.name, false, true) }.
         compact
@@ -573,6 +570,12 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       end
 
       @edge_validity[EdgeAndPlatform.new(edge, target_platform)]
+    end
+
+    # @return [Boolean] whether to emit a warning when a pod is found in multiple sources
+    #
+    def warn_for_multiple_pod_sources
+      podfile.installation_options.warn_for_multiple_pod_sources
     end
   end
 end

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -24,9 +24,7 @@ module Pod
         @pod_bundle.xcconfigs['Debug'] = configuration
         @pod_bundle.xcconfigs['Release'] = configuration
 
-        @installation_options = Pod::Installer::InstallationOptions.new
-
-        @target_integrator = TargetIntegrator.new(@pod_bundle, @installation_options)
+        @target_integrator = TargetIntegrator.new(@pod_bundle)
         @target_integrator.private_methods.grep(/^update_to_cocoapods_/).each do |method|
           @target_integrator.stubs(method)
         end

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -401,15 +401,15 @@ module Pod
               pod_generator_result = @generator.generate!
               pod_generator_result.project.main_group.expects(:sort)
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
-              @generator.write(pod_generator_result.project, pod_generator_result.target_installation_results)
+              PodsProjectGenerator.write(pod_generator_result.project, pod_generator_result.target_installation_results, @generator.sandbox.project_path, false)
             end
 
             it 'saves the project to the given path' do
               pod_generator_result = @generator.generate!
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
-              temporary_directory + 'Pods/Pods.xcodeproj'
-              pod_generator_result.project.expects(:save)
-              @generator.write(pod_generator_result.project, pod_generator_result.target_installation_results)
+              path = temporary_directory + 'Pods/Pods.xcodeproj'
+              pod_generator_result.project.expects(:save).with(path)
+              PodsProjectGenerator.write(pod_generator_result.project, pod_generator_result.target_installation_results, path, false)
             end
           end
 

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -17,15 +17,9 @@ module Pod
 
         # @return [AnalysisResult]
         #
-        def create_validator(sandbox, podfile, lockfile, integrate_targets = false)
-          installation_options = Installer::InstallationOptions.new.tap do |options|
-            options.integrate_targets = integrate_targets
-          end
-
+        def create_validator(sandbox, podfile, lockfile)
           sandbox.specifications_root.mkpath
-          @analyzer = Analyzer.new(sandbox, podfile, lockfile).tap do |analyzer|
-            analyzer.installation_options = installation_options
-          end
+          @analyzer = Analyzer.new(sandbox, podfile, lockfile, nil, true, false)
           result = @analyzer.analyze
 
           aggregate_targets = result.targets
@@ -46,6 +40,7 @@ module Pod
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               project 'SampleProject/SampleProject'
               pod 'BananaLib', :path => (fixture_path + 'banana-lib').to_s
               target 'SampleProject'
@@ -65,6 +60,7 @@ module Pod
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               project 'SampleProject/SampleProject'
               pod 'BananaLib',       :path => (fixture_path + 'banana-lib').to_s
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
@@ -85,6 +81,7 @@ module Pod
             config.repos_dir = fixture_path + 'spec-repos'
             podfile = Pod::Podfile.new do
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               project 'SampleProject/SampleProject'
               use_frameworks!
               pod 'BananaLib',       :path => (fixture_path + 'banana-lib').to_s
@@ -116,7 +113,7 @@ module Pod
             end
             lockfile = generate_lockfile
 
-            @validator = create_validator(config.sandbox, podfile, lockfile, true)
+            @validator = create_validator(config.sandbox, podfile, lockfile)
             should.not.raise(Informative) { @validator.validate! }
           end
         end
@@ -270,6 +267,7 @@ module Pod
             podfile = Podfile.new do
               project 'SampleProject/SampleProject'
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               use_frameworks!
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
@@ -300,6 +298,7 @@ module Pod
               project 'SampleProject/SampleProject'
               use_frameworks!
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
               target 'SampleProject'
@@ -327,6 +326,7 @@ module Pod
               project 'SampleProject/SampleProject'
               use_frameworks!
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
               target 'SampleProject' do
@@ -347,6 +347,7 @@ module Pod
               project 'SampleProject/SampleProject'
               use_frameworks!
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
               target 'SampleProject' do
                 current_target_definition.swift_version = '3.0'
@@ -368,6 +369,7 @@ module Pod
               project 'SampleProject/SampleProject'
               use_frameworks!
               platform :ios, '8.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
               target 'SampleProject' do
@@ -391,6 +393,7 @@ module Pod
             podfile = Podfile.new do
               project 'SampleProject/SampleProject'
               platform :ios, '10.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'MultiSwift', :path => (fixture_path + 'multi-swift').to_s
               supports_swift_versions '< 3.0'
               target 'SampleProject'
@@ -413,6 +416,7 @@ module Pod
             podfile = Podfile.new do
               project 'SampleProject/SampleProject'
               platform :ios, '10.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'MultiSwift', :path => (fixture_path + 'multi-swift').to_s
               supports_swift_versions '> 3.0'
               target 'SampleProject'
@@ -432,6 +436,7 @@ module Pod
             podfile = Podfile.new do
               project 'SampleProject/SampleProject'
               platform :ios, '10.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s, :modular_headers => true
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s, :modular_headers => false
               target 'SampleProject'
@@ -455,6 +460,7 @@ module Pod
             podfile = Podfile.new do
               project 'SampleProject/SampleProject'
               platform :ios, '10.0'
+              install! 'cocoapods', :integrate_targets => false
               pod 'OrangeFramework', :path => (fixture_path + 'orange-framework').to_s, :modular_headers => true
               pod 'matryoshka',      :path => (fixture_path + 'matryoshka').to_s
               target 'SampleProject' do


### PR DESCRIPTION
* Remove dependency on InstallationOptions for several classes that only used one value from them:
    - `Installer::UserProjectIntegrator`
    - `Installer::UserProjectIntegrator::TargetIntegrator`
    - `Installer::Xcode::PodsProjectGenerator::PodTargetIntegrator`
* Add `InstallationOptions` to `Podfile`, since they are defined in the Podfile DSL. (Would love feedback on this part - not sure if this is the right way to go, but right now it does feel a bit odd that the InstallationOptions come from the Podfile but are not associated with it)
* Make `PodProjectGenerator#write` a pure class function
* Cleanup some things along the way
    