### PR TITLE
Properly cache value for `inhibit_warnings?` method

### DIFF
--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -599,7 +599,7 @@ module Pod
           'settings to inhibit warnings. CocoaPods does not currently ' \
           'support different settings and will fall back to your preference ' \
           'set in the root target definition.'
-        podfile.root_target_definitions.first.inhibits_warnings_for_pod?(root_spec.name)
+        @inhibit_warnings = podfile.root_target_definitions.first.inhibits_warnings_for_pod?(root_spec.name)
       end
     end
 


### PR DESCRIPTION
This prevents `UI.warn` from being called multiple times therefore spamming users when they hit that case.