### PR TITLE
Add a Target::BuildType to represent how a target is built

### DIFF
--- a/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking Mac Example.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 				B47968EF64ED4169C658E405 /* Pods-AFNetworking Example.debug.xcconfig */,
 				694801CD9796D99F3BDD0D95 /* Pods-AFNetworking Example.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -117,7 +116,6 @@
 				F8129C061591061B009BFE23 /* Supporting Files */,
 			);
 			name = Classes;
-			path = "AFNetworking-Mac-Example";
 			sourceTree = "<group>";
 		};
 		F8129C061591061B009BFE23 /* Supporting Files */ = {

--- a/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
+++ b/examples/AFNetworking Example/AFNetworking iOS Example.xcodeproj/project.pbxproj
@@ -94,7 +94,6 @@
 				5723FFCCA3CB8D6E467F174B /* Pods-AFNetworking iOS Example.debug.xcconfig */,
 				0678DF4121D5956B85653CB1 /* Pods-AFNetworking iOS Example.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -182,7 +181,6 @@
 				F8E4696B1395739D00DB05C8 /* Supporting Files */,
 			);
 			name = Classes;
-			path = AFNetworkingExample;
 			sourceTree = "<group>";
 		};
 		F8E4696B1395739D00DB05C8 /* Supporting Files */ = {
@@ -214,7 +212,6 @@
 				F8FA94CD150F094D00ED4EAD /* profile-image-placeholder@2x.png */,
 			);
 			name = Images;
-			path = AFNetworkingExample/Images;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/examples/AFNetworking Example/Examples.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/AFNetworking Example/Examples.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -136,17 +136,17 @@ module Pod
     #         The desired captured output from the command, and the status from
     #         running the command.
     #
-    def self.capture_command(executable, command, capture: :merge)
+    def self.capture_command(executable, command, capture: :merge, **kwargs)
       bin = which!(executable)
 
       require 'open3'
       command = command.map(&:to_s)
       case capture
-      when :merge then Open3.capture2e(bin, *command)
-      when :both then Open3.capture3(bin, *command)
-      when :out then Open3.capture3(bin, *command).values_at(0, -1)
-      when :err then Open3.capture3(bin, *command).drop(1)
-      when :none then Open3.capture3(bin, *command).last
+      when :merge then Open3.capture2e(bin, *command, **kwargs)
+      when :both then Open3.capture3(bin, *command, **kwargs)
+      when :out then Open3.capture3(bin, *command, **kwargs).values_at(0, -1)
+      when :err then Open3.capture3(bin, *command, **kwargs).drop(1)
+      when :none then Open3.capture3(bin, *command, **kwargs).last
       end
     end
 

--- a/lib/cocoapods/generator/module_map.rb
+++ b/lib/cocoapods/generator/module_map.rb
@@ -82,7 +82,7 @@ module Pod
       # Ensures that only framework targets have `framework` prepended.
       #
       def module_specifier_prefix
-        if target.requires_frameworks?
+        if target.build_as_framework?
           'framework '
         else
           ''

--- a/lib/cocoapods/installer/analyzer/pod_variant.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant.rb
@@ -19,10 +19,9 @@ module Pod
         #
         attr_reader :platform
 
-        # @return [Bool] whether this pod should be built as framework
+        # @return [Target::BuildType] the build type of the target
         #
-        attr_reader :requires_frameworks
-        alias_method :requires_frameworks?, :requires_frameworks
+        attr_reader :build_type
 
         # @return [Specification] the root specification
         #
@@ -36,15 +35,15 @@ module Pod
         # @param [Array<Specification>] test_specs @see #test_specs
         # @param [Array<Specification>] app_specs  @see #app_specs
         # @param [Platform] platform               @see #platform
-        # @param [Bool] requires_frameworks        @see #requires_frameworks?
+        # @param [Target::BuildType] build_type    @see #build_type
         #
-        def initialize(specs, test_specs, app_specs, platform, requires_frameworks = false)
+        def initialize(specs, test_specs, app_specs, platform, build_type = Target::BuildType.static_library)
           @specs = specs
           @test_specs = test_specs
           @app_specs = app_specs
           @platform = platform
-          @requires_frameworks = requires_frameworks
-          @hash = [specs, platform, requires_frameworks].hash
+          @build_type = build_type
+          @hash = [specs, platform, build_type].hash
         end
 
         # @note Test specs are intentionally not included as part of the equality for pod variants since a
@@ -55,7 +54,7 @@ module Pod
         #
         def ==(other)
           self.class == other.class &&
-            requires_frameworks == other.requires_frameworks &&
+          build_type == other.build_type &&
             platform == other.platform &&
             specs == other.specs
         end

--- a/lib/cocoapods/installer/analyzer/pod_variant_set.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant_set.rb
@@ -71,8 +71,17 @@ module Pod
         # @return [Hash<PodVariant, String>]
         #
         def scope_by_build_type
-          scope_if_necessary(group_by(&:requires_frameworks).map(&:scope_by_platform)) do |variant|
-            variant.requires_frameworks? ? 'framework' : 'library'
+          scope_if_necessary(group_by { |v| v.build_type.packaging }.map(&:scope_by_linkage)) do |variant|
+            variant.build_type.packaging
+          end
+        end
+
+        # @private
+        # @return [Hash<PodVariant, String>]
+        #
+        def scope_by_linkage
+          scope_if_necessary(group_by { |v| v.build_type.linkage }.map(&:scope_by_platform)) do |variant|
+            variant.build_type.linkage
           end
         end
 

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -324,7 +324,7 @@ module Pod
             build_phase = native_target.frameworks_build_phase
 
             # Find and delete possible reference for the other product type
-            old_product_name = target.requires_frameworks? ? target.static_library_name : target.framework_name
+            old_product_name = target.build_as_framework? ? target.static_library_name : target.framework_name
             old_product_ref = frameworks.files.find { |f| f.path == old_product_name }
             if old_product_ref.present?
               UI.message("Removing old Pod product reference #{old_product_name} from project.")

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -162,7 +162,7 @@ module Pod
           sorted_installation_results.each do |target_installation_result|
             pod_target = target_installation_result.target
             next unless pod_target.should_build?
-            next if !pod_target.requires_frameworks? || pod_target.static_framework?
+            next if pod_target.build_as_static?
             pod_target.file_accessors.each do |file_accessor|
               native_target = target_installation_result.native_target_for_spec(file_accessor.spec)
               add_system_frameworks_to_native_target(native_target, file_accessor)
@@ -211,7 +211,7 @@ module Pod
             # First, wire up all resource bundles.
             pod_target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
               native_target.add_dependency(resource_bundle_target)
-              if pod_target.requires_frameworks? && pod_target.should_build?
+              if pod_target.build_as_dynamic_framework? && pod_target.should_build?
                 native_target.add_resources([resource_bundle_target.product_reference])
               end
             end
@@ -297,7 +297,7 @@ module Pod
         end
 
         def add_framework_file_reference_to_native_target(native_target, pod_target, dependent_target, frameworks_group)
