### PR TITLE
Fix PROFILE to COCOAPODS_PROFILE to avoid commonly used the env variable 

### DIFF
--- a/bin/pod
+++ b/bin/pod
@@ -35,7 +35,7 @@ STDOUT.sync = true if ENV['CP_STDOUT_SYNC'] == 'TRUE'
 
 require 'cocoapods'
 
-if profile_filename = ENV['PROFILE']
+if profile_filename = ENV['COCOAPODS_PROFILE']
   require 'ruby-prof'
   reporter =
     case (profile_extname = File.extname(profile_filename))


### PR DESCRIPTION
Fixes #8209 

- To avoid env variable `PROFILE` which can be commonly use in CI environment.
- `COCOAPODS_PROFILE` could be a good alternative