### PR TITLE
Kill sandbox.project

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -497,7 +497,7 @@ module Pod
       if any_plugin_post_install_hooks?
         unlock_pod_sources
 
-        context = PostInstallHooksContext.generate(sandbox, aggregate_targets)
+        context = PostInstallHooksContext.generate(sandbox, pods_project, aggregate_targets)
         HooksManager.run(:post_install, context, plugins)
       end
 

--- a/lib/cocoapods/installer/post_install_hooks_context.rb
+++ b/lib/cocoapods/installer/post_install_hooks_context.rb
@@ -40,6 +40,9 @@ module Pod
       # @param  [Sandbox] sandbox
       #         The sandbox
       #
+      # @param  [Project] pods_project
+      #         The pods project.
+      #
       # @param  [Array<AggregateTarget>] aggregate_targets
       #         The aggregate targets, which will been presented by an adequate
       #         {UmbrellaTargetDescription} in the generated context.
@@ -47,7 +50,7 @@ module Pod
       # @return [HooksContext] Convenience class method to generate the
       #         static context.
       #
-      def self.generate(sandbox, aggregate_targets)
+      def self.generate(sandbox, pods_project, aggregate_targets)
         umbrella_targets_descriptions = aggregate_targets.map do |umbrella|
           user_project = umbrella.user_project
           user_targets = umbrella.user_targets
@@ -58,7 +61,7 @@ module Pod
           UmbrellaTargetDescription.new(user_project, user_targets, specs, platform_name, platform_deployment_target, cocoapods_target_label)
         end
 
-        new(sandbox, sandbox.root.to_s, sandbox.project, umbrella_targets_descriptions)
+        new(sandbox, sandbox.root.to_s, pods_project, umbrella_targets_descriptions)
       end
 
       # Pure data class which describes an umbrella target.

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -67,7 +67,6 @@ module Pod
           project_generator = ProjectGenerator.new(sandbox, project_path, pod_targets, build_configurations,
                                                    platforms, object_version, config.podfile_path)
           project = project_generator.generate!
-          sandbox.project = project
 
           install_file_references(project)
           target_installation_results = install_targets(project)

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -76,10 +76,6 @@ module Pod
       end
     end
 
-    # @return [Project] the Pods project.
-    #
-    attr_accessor :project
-
     # Removes the files of the Pod with the given name from the sandbox.
     #
     # @return [void]

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -318,7 +318,7 @@ module Pod
     def resource_paths
       @resource_paths ||= begin
         file_accessors.each_with_object({}) do |file_accessor, hash|
-          resource_paths = file_accessor.resources.map { |res| "${PODS_ROOT}/#{res.relative_path_from(sandbox.project.path.dirname)}" }
+          resource_paths = file_accessor.resources.map { |res| "${PODS_ROOT}/#{res.relative_path_from(sandbox.project_path.dirname)}" }
           prefix = Pod::Target::BuildSettings::CONFIGURATION_BUILD_DIR_VARIABLE
           prefix = configuration_build_dir unless file_accessor.spec.test_specification?
           resource_bundle_paths = file_accessor.resource_bundles.keys.map { |name| "#{prefix}/#{name.shellescape}.bundle" }

--- a/spec/unit/installer/post_install_hooks_context_spec.rb
+++ b/spec/unit/installer/post_install_hooks_context_spec.rb
@@ -14,7 +14,7 @@ module Pod
       umbrella = AggregateTarget.new(sandbox, false, {}, [], Platform.ios, target_definition, config.sandbox.root.dirname, user_project, [user_target.uuid], 'Release' => [pod_target])
       umbrella.stubs(:platform).returns(Platform.new(:ios, '8.0'))
 
-      result = Installer::PostInstallHooksContext.generate(sandbox, [umbrella])
+      result = Installer::PostInstallHooksContext.generate(sandbox, pods_project, [umbrella])
       result.class.should == Installer::PostInstallHooksContext
       result.sandbox_root.should == '/path'
       result.pods_project.should == pods_project

--- a/spec/unit/installer/user_project_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator_spec.rb
@@ -15,8 +15,6 @@ module Pod
             end
           end
         end
