### PR TITLE
Don't have libraries add app targets to their scheme for building.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Don't have libraries build the app spec.  
+  [Derek Ostrander](https://github.com/dostrander)
+  [#8244](https://github.com/CocoaPods/CocoaPods/pull/8244)
 
 ## 1.6.0.beta.2 (2018-10-17)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -89,10 +89,6 @@ module Pod
               installation_result.test_native_targets.each do |test_native_target|
                 scheme.add_test_target(test_native_target)
               end
-
-              installation_result.app_native_targets.each do |add_build_target|
-                scheme.add_build_target(add_build_target)
-              end
             end
             project.save
           end


### PR DESCRIPTION
Introduced with the introduction of app specs:
https://github.com/CocoaPods/CocoaPods/pull/8158
