### PR TITLE
Only clone the latest commit from Specs

### DIFF
--- a/lib/cocoapods/command/setup.rb
+++ b/lib/cocoapods/command/setup.rb
@@ -50,7 +50,7 @@ module Pod
       # @return [void]
       #
       def add_master_repo
-        cmd = ['master', url, 'master', '--progress']
+        cmd = ['master', url, 'master', '--progress', '--depth', '1']
         Repo::Add.parse(cmd).run
       end
 


### PR DESCRIPTION
Saves a considerable amount of time and space when cloning during a `pod install`: 91 MiB vs 591 MiB