-        config.sandbox.project = Project.new(config.sandbox.project_path)
-        config.sandbox.project.save
         user_build_configurations = { 'Release' => :release, 'Debug' => :debug }
         @target = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, @podfile.target_definitions['SampleProject'], sample_project_path.dirname, Xcodeproj::Project.open(@sample_project_path), ['A346496C14F9BE9A0080D870'], {})
         @empty_library = AggregateTarget.new(config.sandbox, false, user_build_configurations, [], Platform.ios, @podfile.target_definitions[:empty], sample_project_path.dirname, @target.user_project, ['C0C495321B9E5C47004F9854'], {})

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -16,7 +16,6 @@ module Pod
               @target_definition = @podfile.target_definitions['SampleProject']
               @project = Project.new(config.sandbox.project_path)
 
-              config.sandbox.project = @project
               path_list = Sandbox::PathList.new(fixture('banana-lib'))
               @spec = fixture_spec('banana-lib/BananaLib.podspec')
               @spec.prefix_header_contents = '#import "BlocksKit.h"'

--- a/spec/unit/installer/xcode/pods_project_generator/app_host_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/app_host_installer_spec.rb
@@ -7,7 +7,6 @@ module Pod
         describe AppHostInstaller do
           before do
             @project = Project.new(config.sandbox.project_path)
-            config.sandbox.project = @project
             @project.add_pod_group('Subgroup', '')
           end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -16,7 +16,6 @@ module Pod
               @target_definition = @podfile.target_definitions['SampleProject']
               @project = Project.new(config.sandbox.project_path)
 
-              config.sandbox.project = @project
               path_list = Sandbox::PathList.new(fixture('banana-lib'))
               @spec = fixture_spec('banana-lib/BananaLib.podspec')
               file_accessor = Sandbox::FileAccessor.new(path_list, @spec.consumer(:ios))
@@ -161,7 +160,6 @@ module Pod
                 @target_definition = @podfile.target_definitions['SampleProject']
                 @target_definition2 = @podfile.target_definitions['SampleProject2']
                 @project = Project.new(config.sandbox.project_path)
-                config.sandbox.project = @project
 
                 @watermelon_spec = fixture_spec('watermelon-lib/WatermelonLib.podspec')
 
@@ -421,7 +419,6 @@ module Pod
                 end
                 @target_definition = @podfile.target_definitions['SampleProject']
                 @project = Project.new(config.sandbox.project_path)
-                config.sandbox.project = @project
 
                 @minions_spec = fixture_spec('minions-lib/MinionsLib.podspec')
 
@@ -530,7 +527,6 @@ module Pod
 
                 # reset project to use symlinked dir
                 @project = Project.new(config.sandbox.project_path)
-                config.sandbox.project = @project
 
                 path_list = Sandbox::PathList.new(fixture('banana-lib-symlinked/'))
                 @spec = fixture_spec('banana-lib-symlinked/BananaLib.podspec')
@@ -1082,8 +1078,6 @@ module Pod
 
                 @project = Project.new(config.sandbox.project_path)
 
-                config.sandbox.project = @project
-
                 @spec = fixture_spec('banana-lib/BananaLib.podspec')
                 @spec.resources = ['Resources/**/*']
                 @spec.resource_bundle = nil
@@ -1142,8 +1136,6 @@ module Pod
                 config.sandbox.prepare
 
                 @project = Project.new(config.sandbox.project_path)
-
-                config.sandbox.project = @project
 
                 @spec = fixture_spec('banana-lib/BananaLib.podspec')
                 @spec.resources = nil

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -7,7 +7,6 @@ module Pod
         describe TargetInstaller do
           before do
             @project = Project.new(config.sandbox.project_path)
-            config.sandbox.project = @project
             user_build_configurations = { 'Debug' => :debug, 'Release' => :release, 'AppStore' => :release, 'Test' => :debug }
             archs = ['$(ARCHS_STANDARD_64_BIT)']
             @target = Target.new(config.sandbox, false, user_build_configurations, archs, Platform.ios)

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -26,10 +26,6 @@ module Pod
         @sandbox.manifest.should.nil?
       end
 
-      it 'returns the project' do
-        @sandbox.project.should.nil?
-      end
-
       it 'returns the public headers store' do
         @sandbox.public_headers.root.should ==
           temporary_directory + 'Sandbox/Headers/Public'


### PR DESCRIPTION
Removes reference to the pods project on `Sandbox`. Projects should now be injected everywhere as an arg.