-          if pod_target.should_build? && pod_target.requires_frameworks? && !pod_target.static_framework? && dependent_target.should_build?
+          if pod_target.should_build? && pod_target.build_as_dynamic? && dependent_target.should_build?
             product_ref = frameworks_group.files.find { |f| f.path == dependent_target.product_name } ||
                 frameworks_group.new_product_ref_for_target(dependent_target.product_basename, dependent_target.product_type)
             native_target.frameworks_build_phase.add_file_reference(product_ref, true)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -16,7 +16,7 @@ module Pod
               create_support_files_dir
               create_support_files_group
               create_xcconfig_file(native_target)
-              if target.requires_frameworks?
+              if target.host_requires_frameworks?
                 create_info_plist_file(target.info_plist_path, native_target, target.version, target.platform)
                 create_module_map(native_target)
                 create_umbrella_header(native_target)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -144,7 +144,7 @@ module Pod
                 # frameworks, whose headers are included inside the built
                 # framework. Those headers do not need to be linked from the
                 # sandbox.
-                next if pod_target.requires_frameworks? && pod_target.should_build?
+                next if pod_target.build_as_framework? && pod_target.should_build?
 
                 headers_sandbox = Pathname.new(pod_target.pod_name)
                 added_build_headers = false

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -91,11 +91,9 @@ module Pod
               settings['ARCHS'] = target.archs
             end
 
-            if target.requires_frameworks?
-              if target.static_framework?
-                settings['MACH_O_TYPE'] = 'staticlib'
-              end
-            else
+            if target.build_as_static_framework?
+              settings['MACH_O_TYPE'] = 'staticlib'
+            elsif target.build_as_static_library?
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end
 
@@ -204,7 +202,7 @@ module Pod
                 FileUtils.ln_sf(source, linked_path)
               end
 
-              acl = target.requires_frameworks? ? 'Public' : 'Project'
+              acl = target.build_as_framework? ? 'Public' : 'Project'
               build_file.settings ||= {}
               build_file.settings['ATTRIBUTES'] = [acl]
             end

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -47,11 +47,11 @@ module Pod
               file_accessors = pod_targets.flat_map(&:file_accessors)
 
               frameworks = file_accessors.flat_map(&:vendored_frameworks).uniq.map(&:basename)
-              frameworks += pod_targets.select { |pt| pt.should_build? && pt.requires_frameworks? }.map(&:product_module_name).uniq
+              frameworks += pod_targets.select { |pt| pt.should_build? && pt.build_as_framework? }.map(&:product_module_name).uniq
               verify_no_duplicate_names(frameworks, aggregate_target.label, 'frameworks')
 
               libraries = file_accessors.flat_map(&:vendored_libraries).uniq.map(&:basename)
-              libraries += pod_targets.select { |pt| pt.should_build? && !pt.requires_frameworks? }.map(&:product_name)
+              libraries += pod_targets.select { |pt| pt.should_build? && pt.build_as_library? }.map(&:product_name)
               verify_no_duplicate_names(libraries, aggregate_target.label, 'libraries')
             end
           end
@@ -68,24 +68,24 @@ module Pod
 
         def verify_no_static_framework_transitive_dependencies
           aggregate_targets.each do |aggregate_target|
-            next unless aggregate_target.requires_frameworks?
+            aggregate_target.user_build_configurations.each_key do |config|
+              pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
+              built_targets, unbuilt_targets = pod_targets.partition(&:should_build?)
+              dynamic_pod_targets = built_targets.select(&:build_as_dynamic?)
 
-            aggregate_target.user_build_configurations.keys.each do |config|
-              dynamic_pod_targets = aggregate_target.pod_targets_for_build_configuration(config).reject(&:static_framework?)
-
-              dependencies = dynamic_pod_targets.select(&:should_build?).flat_map(&:dependencies)
-              depended_upon_targets = dynamic_pod_targets.select { |t| dependencies.include?(t.pod_name) && !t.should_build? }
+              dependencies = dynamic_pod_targets.flat_map(&:dependencies)
+              depended_upon_targets = unbuilt_targets.select { |t| dependencies.include?(t.pod_name) }
 
               static_libs = depended_upon_targets.flat_map(&:file_accessors).flat_map(&:vendored_static_artifacts)
               unless static_libs.empty?
                 raise Informative, "The '#{aggregate_target.label}' target has " \
-                  "transitive dependencies that include static binaries: (#{static_libs.to_sentence})"
+                  "transitive dependencies that include statically linked binaries: (#{static_libs.to_sentence})"
               end
 
-              static_framework_deps = dynamic_pod_targets.select(&:should_build?).flat_map(&:recursive_dependent_targets).select(&:static_framework?)
-              unless static_framework_deps.empty?
+              static_deps = dynamic_pod_targets.flat_map(&:recursive_dependent_targets).select(&:build_as_static?).uniq
+              unless static_deps.empty?
                 raise Informative, "The '#{aggregate_target.label}' target has " \
-                  "transitive dependencies that include static frameworks: (#{static_framework_deps.flat_map(&:name).to_sentence})"
+                  "transitive dependencies that include statically linked binaries: (#{static_deps.flat_map(&:name).to_sentence})"
               end
             end
           end

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -205,7 +205,7 @@ module Pod
 
       # @return [String]
       define_build_settings_method :code_sign_identity, :build_setting => true do
-        return unless target.requires_frameworks?
+        return unless target.build_as_dynamic?
         return unless target.platform.to_sym == :osx
         ''
       end
@@ -524,7 +524,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :frameworks, :memoized => true, :sorted => true, :uniqued => true do
-          return [] if (!target.requires_frameworks? || target.static_framework?) && library_xcconfig?
+          return [] if target.build_as_static? && library_xcconfig?
 
           frameworks = vendored_dynamic_frameworks.map { |l| File.basename(l, '.framework') }
           frameworks.concat vendored_static_frameworks.map { |l| File.basename(l, '.framework') } if library_xcconfig?
@@ -537,22 +537,22 @@ module Pod
         # @return [Array<String>]
         define_build_settings_method :static_frameworks_to_import, :memoized => true do
           static_frameworks_to_import = []
-          static_frameworks_to_import.concat vendored_static_frameworks.map { |f| File.basename(f, '.framework') } unless target.should_build? && target.requires_frameworks? && !target.static_framework?
-          static_frameworks_to_import << target.product_basename if target.should_build? && target.requires_frameworks? && target.static_framework?
+          static_frameworks_to_import.concat vendored_static_frameworks.map { |f| File.basename(f, '.framework') } unless target.should_build? && target.build_as_dynamic_framework?
+          static_frameworks_to_import << target.product_basename if target.should_build? && target.build_as_static_framework?
           static_frameworks_to_import
         end
 
         # @return [Array<String>]
         define_build_settings_method :dynamic_frameworks_to_import, :memoized => true do
           dynamic_frameworks_to_import = vendored_dynamic_frameworks.map { |f| File.basename(f, '.framework') }
-          dynamic_frameworks_to_import << target.product_basename if target.should_build? && target.requires_frameworks? && !target.static_framework?
+          dynamic_frameworks_to_import << target.product_basename if target.should_build? && target.build_as_dynamic_framework?
           dynamic_frameworks_to_import.concat consumer_frameworks
           dynamic_frameworks_to_import
         end
 
         # @return [Array<String>]
         define_build_settings_method :weak_frameworks, :memoized => true do
