### PR TITLE
Extract project writing into a new object.

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -208,7 +208,10 @@ module Pod
         @target_installation_results = pod_project_generation_result.target_installation_results
         @pods_project = pod_project_generation_result.project
         run_podfile_post_install_hooks
-        Xcode::PodsProjectGenerator.write(@pods_project, target_installation_results, @sandbox.project_path, installation_options.deterministic_uuids?)
+        project_writer = Xcode::PodsProjectWriter.new(sandbox, pods_project,
+                                                      target_installation_results.pod_target_installation_results,
+                                                      installation_options)
+        project_writer.write!
         generator.share_development_pod_schemes(@pods_project)
         write_lockfiles
       end

--- a/lib/cocoapods/installer/xcode.rb
+++ b/lib/cocoapods/installer/xcode.rb
@@ -2,6 +2,7 @@ module Pod
   class Installer
     class Xcode
       autoload :PodsProjectGenerator, 'cocoapods/installer/xcode/pods_project_generator'
+      autoload :PodsProjectWriter, 'cocoapods/installer/xcode/pods_project_generator/pods_project_writer'
       autoload :TargetValidator, 'cocoapods/installer/xcode/target_validator'
     end
   end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
@@ -1,0 +1,68 @@
+module Pod
+  class Installer
+    class Xcode
+      # Responsible for cleaning the project and writing to disk.
+      #
+      class PodsProjectWriter
+        # @return [Sandbox] sandbox
+        #         The Pods sandbox instance.
+        #
+        attr_reader :sandbox
+
+        # @return [Project] project
+        #         The project to save.
+        #
+        attr_reader :project
+
+        # @return [Hash<String, TargetInstallationResult>] pod_target_installation_results
+        #         Hash of pod target name to installation results.
+        #
+        attr_reader :pod_target_installation_results
+
+        # @return [InstallationOptions] installation_options
+        #
+        attr_reader :installation_options
+
+        # Initialize a new instance
+        #
+        # @param [Sandbox] sandbox @see #sandbox
+        # @param [Project] project @see #project
+        # @param [Hash<String, TargetInstallationResult>] pod_target_installation_results @see #pod_target_installation_results
+        # @param [InstallationOptions] installation_options @see #installation_options
+        #
+        def initialize(sandbox, project, pod_target_installation_results, installation_options)
+          @sandbox = sandbox
+          @project = project
+          @pod_target_installation_results = pod_target_installation_results
+          @installation_options = installation_options
+        end
+
+        def write!
+          UI.message "- Writing Xcode project file to #{UI.path sandbox.project_path}" do
+            project.pods.remove_from_project if project.pods.empty?
+            project.support_files_group.remove_from_project if project.support_files_group.empty?
+            project.development_pods.remove_from_project if project.development_pods.empty?
+            project.sort(:groups_position => :below)
+            if installation_options.deterministic_uuids?
+              UI.message('- Generating deterministic UUIDs') { project.predictabilize_uuids }
+            end
+            library_product_types = [:framework, :dynamic_library, :static_library]
+            results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
+              [result.native_target, result]
+            end]
+            project.recreate_user_schemes(false) do |scheme, target|
+              next unless target.respond_to?(:symbol_type)
+              next unless library_product_types.include? target.symbol_type
+              installation_result = results_by_native_target[target]
+              next unless installation_result
+              installation_result.test_native_targets.each do |test_native_target|
+                scheme.add_test_target(test_native_target)
+              end
+            end
+            project.save
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/installer/xcode/pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator_spec.rb
@@ -401,15 +401,18 @@ module Pod
               pod_generator_result = @generator.generate!
               pod_generator_result.project.main_group.expects(:sort)
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
-              PodsProjectGenerator.write(pod_generator_result.project, pod_generator_result.target_installation_results, @generator.sandbox.project_path, false)
+              Xcode::PodsProjectWriter.new(@generator.sandbox, pod_generator_result.project,
+                                           pod_generator_result.target_installation_results.pod_target_installation_results,
+                                           @generator.installation_options).write!
             end
 
             it 'saves the project to the given path' do
               pod_generator_result = @generator.generate!
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
-              path = temporary_directory + 'Pods/Pods.xcodeproj'
-              pod_generator_result.project.expects(:save).with(path)
-              PodsProjectGenerator.write(pod_generator_result.project, pod_generator_result.target_installation_results, path, false)
+              pod_generator_result.project.expects(:save)
+              Xcode::PodsProjectWriter.new(@generator.sandbox, pod_generator_result.project,
+                                           pod_generator_result.target_installation_results.pod_target_installation_results,
+                                           @generator.installation_options).write!
             end
           end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -69,7 +69,7 @@ module Pod
         @installer.stubs(:perform_post_install_actions)
         Installer::Xcode::PodsProjectGenerator.any_instance.stubs(:share_development_pod_schemes)
         Installer::Xcode::PodsProjectGenerator.any_instance.stubs(:generate!)
-        Installer::Xcode::PodsProjectGenerator.stubs(:write)
+        Installer::Xcode::PodsProjectWriter.any_instance.stubs(:write!)
       end
 
       it 'in runs the pre-install hooks before cleaning the Pod sources' do
@@ -92,13 +92,14 @@ module Pod
         @installer.unstub(:generate_pods_project)
         generator = @installer.send(:create_generator)
         @installer.stubs(:create_generator).returns(generator)
-        generator_result = Installer::Xcode::PodsProjectGenerator::PodsProjectGeneratorResult.new(nil, [])
+        target_installation_results = Installer::Xcode::PodsProjectGenerator::InstallationResults.new({}, {})
+        generator_result = Installer::Xcode::PodsProjectGenerator::PodsProjectGeneratorResult.new(nil, target_installation_results)
         generator.stubs(:generate!).returns(generator_result)
         generator.stubs(:share_development_pod_schemes)
 
         hooks = sequence('hooks')
         @installer.expects(:run_podfile_post_install_hooks).once.in_sequence(hooks)
-        Installer::Xcode::PodsProjectGenerator.expects(:write).once.in_sequence(hooks)
+        Installer::Xcode::PodsProjectWriter.any_instance.expects(:write!).once.in_sequence(hooks)
 
         @installer.install!
       end


### PR DESCRIPTION
This extracts writing and cleaning up a `Project` out of `PodsProjectGenerator` and into its own object called `PodsProjectWriter`.