### PR TITLE
Add CDN repo Source to allow retrieving specs from a web URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#8287](https://github.com/CocoaPods/CocoaPods/issues/8287)
 
+* Add CDN repo Source to allow retrieving specs from a web URL.  
+  [igor-makarov](https://github.com/igor-makarov)
+  [#8268](https://github.com/CocoaPods/CocoaPods/issues/8268) (partial beta solution)
+
 * Multi Pod Project Generation Support.  
   Support for splitting the pods project into a subproject per pod target, gated by the `generate_multiple_pod_projects` installation option.  
   [Sebastian Shanus](https://github.com/sebastianv1)

--- a/lib/cocoapods/command/repo.rb
+++ b/lib/cocoapods/command/repo.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'cocoapods/command/repo/add'
+require 'cocoapods/command/repo/add_cdn'
 require 'cocoapods/command/repo/lint'
 require 'cocoapods/command/repo/list'
 require 'cocoapods/command/repo/push'

--- a/lib/cocoapods/command/repo/add_cdn.rb
+++ b/lib/cocoapods/command/repo/add_cdn.rb
@@ -1,0 +1,58 @@
+module Pod
+  class Command
+    class Repo < Command
+      class AddCDN < Repo
+        self.summary = 'Add a spec repo backed by a CDN'
+
+        self.description = <<-DESC
+          Add `URL` to the local spec-repos directory at `#{Config.instance.repos_dir}`. The
+          remote can later be referred to by `NAME`.
+        DESC
+
+        self.arguments = [
+          CLAide::Argument.new('NAME',   true),
+          CLAide::Argument.new('URL',    true),
+        ]
+
+        def initialize(argv)
+          @name = argv.shift_argument
+          @url = argv.shift_argument
+          super
+        end
+
+        def validate!
+          super
+          unless @name && @url
+            help! 'Adding a repo needs a `NAME` and a `URL`.'
+          end
+          if @name == 'master'
+            raise Informative,
+                  'To setup the master specs repo, please run `pod setup`.'
+          end
+        end
+
+        def run
+          section = "Adding spec repo `#{@name}` with CDN `#{@url}`"
+          UI.section(section) do
+            save_url
+            config.sources_manager.sources([dir.basename.to_s]).each(&:verify_compatibility!)
+          end
+        end
+
+        private
+
+        # Saves the spec-repo URL to a '.url' file.
+        #
+        # @return [void]
+        #
+        def save_url
+          dir.mkpath
+          File.open(dir + '.url', 'w') { |file| file.write(@url) }
+        rescue => e
+          raise Informative, "Could not create '#{config.repos_dir}', the CocoaPods repo cache directory.\n" \
+              "#{e.class.name}: #{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods/command/repo/list.rb
+++ b/lib/cocoapods/command/repo/list.rb
@@ -52,7 +52,7 @@ module Pod
               UI.puts "- Type: git (#{branch_name})"
             end
           else
-            UI.puts '- Type: local'
+            UI.puts "- Type: #{source.type}"
           end
 
           UI.puts "- URL:  #{source.url}"

--- a/spec/functional/command/repo/add_cdn_spec.rb
+++ b/spec/functional/command/repo/add_cdn_spec.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+
+module Pod
+  describe Command::Repo::AddCDN do
+    extend SpecHelper::Command
+    extend SpecHelper::TemporaryRepos
+    TEST_REPO_URL = 'https://localhost:4321/'.freeze
+
+    before do
+      config.repos_dir = SpecHelper.tmp_repos_path
+    end
+
+    it 'adds a spec-repo' do
+      run_command('repo', 'add-cdn', 'private', TEST_REPO_URL)
+      Dir.chdir(config.repos_dir + 'private') do
+        File.read('.url').should == TEST_REPO_URL
+      end
+    end
+
+    it 'raises an informative error when the repos directory fails to be created' do
+      Pathname.any_instance.expects(:mkpath).raises(SystemCallError, 'Operation not permitted')
+      e = lambda { run_command('repo', 'add-cdn', 'private', TEST_REPO_URL) }.should.raise Informative
+      e.message.should.match /Could not create '#{tmp_repos_path}', the CocoaPods repo cache directory./
+    end
+  end
+end


### PR DESCRIPTION
As discussed in #8268, I am submitting an initial draft of the CDN source implementation.

Please note that at this point, the implementation is purely additive, and does not interfere with traditional spec repo retrieval.

There's a corresponding [PR in Core](https://github.com/CocoaPods/Core/pull/469) that needs to be merged first.

The tests on travis will fail because of Core integration, but I've hacked together [another branch](https://travis-ci.org/igor-makarov/CocoaPods/builds/455397872) to show that everything passes. As soon as the [Core PR](https://github.com/CocoaPods/Core/pull/469) is merged, the tests here will pass as well.