-          return [] if (!target.requires_frameworks? || target.static_framework?) && library_xcconfig?
+          return [] if target.build_as_static? && library_xcconfig?
 
           weak_frameworks = spec_consumers.flat_map(&:weak_frameworks)
           weak_frameworks.concat dependent_targets.flat_map { |pt| pt.build_settings.weak_frameworks_to_import }
@@ -580,7 +580,7 @@ module Pod
 
         # @return [String]
         define_build_settings_method :framework_header_search_path, :memoized => true do
-          return unless target.requires_frameworks?
+          return unless target.build_as_framework?
           "#{target.build_product_path}/Headers"
         end
 
@@ -593,7 +593,7 @@ module Pod
         define_build_settings_method :framework_search_paths_to_import, :memoized => true do
           paths = framework_search_paths_to_import_developer_frameworks(consumer_frameworks)
           paths.concat vendored_framework_search_paths
-          return paths unless target.requires_frameworks? && target.should_build?
+          return paths unless target.build_as_framework? && target.should_build?
 
           paths + [target.configuration_build_dir(CONFIGURATION_BUILD_DIR_VARIABLE)]
         end
@@ -614,7 +614,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :libraries, :memoized => true, :sorted => true, :uniqued => true do
-          return [] if library_xcconfig? && (!target.requires_frameworks? || target.static_framework?)
+          return [] if library_xcconfig? && target.build_as_static?
 
           libraries = libraries_to_import.dup
           libraries.concat dependent_targets.flat_map { |pt| pt.build_settings.dynamic_libraries_to_import }
@@ -625,14 +625,16 @@ module Pod
         # @return [Array<String>]
         define_build_settings_method :static_libraries_to_import, :memoized => true do
           static_libraries_to_import = vendored_static_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') }
-          static_libraries_to_import << target.product_basename if target.should_build? && !target.requires_frameworks?
+          static_libraries_to_import << target.product_basename if target.should_build? && target.build_as_static_library?
           static_libraries_to_import
         end
 
         # @return [Array<String>]
         define_build_settings_method :dynamic_libraries_to_import, :memoized => true do
-          vendored_dynamic_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') } +
-          spec_consumers.flat_map(&:libraries)
+          dynamic_libraries_to_import = vendored_dynamic_libraries.map { |l| File.basename(l, l.extname).sub(/\Alib/, '') }
+          dynamic_libraries_to_import.concat spec_consumers.flat_map(&:libraries)
+          dynamic_libraries_to_import << target.product_basename if target.should_build? && target.build_as_dynamic_library?
+          dynamic_libraries_to_import
         end
 
         # @return [Array<String>]
@@ -642,7 +644,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :library_search_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
-          return [] if library_xcconfig? && (!target.requires_frameworks? || target.static_framework?)
+          return [] if library_xcconfig? && target.build_as_static?
 
           vendored = library_search_paths_to_import.dup
           vendored.concat dependent_targets.flat_map { |t| t.build_settings.vendored_dynamic_library_search_paths }
@@ -677,7 +679,7 @@ module Pod
         # @return [Array<String>]
         define_build_settings_method :library_search_paths_to_import, :memoized => true do
           vendored_library_search_paths = vendored_static_library_search_paths + vendored_dynamic_library_search_paths
-          return vendored_library_search_paths if target.requires_frameworks? || !target.should_build?
+          return vendored_library_search_paths if target.build_as_framework? || !target.should_build?
 
           vendored_library_search_paths << target.configuration_build_dir(CONFIGURATION_BUILD_DIR_VARIABLE)
         end
@@ -694,7 +696,7 @@ module Pod
         # @return [Array<String>]
         define_build_settings_method :module_map_file_to_import, :memoized => true do
           return unless target.should_build?
-          return if target.requires_frameworks?
+          return if target.build_as_framework? # framework module maps are automatically discovered
           return unless target.defines_module?
 
           if target.uses_swift?
@@ -732,7 +734,7 @@ module Pod
 
           flags = super()
           flags << '-suppress-warnings' if target.inhibit_warnings? && library_xcconfig?
-          if !target.requires_frameworks? && target.defines_module? && library_xcconfig?
+          if !target.build_as_framework? && target.defines_module? && library_xcconfig?
             flags.concat %w( -import-underlying-module -Xcc -fmodule-map-file=${SRCROOT}/${MODULEMAP_FILE} )
           end
           flags
@@ -747,7 +749,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :swift_include_paths_to_import, :memoized => true do
-          return [] unless target.uses_swift? && !target.requires_frameworks?
+          return [] unless target.uses_swift? && !target.build_as_framework?
 
           [target.configuration_build_dir(CONFIGURATION_BUILD_DIR_VARIABLE)]
         end
@@ -938,14 +940,14 @@ module Pod
         define_build_settings_method :header_search_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
           paths = []
 
-          if !target.requires_frameworks? || !pod_targets.all?(&:should_build?)
+          if !target.build_as_framework? || !pod_targets.all?(&:should_build?)
             paths.concat target.sandbox.public_headers.search_paths(target.platform)
           end
 
           # Make frameworks headers discoverable with any syntax (quotes,
           # brackets, @import, etc.)
           paths.concat pod_targets.
-            select { |pt| pt.requires_frameworks? && pt.should_build? }.
+            select { |pt| pt.build_as_framework? && pt.should_build? }.
             map { |pt| pt.build_settings.framework_header_search_path }
 
           paths.concat target.search_paths_aggregate_targets.flat_map { |at| at.build_settings(configuration_name).header_search_paths }
@@ -962,7 +964,7 @@ module Pod
           silenced_headers = []
           silenced_frameworks = []
           pod_targets_inhibiting_warnings.each do |pt|
-            if pt.requires_frameworks? && pt.should_build?
+            if pt.build_as_framework? && pt.should_build?
               silenced_headers.append pt.build_settings.framework_header_search_path
             else
               silenced_headers.concat pt.build_settings.public_header_search_paths
@@ -1022,7 +1024,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :ld_runpath_search_paths, :build_setting => true, :memoized => true, :uniqued => true do
-          return unless target.requires_frameworks? || any_vendored_dynamic_artifacts?
+          return unless pod_targets.any?(&:build_as_dynamic?) || any_vendored_dynamic_artifacts?
           symbol_type = target.user_targets.map(&:symbol_type).uniq.first
           test_bundle = symbol_type == :octest_bundle || symbol_type == :unit_test_bundle || symbol_type == :ui_test_bundle
           _ld_runpath_search_paths(:requires_host_target => target.requires_host_target?, :test_bundle => test_bundle)
@@ -1032,16 +1034,24 @@ module Pod
         define_build_settings_method :any_vendored_dynamic_artifacts?, :memoized => true do
           pod_targets.any? do |pt|
             pt.file_accessors.any? do |fa|
-              fa.vendored_dynamic_artifacts.any?
+              !fa.vendored_dynamic_artifacts.empty?
+            end
+          end
+        end
+
+        # @return [Boolean]
+        define_build_settings_method :any_vendored_static_artifacts?, :memoized => true do
+          pod_targets.any? do |pt|
+            pt.file_accessors.any? do |fa|
+              !fa.vendored_static_artifacts.empty?
             end
           end
         end
 
         # @return [Boolean]
         define_build_settings_method :requires_objc_linker_flag?, :memoized => true do
