### PR TITLE
Update call to generate deterministic UUIDs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: e0287156d426ba588c9234bb2a4c824149889860
+  revision: ac6493bb51448059a2f13fcf7c0fa8708420c7a3
   branch: master
   specs:
     xcodeproj (1.7.0)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
@@ -9,10 +9,10 @@ module Pod
         #
         attr_reader :sandbox
 
-        # @return [Project] project
-        #         The project to save.
+        # @return [Array<Project>] projects
+        #         The list project to write.
         #
-        attr_reader :project
+        attr_reader :projects
 
         # @return [Hash<String, TargetInstallationResult>] pod_target_installation_results
         #         Hash of pod target name to installation results.
@@ -26,39 +26,53 @@ module Pod
         # Initialize a new instance
         #
         # @param [Sandbox] sandbox @see #sandbox
-        # @param [Project] project @see #project
+        # @param [Project] projects @see #project
         # @param [Hash<String, TargetInstallationResult>] pod_target_installation_results @see #pod_target_installation_results
         # @param [InstallationOptions] installation_options @see #installation_options
         #
-        def initialize(sandbox, project, pod_target_installation_results, installation_options)
+        def initialize(sandbox, projects, pod_target_installation_results, installation_options)
           @sandbox = sandbox
-          @project = project
+          @projects = projects
           @pod_target_installation_results = pod_target_installation_results
           @installation_options = installation_options
         end
 
         def write!
-          UI.message "- Writing Xcode project file to #{UI.path project.path}" do
+          cleanup_projects(projects)
+
+          if installation_options.deterministic_uuids?
+            UI.message('- Generating deterministic UUIDs') { Xcodeproj::Project.predictabilize_uuids(projects) }
+          end
+
+          projects.each do |project|
+            UI.message "- Writing Xcode project file to #{UI.path project.path}" do
+              library_product_types = [:framework, :dynamic_library, :static_library]
+              results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
+                [result.native_target, result]
+              end]
+              project.recreate_user_schemes(false) do |scheme, target|
+                next unless target.respond_to?(:symbol_type)
+                next unless library_product_types.include? target.symbol_type
+                installation_result = results_by_native_target[target]
+                next unless installation_result
+                installation_result.test_native_targets.each do |test_native_target|
+                  scheme.add_test_target(test_native_target)
+                end
+              end
+              project.save
+            end
+          end
+        end
+
+        private
+
+        # Cleans up projects before writing.
+        #
+        def cleanup_projects(projects)
+          projects.each do |project|
             [project.pods, project.support_files_group,
              project.development_pods, project.dependencies_group].each { |group| group.remove_from_project if group.empty? }
             project.sort(:groups_position => :below)
-            if installation_options.deterministic_uuids?
-              UI.message('- Generating deterministic UUIDs') { project.predictabilize_uuids }
-            end
-            library_product_types = [:framework, :dynamic_library, :static_library]
-            results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
-              [result.native_target, result]
-            end]
-            project.recreate_user_schemes(false) do |scheme, target|
-              next unless target.respond_to?(:symbol_type)
-              next unless library_product_types.include? target.symbol_type
-              installation_result = results_by_native_target[target]
-              next unless installation_result
-              installation_result.test_native_targets.each do |test_native_target|
-                scheme.add_test_target(test_native_target)
-              end
-            end
-            project.save
           end
         end
       end

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -401,7 +401,7 @@ module Pod
               pod_generator_result = @generator.generate!
               pod_generator_result.project.main_group.expects(:sort)
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
-              Xcode::PodsProjectWriter.new(@generator.sandbox, pod_generator_result.project,
+              Xcode::PodsProjectWriter.new(@generator.sandbox, [pod_generator_result.project],
                                            pod_generator_result.target_installation_results.pod_target_installation_results,
                                            @generator.installation_options).write!
             end
@@ -410,7 +410,7 @@ module Pod
               pod_generator_result = @generator.generate!
               Xcodeproj::Project.any_instance.stubs(:recreate_user_schemes)
               pod_generator_result.project.expects(:save)
-              Xcode::PodsProjectWriter.new(@generator.sandbox, pod_generator_result.project,
+              Xcode::PodsProjectWriter.new(@generator.sandbox, [pod_generator_result.project],
                                            pod_generator_result.target_installation_results.pod_target_installation_results,
                                            @generator.installation_options).write!
             end


### PR DESCRIPTION
Instead of calling `predictabilize` on each individual project, we will pass in the list of generated projects such that UUIDs are unique across all projects instead of unique per individual xcode project.