### PR TITLE
Use maximally-compatible launch storyboard for iOS 8 compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Derek Ostrander](https://github.com/dostrander)
   [#8244](https://github.com/CocoaPods/CocoaPods/pull/8244)
 
-* Fix running test specs that support iOS 8.
+* Fix running test specs that support iOS 8.  
   [Jeff Kelley](https://github.com/SlaunchaMan)
   [#8286](https://github.com/CocoaPods/CocoaPods/pull/8286)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Derek Ostrander](https://github.com/dostrander)
   [#8244](https://github.com/CocoaPods/CocoaPods/pull/8244)
 
+* Fix running test specs that support iOS 8.
+  [Jeff Kelley](https://github.com/SlaunchaMan)
+  [#8286](https://github.com/CocoaPods/CocoaPods/pull/8286)
+
 ## 1.6.0.beta.2 (2018-10-17)
 
 ##### Enhancements

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -281,10 +281,9 @@ EOS
 
       LAUNCHSCREEN_STORYBOARD_CONTENTS = <<-XML.strip_heredoc.freeze
               <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-              <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+              <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
                 <dependencies>
                   <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
-                  <capability name="Safe area layout guides" minToolsVersion="9.0"/>
                   <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
                 </dependencies>
                 <scenes>
@@ -292,11 +291,14 @@ EOS
                   <scene sceneID="EHf-IW-A2E">
                     <objects>
                       <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                        <layoutGuides>
+                          <viewControllerLayoutGuide type="top" id="rUq-ht-380"/>
+                          <viewControllerLayoutGuide type="bottom" id="a9l-8d-mfx"/>
+                        </layoutGuides>
                         <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                           <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                           <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                           <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                          <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         </view>
                       </viewController>
                       <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -105,13 +105,16 @@ module Pod
       # @param  [Symbol] platform
       #         the platform of the target. Can be `:ios` or `:osx`, etc.
       #
+      # @param  [String] deployment_target
+      #         the deployment target for the platform.
+      #
       # @param  [String] name
       #         The name to use for the target, defaults to 'App'.
       #
       # @return [PBXFileReference] the created file reference of the launchscreen storyboard.
       #
-      def self.add_launchscreen_storyboard(project, target, group, name = 'App')
-        launch_storyboard_file = AppTargetHelper.create_launchscreen_storyboard_file(project, name)
+      def self.add_launchscreen_storyboard(project, target, group, deployment_target, name = 'App')
+        launch_storyboard_file = AppTargetHelper.create_launchscreen_storyboard_file(project, deployment_target, name)
         launch_storyboard_ref = group.new_file(launch_storyboard_file)
         target.resources_build_phase.add_file_reference(launch_storyboard_ref)
       end
@@ -199,15 +202,22 @@ module Pod
       # @param  [Project] project
       #         the Xcodeproj to generate the launchscreen storyboard into.
       #
+      # @param  [String] deployment_target
+      #         the deployment target for the platform.
+      #
       # @param  [String] name
       #         The name of the folder to use and save the generated launchscreen storyboard file.
       #
       # @return [Pathname] the new launchscreen storyboard file that was generated.
       #
-      def self.create_launchscreen_storyboard_file(project, name = 'App')
+      def self.create_launchscreen_storyboard_file(project, deployment_target, name = 'App')
         launch_storyboard_file = project.path.dirname.+("#{name}/LaunchScreen.storyboard")
         launch_storyboard_file.parent.mkpath
-        File.write(launch_storyboard_file, LAUNCHSCREEN_STORYBOARD_CONTENTS)
+        if Version.new(deployment_target) >= Version.new('9.0')
+          File.write(launch_storyboard_file, LAUNCHSCREEN_STORYBOARD_CONTENTS)
+        else
+          File.write(launch_storyboard_file, LAUNCHSCREEN_STORYBOARD_CONTENTS_IOS_8)
+        end
         launch_storyboard_file
       end
 
@@ -279,7 +289,7 @@ int main(int argc, const char * argv[]) {
 }
 EOS
 
-      LAUNCHSCREEN_STORYBOARD_CONTENTS = <<-XML.strip_heredoc.freeze
+      LAUNCHSCREEN_STORYBOARD_CONTENTS_IOS_8 = <<-XML.strip_heredoc.freeze
               <?xml version="1.0" encoding="UTF-8" standalone="no"?>
               <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
                 <dependencies>
@@ -308,6 +318,35 @@ EOS
                 </scenes>
               </document>
       XML
+
+      LAUNCHSCREEN_STORYBOARD_CONTENTS = <<-XML.strip_heredoc.freeze
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+              <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+                <dependencies>
+                  <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+                  <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+                  <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+                </dependencies>
+                <scenes>
+                  <!--View Controller-->
+                  <scene sceneID="EHf-IW-A2E">
+                    <objects>
+                      <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                        <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                          <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                          <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                          <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                          <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        </view>
+                      </viewController>
+                      <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                    </objects>
+                    <point key="canvasLocation" x="53" y="375"/>
+                  </scene>
+                </scenes>
+              </document>
+      XML
+
     end
   end
 end

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -346,7 +346,6 @@ EOS
                 </scenes>
               </document>
       XML
-
     end
   end
 end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
@@ -73,7 +73,7 @@ module Pod
             end
 
             Pod::Generator::AppTargetHelper.add_app_host_main_file(project, app_host_target, platform_name, @group, app_target_label) if add_main
-            Pod::Generator::AppTargetHelper.add_launchscreen_storyboard(project, app_host_target, @group, app_target_label) if platform == :ios
+            Pod::Generator::AppTargetHelper.add_launchscreen_storyboard(project, app_host_target, @group, deployment_target, app_target_label) if platform == :ios
             additional_entries = platform == :ios ? ADDITIONAL_IOS_INFO_PLIST_ENTRIES : {}
             create_info_plist_file_with_sandbox(sandbox, app_host_info_plist_path, app_host_target, '1.0.0', platform,
                                                 :appl, additional_entries)

--- a/spec/unit/generator/app_target_helper_spec.rb
+++ b/spec/unit/generator/app_target_helper_spec.rb
@@ -125,7 +125,6 @@ module Pod
             file.basename.to_s.should == 'LaunchScreen.storyboard'
             file.read.should == AppTargetHelper::LAUNCHSCREEN_STORYBOARD_CONTENTS
           end
-
         end
 
         describe 'on iOS 8' do
@@ -139,11 +138,8 @@ module Pod
             file.basename.to_s.should == 'LaunchScreen.storyboard'
             file.read.should == AppTargetHelper::LAUNCHSCREEN_STORYBOARD_CONTENTS_IOS_8
           end
-
         end
-
       end
-
     end
   end
 end

--- a/spec/unit/generator/app_target_helper_spec.rb
+++ b/spec/unit/generator/app_target_helper_spec.rb
@@ -114,17 +114,36 @@ module Pod
       end
 
       describe 'creating a launchscreen storyboard' do
-        it 'creates the correct launchscreen storyboard contents' do
-          pod_target = stub('PodTarget', :uses_swift? => false, :should_build? => true,
-                                         :product_module_name => 'ModuleName', :name => 'ModuleName',
-                                         :sandbox => @sandbox)
-          project = stub('Project', :path => Pathname(Dir.mktmpdir(['CocoaPods-Lint-', "-#{pod_target.name}"])) + 'App.xcodeproj')
+        describe 'on iOS 9 and above' do
+          it 'creates the correct launchscreen storyboard contents' do
+            pod_target = stub('PodTarget', :uses_swift? => false, :should_build? => true,
+                                           :product_module_name => 'ModuleName', :name => 'ModuleName',
+                                           :sandbox => @sandbox)
+            project = stub('Project', :path => Pathname(Dir.mktmpdir(['CocoaPods-Lint-', "-#{pod_target.name}"])) + 'App.xcodeproj')
 
-          file = AppTargetHelper.create_launchscreen_storyboard_file(project)
-          file.basename.to_s.should == 'LaunchScreen.storyboard'
-          file.read.should == AppTargetHelper::LAUNCHSCREEN_STORYBOARD_CONTENTS
+            file = AppTargetHelper.create_launchscreen_storyboard_file(project, '9.0')
+            file.basename.to_s.should == 'LaunchScreen.storyboard'
+            file.read.should == AppTargetHelper::LAUNCHSCREEN_STORYBOARD_CONTENTS
+          end
+
         end
+
+        describe 'on iOS 8' do
+          it 'creates the correct launchscreen storyboard contents' do
+            pod_target = stub('PodTarget', :uses_swift? => false, :should_build? => true,
+                                           :product_module_name => 'ModuleName', :name => 'ModuleName',
+                                           :sandbox => @sandbox)
+            project = stub('Project', :path => Pathname(Dir.mktmpdir(['CocoaPods-Lint-', "-#{pod_target.name}"])) + 'App.xcodeproj')
+
+            file = AppTargetHelper.create_launchscreen_storyboard_file(project, '8.0')
+            file.basename.to_s.should == 'LaunchScreen.storyboard'
+            file.read.should == AppTargetHelper::LAUNCHSCREEN_STORYBOARD_CONTENTS_IOS_8
+          end
+
+        end
+
       end
+
     end
   end
 end


### PR DESCRIPTION
Fixes #8285. This PR modifies the template for launch storyboards to be compatible with iOS 8 by not including safe area insets.

If we want to keep the current state, it looks like we could pass the deployment target to the method that uses this, so I could create an alternative version that works for iOS 8 targets, keeping this version for iOS 9 targets.