-          !target.requires_frameworks? ||
-            pod_targets.any?(&:static_framework?) ||
-            pod_targets.flat_map(&:file_accessors).any? { |fa| !fa.vendored_static_artifacts.empty? }
+          pod_targets.any?(&:build_as_static?) ||
+            any_vendored_static_artifacts?
         end
 
         # @return [Boolean]

--- a/lib/cocoapods/target/build_type.rb
+++ b/lib/cocoapods/target/build_type.rb
@@ -1,0 +1,139 @@
+module Pod
+  class Target
+    class BuildType
+      # @return [Array<Symbol>] known packaging options.
+      #
+      KNOWN_PACKAGING_OPTIONS = %i(library framework).freeze
+
+      # @return [Array<Symbol>] known linking options.
+      #
+      KNOWN_LINKAGE_OPTIONS = %i(static dynamic).freeze
+
+      # @return [Symbol] the packaging for this build type, one of KNOWN_PACKAGING_OPTIONS
+      #
+      attr_reader :packaging
+
+      # @return [Symbol] the linkage for this build type, one of KNOWN_LINKAGE_OPTIONS
+      #
+      attr_reader :linkage
+
+      def initialize(linkage: :static, packaging: :library)
+        raise ArgumentError, "Invalid linkage option #{linkage.inspect}, valid options are #{KNOWN_LINKAGE_OPTIONS.inspect}" unless KNOWN_LINKAGE_OPTIONS.include?(linkage)
+        raise ArgumentError, "Invalid packaging option #{packaging.inspect}, valid options are #{KNOWN_PACKAGING_OPTIONS.inspect}" unless KNOWN_PACKAGING_OPTIONS.include?(packaging)
+
+        @packaging = packaging
+        @linkage = linkage
+        @hash = packaging.hash ^ linkage.hash
+      end
+
+      # @param  [Specification] spec
+      #         the specification to infer the build type from
+      #
+      # @param  [Boolean] host_requires_frameworks
+      #         whether the host target definition specified `use_frameworks!`
+      #
+      # @return [BuildType] the appropriate build type for the given spec,
+      #         based on whether the host target definition requires frameworks.
+      #
+      def self.infer_from_spec(spec, host_requires_frameworks: false)
+        if host_requires_frameworks
+          root_spec = spec && spec.root
+          if root_spec && root_spec.static_framework
+            static_framework
+          else
+            dynamic_framework
+          end
+        else
+          static_library
+        end
+      end
+
+      # @return [BuildType] the build type for a dynamic library
+      #
+      def self.dynamic_library
+        new(:linkage => :dynamic, :packaging => :library)
+      end
+
+      # @return [BuildType] the build type for a static library
+      #
+      def self.static_library
+        new(:linkage => :static, :packaging => :library)
+      end
+
+      # @return [BuildType] the build type for a dynamic framework
+      #
+      def self.dynamic_framework
+        new(:linkage => :dynamic, :packaging => :framework)
+      end
+
+      # @return [BuildType] the build type for a static framework
+      #
+      def self.static_framework
+        new(:linkage => :static, :packaging => :framework)
+      end
+
+      # @return [Boolean] whether the target is built dynamically
+      #
+      def dynamic?
+        linkage == :dynamic
+      end
+
+      # @return [Boolean] whether the target is built statically
+      #
+      def static?
+        linkage == :static
+      end
+
+      # @return [Boolean] whether the target is built as a framework
+      #
+      def framework?
+        packaging == :framework
+      end
+
+      # @return [Boolean] whether the target is built as a library
+      #
+      def library?
+        packaging == :library
+      end
+
+      # @return [Boolean] whether the target is built as a dynamic framework
+      #
+      def dynamic_framework?
+        dynamic? && framework?
+      end
+
+      # @return [Boolean] whether the target is built as a dynamic library
+      #
+      def dynamic_library?
+        dynamic? && library?
+      end
+
+      # @return [Boolean] whether the target is built as a static framework
+      #
+      def static_framework?
+        static? && framework?
+      end
+
+      # @return [Boolean] whether the target is built as a static library
+      #
+      def static_library?
+        static? && library?
+      end
+
+      attr_reader :hash
+
+      def to_s
+        "#{linkage} #{packaging}"
+      end
+
+      def inspect
+        "#<#{self.class} linkage=#{linkage} packaging=#{packaging}>"
+      end
+
+      def ==(other)
+        linkage == other.linkage &&
+            packaging == other.packaging
+      end
+    end
+  end
+end

--- a/lib/cocoapods/target/build_type.rb
+++ b/lib/cocoapods/target/build_type.rb
@@ -17,6 +17,8 @@ module Pod
       #
       attr_reader :linkage
 
+      attr_reader :hash
+
       def initialize(linkage: :static, packaging: :library)
         raise ArgumentError, "Invalid linkage option #{linkage.inspect}, valid options are #{KNOWN_LINKAGE_OPTIONS.inspect}" unless KNOWN_LINKAGE_OPTIONS.include?(linkage)
         raise ArgumentError, "Invalid packaging option #{packaging.inspect}, valid options are #{KNOWN_PACKAGING_OPTIONS.inspect}" unless KNOWN_PACKAGING_OPTIONS.include?(packaging)
@@ -119,8 +121,6 @@ module Pod
       def static_library?
         static? && library?
       end
-
-      attr_reader :hash
 
       def to_s
         "#{linkage} #{packaging}"

--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -117,6 +117,9 @@ EOS
           inspector = GhInspector::Inspector.new 'cocoapods', 'cocoapods'
           message_delegate = UserInterface::InspectorReporter.new
           inspector.search_exception exception, message_delegate
+        rescue => e
+          warn "Searching for inspections failed: #{e}"
+          nil
         end
 
         private

--- a/spec/spec_helper/fixture.rb
+++ b/spec/spec_helper/fixture.rb
@@ -14,14 +14,14 @@ module SpecHelper
   end
 
   module Fixture
-    ROOT = ::ROOT + 'spec/fixtures'
+    ROOT = Pathname('../fixtures').expand_path(__dir__)
 
     def fixture(name)
       file = ROOT + name
       unless file.exist?
         archive = Pathname.new(file.to_s + '.tar.gz')
         if archive.exist?
-          system "cd '#{archive.dirname}' && tar -zxvf '#{archive}' > /dev/null 2>&1"
+          Pod::Executable.capture_command('tar', ['-zxvf', archive], :capture => none, :chdir => archive.dirname.to_s)
         end
       end
       file

--- a/spec/spec_helper/fixture_specification_source.rb
+++ b/spec/spec_helper/fixture_specification_source.rb
@@ -14,4 +14,4 @@ module Pod
       result
     end
   end
-  end
+end

--- a/spec/spec_helper/fixture_specification_source.rb
+++ b/spec/spec_helper/fixture_specification_source.rb
@@ -1,0 +1,17 @@
+require_relative 'fixture'
+
+# README!
+#
+# Override {Specification#source} to return sources from fixtures and limit
+# network connections.
+#
+module Pod
+  class Specification
+    def source
+      fixture = SpecHelper.fixture("integration/#{name}")
+      result = super
+      result[:git] = fixture.to_s if fixture.exist?
+      result
+    end
+  end
+  end

