### PR TITLE
Generate Info.plist files for static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Generate Info.plist files for static frameworks  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#8287](https://github.com/CocoaPods/CocoaPods/issues/8287)
+
 * Multi Pod Project Generation Support.  
   Support for splitting the pods project into a subproject per pod target, gated by the `generate_multiple_pod_projects` installation option.  
   [Sebastian Shanus](https://github.com/sebastianv1)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -86,7 +86,7 @@ module Pod
                 end
               end
 
-              if target.build_as_dynamic_framework?
+              if target.build_as_framework?
                 unless skip_info_plist?(native_target)
                   create_info_plist_file(target.info_plist_path, native_target, target.version, target.platform)
                 end
@@ -143,7 +143,6 @@ module Pod
           # @return [Boolean] Whether the target should build an Info.plist file
           #
           def skip_info_plist?(native_target)
-            return true if target.static_framework?
             existing_setting = native_target.resolved_build_setting('INFOPLIST_FILE', true).values.compact
             !existing_setting.empty?
           end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -870,6 +870,19 @@ module Pod
               ]
             end
 
+            it 'creates an info.plist file when static frameworks are required' do
+              @pod_target.stubs(:build_type).returns(Target::BuildType.static_framework)
+              @installer.install!
+              group = @project['Pods/BananaLib/Support Files']
+              group.children.map(&:display_name).sort.should == [
+                'BananaLib-Info.plist',
+                'BananaLib-dummy.m',
+                'BananaLib-prefix.pch',
+                'BananaLib.modulemap',
+                'BananaLib.xcconfig',
+              ]
+            end
+
             it 'does not create an Info.plist file if INFOPLIST_FILE is set' do
               @pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
               @spec.pod_target_xcconfig = {


### PR DESCRIPTION
The new Xcode 10 build system spits out a warning about missing Info.plist files for static frameworks like:

`    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'FirebaseCore')`

Even though Info.plist files should not be needed since static frameworks are fully linked into apps before bundling, they should be harmless to include.

Reported at https://github.com/firebase/firebase-ios-sdk/issues/1846