--- a/spec/unit/generator/module_map_spec.rb
+++ b/spec/unit/generator/module_map_spec.rb
@@ -10,7 +10,7 @@ module Pod
 
     it 'writes the module map to the disk' do
       path = temporary_directory + 'BananaLib.modulemap'
-      @pod_target.stubs(:requires_frameworks?).returns(true)
+      @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
         framework module BananaLib {
@@ -24,7 +24,7 @@ module Pod
 
     it 'writes the module map to the disk for a library' do
       path = temporary_directory + 'BananaLib.modulemap'
-      @pod_target.stubs(:requires_frameworks?).returns(false)
+      @pod_target.stubs(:build_type => Target::BuildType.static_library)
       @gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc
         module BananaLib {
@@ -36,10 +36,24 @@ module Pod
       EOS
     end
 
+    it 'writes the module map to the disk for a static framework' do
+      path = temporary_directory + 'BananaLib.modulemap'
+      @pod_target.stubs(:build_type => Target::BuildType.static_framework)
+      @gen.save_as(path)
+      path.read.should == <<-EOS.strip_heredoc
+        framework module BananaLib {
+          umbrella header "BananaLib-umbrella.h"
+
+          export *
+          module * { export * }
+        }
+      EOS
+    end
+
     it 'escapes double quotes properly for module map contents' do
       path = temporary_directory + 'BananaLib.modulemap'
       @pod_target.stubs(:umbrella_header_path).returns(Pathname.new('BananaLibWith"Quotes"-umbrella.h'))
-      @pod_target.stubs(:requires_frameworks?).returns(true)
+      @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
       gen = Generator::ModuleMap.new(@pod_target)
       gen.save_as(path)
       path.read.should == <<-EOS.strip_heredoc

--- a/spec/unit/installer/analyzer/pod_variant_set_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_set_spec.rb
@@ -20,8 +20,8 @@ module Pod
 
       it 'returns scopes by built types if they qualify' do
         variants = PodVariantSet.new([
-          PodVariant.new([@root_spec], [], [], Platform.ios, true),
-          PodVariant.new([@root_spec], [], [], Platform.ios, false),
+          PodVariant.new([@root_spec], [], [], Platform.ios, Target::BuildType.dynamic_framework),
+          PodVariant.new([@root_spec], [], [], Platform.ios),
         ])
         variants.scope_suffixes.values.should == %w(framework library)
       end
@@ -139,14 +139,27 @@ module Pod
         variants = PodVariantSet.new([
           PodVariant.new([@root_spec, @default_subspec], [], [], Platform.new(:ios, '7.0')),
           PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios),
-          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.osx, true),
-          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], [], Platform.osx, true),
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.osx, Target::BuildType.dynamic_framework),
+          PodVariant.new([@root_spec, @default_subspec, @foo_subspec], [], [], Platform.osx, Target::BuildType.dynamic_framework),
         ])
         variants.scope_suffixes.values.should == %w(
           library-iOS7.0
           library-iOS
           framework
           .default-Foo
+        )
+      end
+
+      it 'returns scopes differentiating build types' do
+        variants = PodVariantSet.new([
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios),
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios, Target::BuildType.dynamic_framework),
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios, Target::BuildType.static_framework),
+        ])
+        variants.scope_suffixes.values.should == %w(
+          library
+          framework-dynamic
+          framework-static
         )
       end
     end

--- a/spec/unit/installer/analyzer/pod_variant_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_spec.rb
@@ -9,20 +9,21 @@ module Pod
           @testspecs = [stub('Spec/Tests')]
           @appspecs = [stub('Spec/App')]
           @platform = Platform.ios
+          @type = Target::BuildType.dynamic_framework
         end
 
         it 'can be initialized with specs and platform' do
           variant = PodVariant.new(@specs, [], [], @platform)
           variant.specs.should == @specs
           variant.platform.should == @platform
-          variant.requires_frameworks.should == false
+          variant.build_type.should == Target::BuildType.static_library
         end
 
         it 'can be initialized with specs, platform and whether it requires frameworks' do
-          variant = PodVariant.new(@specs, [], [], @platform, true)
+          variant = PodVariant.new(@specs, [], [], @platform, @type)
           variant.specs.should == @specs
           variant.platform.should == @platform
-          variant.requires_frameworks.should == true
+          variant.build_type.should == @type
         end
 
         it 'can return the root spec' do

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -1180,8 +1180,8 @@ module Pod
           ].sort
           result.targets.flat_map { |at| at.pod_targets_for_build_configuration('Release').map { |pt| "#{at.name}/Release/#{pt.name}" } }.sort.should == [
             'Pods-Sample Extensions Project/Release/JSONKit',
-            'Pods-Sample Extensions Project/Release/monkey',
             'Pods-Sample Extensions Project/Release/matryoshka-Bar-Foo',
+            'Pods-Sample Extensions Project/Release/monkey',
             'Pods-Today Extension/Release/matryoshka-Bar',
             'Pods-Today Extension/Release/monkey',
           ].sort

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -64,13 +64,13 @@ module Pod
         end
 
         it 'adds references to the Pods static framework to the Frameworks group' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           @target_integrator.send(:user_project)['Frameworks/Pods.framework'].should.not.be.nil
         end
 
         it 'adds the Pods static framework to the "Link binary with libraries" build phase of each target' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.frameworks_build_phase
@@ -122,7 +122,7 @@ module Pod
         end
 
         it 'adds an embed frameworks build phase if frameworks are used' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
@@ -137,7 +137,7 @@ module Pod
         end
 
         it 'adds an embed frameworks build phase if the target to integrate is a messages application' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:messages_application)
           @target_integrator.integrate!
@@ -146,7 +146,7 @@ module Pod
         end
 
         it 'does not add an embed frameworks build phase if the target to integrate is a framework' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:framework)
           @target_integrator.integrate!
@@ -155,7 +155,7 @@ module Pod
         end
 
         it 'does not add an embed frameworks build phase if the target to integrate is an app extension' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:app_extension)
           @target_integrator.integrate!
@@ -164,7 +164,7 @@ module Pod
         end
 
         it 'does not add an embed frameworks build phase if the target to integrate is a watch extension' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:watch_extension)
           @target_integrator.integrate!
@@ -173,7 +173,7 @@ module Pod
         end
 
         it 'adds an embed frameworks build phase if the target to integrate is a watchOS 2 extension' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:watch2_extension)
           @target_integrator.integrate!
@@ -182,7 +182,7 @@ module Pod
         end
 
         it 'does not add an embed frameworks build phase if the target to integrate is a messages extension' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:messages_extension)
           @target_integrator.integrate!
@@ -191,7 +191,7 @@ module Pod
         end
 
         it 'adds an embed frameworks build phase if the target to integrate is a UI Test bundle' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first
           target.stubs(:symbol_type).returns(:ui_test_bundle)
           @target_integrator.integrate!
@@ -200,7 +200,7 @@ module Pod
         end
 
         it 'does not remove existing embed frameworks build phases from integrated framework targets' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           @pod_bundle.stubs(:requires_frameworks? => false)
           target = @target_integrator.send(:native_targets).first
@@ -210,7 +210,7 @@ module Pod
         end
 
         it 'does not remove existing embed frameworks build phases if frameworks are not used anymore' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           @pod_bundle.stubs(:requires_frameworks? => false)
           @target_integrator.integrate!
@@ -220,7 +220,7 @@ module Pod
         end
 
         it 'removes embed frameworks build phases from app extension targets' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
@@ -232,7 +232,7 @@ module Pod
         end
 
         it 'removes embed frameworks build phases from watch extension targets' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
@@ -244,7 +244,7 @@ module Pod
         end
 
         it 'removes embed frameworks build phases from messages extension targets that are used in an iOS app' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
@@ -256,7 +256,7 @@ module Pod
         end
 
         it 'does not remove embed frameworks build phases from messages extension targets that are used in a messages app' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
@@ -269,7 +269,7 @@ module Pod
         end
 
         it 'removes embed frameworks build phases from framework targets' do
-          @pod_bundle.stubs(:requires_frameworks? => true)
+          @pod_bundle.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -156,7 +156,7 @@ module Pod
 
             it 'does not add framework resources to copy resources script' do
               @target.stubs(:includes_resources?).returns(true)
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
               @installer.install!
               support_files_dir = config.sandbox.target_support_files_dir('Pods-SampleProject')
               script = support_files_dir + 'Pods-SampleProject-resources.sh'
@@ -184,7 +184,7 @@ module Pod
             end
 
             it 'does add pods to the embed frameworks script' do
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
               @target.stubs(:requires_frameworks? => true)
               @installer.install!
               support_files_dir = config.sandbox.target_support_files_dir('Pods-SampleProject')
@@ -209,7 +209,7 @@ module Pod
 
             it 'does not add pods to the embed frameworks script if they are not to be built' do
               @pod_target.stubs(:should_build? => false)
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
               @target.stubs(:requires_frameworks? => true)
               @target.stubs(:includes_frameworks? => true)
               @installer.install!
@@ -219,8 +219,7 @@ module Pod
             end
 
             it 'does not add pods to the embed frameworks script if they are static' do
-              @pod_target.stubs(:static_framework? => true)
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.static_framework)
               @target.stubs(:requires_frameworks? => true)
               @target.stubs(:includes_frameworks? => true)
               @installer.install!
@@ -249,7 +248,7 @@ module Pod
             end
 
             it 'creates an embed frameworks script, if the target does not require a host target' do
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
               @target.stubs(:requires_frameworks? => true)
               @installer.install!
               support_files_dir = config.sandbox.target_support_files_dir('Pods-SampleProject')
@@ -258,7 +257,7 @@ module Pod
             end
 
             it 'does not create an embed frameworks script, if the target requires a host target' do
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
               @target.stubs(:requires_frameworks? => true)
               @target.stubs(:requires_host_target? => true)
               @installer.install!
@@ -268,7 +267,7 @@ module Pod
             end
 
             it 'does not create an embed frameworks script, if the target does not have frameworks to embed' do
-              @pod_target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
               @target.stubs(:requires_frameworks? => true)
               @target.stubs(:includes_frameworks? => false)
               @installer.install!
@@ -287,8 +286,8 @@ module Pod
             end
 
             it 'installs umbrella headers for frameworks' do
-              @pod_target.stubs(:requires_frameworks? => true)
-              @target.stubs(:requires_frameworks? => true)
+              @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
+              @target.stubs(:build_type => Target::BuildType.static_framework, :host_requires_frameworks? => true)
               build_files = @installer.install!.native_target.headers_build_phase.files
               build_file = build_files.find { |bf| bf.file_ref.path.include?('Pods-SampleProject-umbrella.h') }
               build_file.should.not.be.nil

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -95,9 +95,8 @@ module Pod
             end
 
             it 'links the public headers meant for the user for a vendored framework' do
-              Target.any_instance.stubs(:requires_frameworks?).returns(true)
-              pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec')
-              pod_target_two = fixture_pod_target('monkey/monkey.podspec')
+              pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec', true)
+              pod_target_two = fixture_pod_target('monkey/monkey.podspec', true)
               project = Project.new(config.sandbox.project_path)
               project.add_pod_group('BananaLib', fixture('banana-lib'))
               project.add_pod_group('monkey', fixture('monkey'))
@@ -115,7 +114,7 @@ module Pod
             end
 
             it 'does not link public headers from vendored framework, when frameworks required' do
-              @pod_target.stubs(:requires_frameworks?).returns(true)
+              @pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
               @installer.install!
               headers_root = config.sandbox.public_headers.root
               framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -52,8 +52,7 @@ module Pod
           end
 
           it 'verify static framework is building a static library' do
-            @target.stubs(:requires_frameworks?).returns(true)
-            @target.stubs(:static_framework?).returns(true)
+            @target.stubs(:build_type => Target::BuildType.static_framework)
             @installer.send(:add_target).resolved_build_setting('MACH_O_TYPE').should == {
               'Release' => 'staticlib',
               'Debug' => 'staticlib',

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -206,7 +206,7 @@ module Pod
           end
 
           it 'adds system frameworks to dynamic targets' do
-            @orangeframework_pod_target.stubs(:requires_frameworks? => true)
+            @orangeframework_pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
             pod_generator_result = @generator.generate!
             pod_generator_result.project.targets.find { |t| t.name == 'OrangeFramework' }.frameworks_build_phase.file_display_names.should == %w(
               Foundation.framework
@@ -270,8 +270,8 @@ module Pod
           end
 
           it 'adds framework file references for framework pod targets that require building' do
-            @orangeframework_pod_target.stubs(:requires_frameworks?).returns(true)
-            @coconut_ios_pod_target.stubs(:requires_frameworks?).returns(true)
+            @orangeframework_pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
+            @coconut_ios_pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
             @coconut_ios_pod_target.stubs(:should_build?).returns(true)
             pod_generator_result = @generator.generate!
             native_target = pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS' }
@@ -283,8 +283,8 @@ module Pod
           end
 
           it 'does not add framework references for framework pod targets that do not require building' do
-            @orangeframework_pod_target.stubs(:requires_frameworks?).returns(true)
-            @coconut_ios_pod_target.stubs(:requires_frameworks?).returns(true)
+            @orangeframework_pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
+            @coconut_ios_pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
             @coconut_ios_pod_target.stubs(:should_build?).returns(false)
             pod_generator_result = @generator.generate!
             pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.isa.should == 'PBXAggregateTarget'

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -226,7 +226,7 @@ module Pod
           end
 
           it 'allows transitive static dependencies when building a static framework' do
-            PodTarget.any_instance.stubs(:static_framework? => true)
+            PodTarget.any_instance.stubs(:build_type => Target::BuildType.static_framework)
             Sandbox::FileAccessor.any_instance.stubs(:vendored_libraries).returns([@lib_thing])
             @validator = create_validator(config.sandbox, @podfile, @lockfile)
             should.not.raise(Informative) { @validator.validate! }

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -149,7 +149,7 @@ module Pod
 
         it 'returns non vendored framework input and output paths by config' do
           @pod_target.stubs(:should_build?).returns(true)
-          @pod_target.stubs(:requires_frameworks?).returns(true)
+          @pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
           @target.framework_paths_by_config['Debug'].should == [
             Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
           ]
@@ -160,8 +160,7 @@ module Pod
 
         it 'checks resource paths are empty for dynamic frameworks' do
           @pod_target.stubs(:should_build?).returns(true)
-          @pod_target.stubs(:requires_frameworks?).returns(true)
-          @pod_target.stubs(:static_framework?).returns(false)
+          @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
           @pod_target.stubs(:resource_paths).returns(['MyResources.bundle'])
           @target.stubs(:bridge_support_file).returns(nil)
           resource_paths_by_config = @target.resource_paths_by_config
@@ -171,8 +170,7 @@ module Pod
 
         it 'checks resource paths are included for static frameworks' do
           @pod_target.stubs(:should_build?).returns(true)
-          @pod_target.stubs(:requires_frameworks?).returns(true)
-          @pod_target.stubs(:static_framework?).returns(true)
+          @pod_target.stubs(:build_type => Target::BuildType.static_framework)
           @pod_target.stubs(:resource_paths).returns('BananaLib' => ['MyResources.bundle'])
           @target.stubs(:bridge_support_file).returns(nil)
           resource_paths_by_config = @target.resource_paths_by_config
@@ -182,9 +180,9 @@ module Pod
 
         it 'returns non vendored frameworks by config with different release and debug targets' do
           @pod_target_release.stubs(:should_build?).returns(true)
-          @pod_target_release.stubs(:requires_frameworks?).returns(true)
+          @pod_target_release.stubs(:build_type => Target::BuildType.dynamic_framework)
           @pod_target.stubs(:should_build?).returns(true)
-          @pod_target.stubs(:requires_frameworks?).returns(true)
+          @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target.stubs(:pod_targets_for_build_configuration).with('Debug').returns([@pod_target])
           @target.stubs(:pod_targets_for_build_configuration).with('Release').returns([@pod_target, @pod_target_release])
           @target.stubs(:pod_targets).returns([@pod_target, @pod_target_release])
@@ -214,7 +212,7 @@ module Pod
 
         it 'returns correct input and output paths for non vendored frameworks' do
           @pod_target.stubs(:should_build?).returns(true)
-          @pod_target.stubs(:requires_frameworks?).returns(true)
+          @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target.framework_paths_by_config['Debug'].should == [
             Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
           ]
@@ -287,7 +285,7 @@ module Pod
 
         describe 'Host requires frameworks' do
           before do
-            @target.stubs(:host_requires_frameworks?).returns(true)
+            @target.stubs(:build_type).returns(Target::BuildType.static_framework)
           end
 
           it 'returns the product name' do

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -36,8 +36,7 @@ module Pod
               :pod_name => 'BananaLib',
               :sandbox => config.sandbox,
               :should_build? => false,
-              :requires_frameworks? => true,
-              :static_framework? => false,
+              :build_as_framework? => true,
               :dependent_targets => [],
               :_add_recursive_dependent_targets => [],
               :recursive_dependent_targets => [],
@@ -124,7 +123,7 @@ module Pod
           end
 
           it 'vendored frameworks should be added to frameworks paths if use_frameworks! isnt set' do
-            @pod_target.stubs(:requires_frameworks?).returns(false)
+            @pod_target.stubs(:build_type).returns(Target::BuildType.static_library)
             @xcconfig = @generator.generate
             @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('spec/fixtures/monkey')
             @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should.include('${PODS_ROOT}/AAA')
@@ -179,7 +178,7 @@ module Pod
           end
 
           it 'does not have a module map to import if it is not built' do
-            @pod_target.stubs(:should_build? => false, :requires_frameworks? => false, :defines_module? => true)
+            @pod_target.stubs(:should_build? => false, :build_as_framework? => false, :defines_module? => true)
             @generator.generate
             @generator.module_map_file_to_import.should.be.nil
           end
@@ -210,8 +209,10 @@ module Pod
             pod_target = stub('pod_target',
                               :file_accessors => [file_accessor],
                               :spec_consumers => [consumer],
-                              :requires_frameworks? => true,
-                              :static_framework? => true,
+                              :build_as_framework? => true,
+                              :build_as_static_framework? => true,
+                              :build_as_dynamic_library? => false,
+                              :build_as_dynamic_framework? => false,
                               :dependent_targets => [],
                               :recursive_dependent_targets => [],
                               :sandbox => config.sandbox,
@@ -272,7 +273,7 @@ module Pod
           end
 
           it 'includes correct other ld flags when requires frameworks' do
-            @coconut_pod_target.stubs(:requires_frameworks?).returns(true)
+            @coconut_pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
             generator = PodTargetSettings.new(@coconut_pod_target, @coconut_test_spec)
             xcconfig = generator.generate
             xcconfig.to_hash['OTHER_LDFLAGS'].should == '$(inherited) -ObjC -framework "CoconutLib"'

--- a/spec/unit/target/build_settings_spec.rb
+++ b/spec/unit/target/build_settings_spec.rb
@@ -91,7 +91,7 @@ module Pod
 
       describe 'concerning settings for file accessors' do
         it 'does not propagate framework or libraries from a test specification to an aggregate target' do
-          target_definition = stub('target_definition', :inheritance => 'complete', :abstract? => false, :podfile => Podfile.new)
+          target_definition = fixture_target_definition(:contents => { 'inheritance' => 'complete' })
           spec = stub('spec', :library_specification? => false, :spec_type => :test)
           consumer = stub('consumer',
                           :libraries => ['xml2'],
@@ -103,7 +103,8 @@ module Pod
                                :spec => spec,
                                :spec_consumer => consumer,
                                :vendored_static_frameworks => [config.sandbox.root + 'StaticFramework.framework'],
-                               :vendored_static_libraries => [config.sandbox.root + 'StaticLibrary.a'],
+                               :vendored_static_libraries => [config.sandbox.root + 'libStaticLibrary.a'],
+                               :vendored_static_artifacts => [config.sandbox.root + 'StaticFramework.framework', config.sandbox.root + 'libStaticLibrary.a'],
                                :vendored_dynamic_frameworks => [config.sandbox.root + 'VendoredFramework.framework'],
                                :vendored_dynamic_libraries => [config.sandbox.root + 'VendoredDyld.dyld'],
                               )
@@ -116,7 +117,7 @@ module Pod
                             :include_in_build_config? => true,
                             :should_build? => false,
                             :spec_consumers => [consumer],
-                            :static_framework? => false,
+                            :build_as_static? => false,
                             :product_basename => 'PodTarget',
                             :target_definitions => [target_definition],
                            )
@@ -126,7 +127,7 @@ module Pod
         end
 
         it 'does not propagate framework or libraries from a app specification to an aggregate target' do
-          target_definition = stub('target_definition', :inheritance => 'complete', :abstract? => false, :podfile => Podfile.new)
+          target_definition = fixture_target_definition(:contents => { 'inheritance' => 'complete' })
           spec = stub('spec', :library_specification? => false, :spec_type => :app)
           consumer = stub('consumer',
                           :libraries => ['xml2'],
@@ -138,7 +139,8 @@ module Pod
                                :spec => spec,
                                :spec_consumer => consumer,
                                :vendored_static_frameworks => [config.sandbox.root + 'StaticFramework.framework'],
-                               :vendored_static_libraries => [config.sandbox.root + 'StaticLibrary.a'],
+                               :vendored_static_libraries => [config.sandbox.root + 'libStaticLibrary.a'],
+                               :vendored_static_artifacts => [config.sandbox.root + 'StaticFramework.framework', config.sandbox.root + 'libStaticLibrary.a'],
                                :vendored_dynamic_frameworks => [config.sandbox.root + 'VendoredFramework.framework'],
                                :vendored_dynamic_libraries => [config.sandbox.root + 'VendoredDyld.dyld'],
                               )
@@ -151,7 +153,7 @@ module Pod
                             :include_in_build_config? => true,
                             :should_build? => false,
                             :spec_consumers => [consumer],
-                            :static_framework? => false,
+                            :build_as_static? => false,
                             :product_basename => 'PodTarget',
                             :target_definitions => [target_definition],
                            )
@@ -163,7 +165,7 @@ module Pod
 
       describe 'concerning other_ld_flags' do
         it 'other_ld_flags should not include -ObjC when there are not static frameworks' do
-          target_definition = stub('target_definition', :inheritance => 'complete', :abstract? => false, :podfile => Podfile.new)
+          target_definition = fixture_target_definition(:contents => { 'inheritance' => 'complete' })
           spec = stub('spec', :library_specification? => false, :spec_type => :test)
           consumer = stub('consumer',
                           :libraries => ['xml2'],
@@ -185,7 +187,7 @@ module Pod
                             :include_in_build_config? => true,
                             :should_build? => false,
                             :spec_consumers => [consumer],
-                            :static_framework? => false,
+                            :build_as_static? => false,
                             :product_basename => 'PodTarget',
                             :target_definitions => [target_definition],
                            )
@@ -195,7 +197,7 @@ module Pod
         end
 
         it 'other_ld_flags should include -ObjC when linking static frameworks' do
-          target_definition = stub('target_definition', :inheritance => 'complete', :abstract? => false, :podfile => Podfile.new)
+          target_definition = fixture_target_definition(:contents => { 'inheritance' => 'complete' })
           spec = stub('spec', :library_specification? => true, :spec_type => :library)
           consumer = stub('consumer',
                           :libraries => ['xml2'],
@@ -221,7 +223,7 @@ module Pod
                             :include_in_build_config? => true,
                             :should_build? => false,
                             :spec_consumers => [consumer],
-                            :static_framework? => true,
+                            :build_as_static? => true,
                             :product_basename => 'PodTarget',
                             :target_definitions => [target_definition],
                            )

--- a/spec/unit/target/build_type_spec.rb
+++ b/spec/unit/target/build_type_spec.rb
@@ -1,0 +1,77 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  class Target
+    describe BuildType do
+      describe '#initialize' do
+        it 'returns static library by default' do
+          BuildType.new.should == BuildType.static_library
+        end
+
+        it 'allows specifying linkage' do
+          BuildType.new(:linkage => :dynamic).should == BuildType.dynamic_library
+        end
+
+        it 'allows specifying packaging' do
+          BuildType.new(:packaging => :framework).should == BuildType.static_framework
+        end
+
+        it 'raises when given an unknown linkage' do
+          -> { BuildType.new(:linkage => :foo) }.should.raise(ArgumentError).
+            message.should.include? 'Invalid linkage option :foo, valid options are [:static, :dynamic]'
+        end
+      end
+
+      describe 'convenience factory methods' do
+        it '#dynamic_library' do
+          BuildType.dynamic_library.should == BuildType.new(:linkage => :dynamic, :packaging => :library)
+        end
+
+        it '#static_library' do
+          BuildType.static_library.should == BuildType.new(:linkage => :static, :packaging => :library)
+        end
+
+        it '#dynamic_framework' do
+          BuildType.dynamic_framework.should == BuildType.new(:linkage => :dynamic, :packaging => :framework)
+        end
+
+        it '#static_framework' do
+          BuildType.static_framework.should == BuildType.new(:linkage => :static, :packaging => :framework)
+        end
+      end
+
+      describe '.infer_from_spec' do
+        it 'infers the build type' do
+          BuildType.infer_from_spec(nil, :host_requires_frameworks => false).should == BuildType.static_library
+          BuildType.infer_from_spec(nil, :host_requires_frameworks => true).should == BuildType.dynamic_framework
+
+          BuildType.infer_from_spec(stub('spec', :root => stub('root_spec', :static_framework => true)), :host_requires_frameworks => false).
+            should == BuildType.static_library
+          BuildType.infer_from_spec(stub('spec', :root => stub('root_spec', :static_framework => false)), :host_requires_frameworks => false).
+            should == BuildType.static_library
+          BuildType.infer_from_spec(stub('spec', :root => stub('root_spec', :static_framework => true)), :host_requires_frameworks => true).
+            should == BuildType.static_framework
+          BuildType.infer_from_spec(stub('spec', :root => stub('root_spec', :static_framework => false)), :host_requires_frameworks => true).
+            should == BuildType.dynamic_framework
+        end
+      end
+
+      describe '#==' do
+        it 'compares equal build types as equal' do
+          BuildType.new(:linkage => :dynamic, :packaging => :library).should == BuildType.new(:linkage => :dynamic, :packaging => :library)
+        end
+
+        it 'compares unequal build types as unequal' do
+          BuildType.new(:linkage => :dynamic, :packaging => :framework).should != BuildType.new(:linkage => :dynamic, :packaging => :library)
+          BuildType.new(:linkage => :static, :packaging => :library).should != BuildType.new(:linkage => :dynamic, :packaging => :library)
+        end
+      end
+
+      describe '#to_s' do
+        it 'returns a readable representation' do
+          BuildType.static_framework.to_s.should == 'static framework'
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -5,7 +5,7 @@ module Pod
     before do
       @banana_spec = fixture_spec('banana-lib/BananaLib.podspec')
       @target_definition = fixture_target_definition
-      @pod_target = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@banana_spec], [@target_definition])
+      @pod_target = fixture_pod_target(@banana_spec, false, {}, [], Platform.ios, [@target_definition])
     end
 
     describe 'Meta' do
@@ -384,12 +384,12 @@ module Pod
       end
 
       it 'returns true when building as a framework' do
-        @pod_target.stubs(:requires_frameworks? => true)
+        @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
         @pod_target.should.defines_module
       end
 
       it 'returns true when building as a static framework' do
-        @pod_target.stubs(:requires_frameworks? => true, :static_framework? => true)
+        @pod_target.stubs(:build_type => Target::BuildType.static_framework)
         @pod_target.should.defines_module
       end
 
@@ -401,8 +401,8 @@ module Pod
       it 'returns false when any target definition says to' do
         @target_definition.set_use_modular_headers_for_pod('BananaLib', true)
 
-        other_target_definition = Podfile::TargetDefinition.new('Other', nil)
-        other_target_definition.abstract = false
+        other_target_definition = fixture_target_definition('Other')
+        other_target_definition.store_pod('BananaLib')
 
         @pod_target.stubs(:target_definitions).returns([@target_definition, other_target_definition])
 


### PR DESCRIPTION
This centralizes logic for static/dynamic library/framework in a single place, and will make future per-target configuration much easier.

- [x] Docs
- [x] Tests for the new class
- [x] Update integration specs
- [x] Rebase