### PR TITLE
Move calling link headers for all pod targets earlier

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -40,6 +40,7 @@ module Pod
     autoload :PodSourcePreparer,          'cocoapods/installer/pod_source_preparer'
     autoload :UserProjectIntegrator,      'cocoapods/installer/user_project_integrator'
     autoload :Xcode,                      'cocoapods/installer/xcode'
+    autoload :SandboxHeaderLinker,        'cocoapods/installer/sandbox_header_linker'
 
     include Config::Mixin
 
@@ -134,6 +135,7 @@ module Pod
       resolve_dependencies
       download_dependencies
       validate_targets
+      link_sandbox_files
       generate_pods_project
       if installation_options.integrate_targets?
         integrate_user_project
@@ -188,6 +190,13 @@ module Pod
         run_podfile_pre_install_hooks
         clean_pod_sources
       end
+    end
+
+    # Links files into the Sandbox before project generation so they exist and can be used
+    # to analyze pod target build settings that depend on the Sandbox dir (ex. HEADER_SEARCH_PATHS).
+    #
+    def link_sandbox_files
+      SandboxHeaderLinker.new(sandbox, pod_targets).link!
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/installer/sandbox_header_linker.rb
+++ b/lib/cocoapods/installer/sandbox_header_linker.rb
@@ -1,0 +1,105 @@
+module Pod
+  class Installer
+    # Links the headers from every pod target into the Sandbox directory.
+    #
+    class SandboxHeaderLinker
+      # @return [Sandbox] The sandbox of the installation.
+      #
+      attr_reader :sandbox
+
+      # @return [Array<PodTarget>] The pod targets of the installation.
+      #
+      attr_reader :pod_targets
+
+      # Initialize a new instance
+      #
+      # @param [Sandbox] sandbox @see #sandbox
+      # @param [Array<PodTarget>] pod_targets @see #pod_targets
+      #
+      def initialize(sandbox, pod_targets)
+        @sandbox = sandbox
+        @pod_targets = pod_targets
+      end
+
+      # Creates the link to the headers of the Pod in the sandbox.
+      #
+      # @return [void]
+      #
+      def link!
+        UI.message '- Linking headers' do
+          pod_targets.each do |pod_target|
+            # When integrating Pod as frameworks, built Pods are built into
+            # frameworks, whose headers are included inside the built
+            # framework. Those headers do not need to be linked from the
+            # sandbox.
+            next if pod_target.build_as_framework? && pod_target.should_build?
+
+            headers_sandbox = Pathname.new(pod_target.pod_name)
+            added_build_headers = false
+            added_public_headers = false
+
+            file_accessors = pod_target.file_accessors.reject { |fa| fa.spec.non_library_specification? }
+            file_accessors.each do |file_accessor|
+              # Private headers will always end up in Pods/Headers/Private/PodA/*.h
+              # This will allow for `""` imports to work.
+              header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
+                added_build_headers = true
+                pod_target.build_headers.add_files(namespaced_path, files)
+              end
+
+              # Public headers on the other hand will be added in Pods/Headers/Public/PodA/PodA/*.h
+              # The extra folder is intentional in order for `<>` imports to work.
+              header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
+                added_public_headers = true
+                sandbox.public_headers.add_files(namespaced_path, files)
+              end
+            end
+
+            pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform) if added_build_headers
+            sandbox.public_headers.add_search_path(headers_sandbox, pod_target.platform) if added_public_headers
+          end
+        end
+      end
+
+      private
+
+      # Computes the destination sub-directory in the sandbox
+      #
+      # @param  [Pathname] headers_sandbox
+      #         The sandbox where the header links should be stored for this
+      #         Pod.
+      #
+      # @param  [Sandbox::FileAccessor] file_accessor
+      #         The consumer file accessor for which the headers need to be
+      #         linked.
+      #
+      # @param  [Array<Pathname>] headers
+      #         The absolute paths of the headers which need to be mapped.
+      #
+      # @return [Hash{Pathname => Array<Pathname>}] A hash containing the
+      #         headers folders as the keys and the absolute paths of the
+      #         header files as the values.
+      #
+      def header_mappings(headers_sandbox, file_accessor, headers)
+        consumer = file_accessor.spec_consumer
+        header_mappings_dir = consumer.header_mappings_dir
+        dir = headers_sandbox
+        dir += consumer.header_dir if consumer.header_dir
+
+        mappings = {}
+        headers.each do |header|
+          next if header.to_s.include?('.framework/')
+
+          sub_dir = dir
+          if header_mappings_dir
+            relative_path = header.relative_path_from(file_accessor.path_list.root + header_mappings_dir)
+            sub_dir += relative_path.dirname
+          end
+          mappings[sub_dir] ||= []
+          mappings[sub_dir] << header
+        end
+        mappings
+      end
+    end
+  end
+end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -47,7 +47,6 @@ module Pod
             add_vendored_libraries
             add_resources
             add_developer_files unless sandbox.development_pods.empty?
-            link_headers
           end
 
           #-----------------------------------------------------------------------#
@@ -129,46 +128,6 @@ module Pod
                     pods_project.mark_ruby_file_ref(ref)
                   end
                 end
-              end
-            end
-          end
-
-          # Creates the link to the headers of the Pod in the sandbox.
-          #
-          # @return [void]
-          #
-          def link_headers
-            UI.message '- Linking headers' do
-              pod_targets.each do |pod_target|
-                # When integrating Pod as frameworks, built Pods are built into
-                # frameworks, whose headers are included inside the built
-                # framework. Those headers do not need to be linked from the
-                # sandbox.
-                next if pod_target.build_as_framework? && pod_target.should_build?
-
-                headers_sandbox = Pathname.new(pod_target.pod_name)
-                added_build_headers = false
-                added_public_headers = false
-
-                file_accessors = pod_target.file_accessors.reject { |fa| fa.spec.non_library_specification? }
-                file_accessors.each do |file_accessor|
-                  # Private headers will always end up in Pods/Headers/Private/PodA/*.h
-                  # This will allow for `""` imports to work.
-                  header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
-                    added_build_headers = true
-                    pod_target.build_headers.add_files(namespaced_path, files)
-                  end
-
-                  # Public headers on the other hand will be added in Pods/Headers/Public/PodA/PodA/*.h
-                  # The extra folder is intentional in order for `<>` imports to work.
-                  header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
-                    added_public_headers = true
-                    sandbox.public_headers.add_files(namespaced_path, files)
-                  end
-                end
-
-                pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform) if added_build_headers
-                sandbox.public_headers.add_search_path(headers_sandbox, pod_target.platform) if added_public_headers
               end
             end
           end
@@ -292,44 +251,6 @@ module Pod
             result = Pathname.new(min[0...idx].join('/'))
             # Don't consider "/" a common path
             return result unless result.to_s == '' || result.to_s == '/'
-          end
-
-          # Computes the destination sub-directory in the sandbox
-          #
-          # @param  [Pathname] headers_sandbox
-          #         The sandbox where the header links should be stored for this
-          #         Pod.
-          #
-          # @param  [Sandbox::FileAccessor] file_accessor
-          #         The consumer file accessor for which the headers need to be
-          #         linked.
-          #
-          # @param  [Array<Pathname>] headers
-          #         The absolute paths of the headers which need to be mapped.
-          #
-          # @return [Hash{Pathname => Array<Pathname>}] A hash containing the
-          #         headers folders as the keys and the absolute paths of the
-          #         header files as the values.
-          #
-          def header_mappings(headers_sandbox, file_accessor, headers)
-            consumer = file_accessor.spec_consumer
-            header_mappings_dir = consumer.header_mappings_dir
-            dir = headers_sandbox
-            dir += consumer.header_dir if consumer.header_dir
-
-            mappings = {}
-            headers.each do |header|
-              next if header.to_s.include?('.framework/')
-
-              sub_dir = dir
-              if header_mappings_dir
-                relative_path = header.relative_path_from(file_accessor.path_list.root + header_mappings_dir)
-                sub_dir += relative_path.dirname
-              end
-              mappings[sub_dir] ||= []
-              mappings[sub_dir] << header
-            end
-            mappings
           end
 
           #-----------------------------------------------------------------------#

--- a/spec/unit/installer/sandbox_header_linker_specs.rb
+++ b/spec/unit/installer/sandbox_header_linker_specs.rb
@@ -1,0 +1,126 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  class Installer
+    describe SandboxHeaderLinker do
+      describe 'in general' do
+        before do
+          @pod_target = fixture_pod_target('banana-lib/BananaLib.podspec')
+          @file_accessor = @pod_target.file_accessors.first
+          @linker = SandboxHeaderLinker.new(config.sandbox, [@pod_target])
+        end
+        it 'does not symlink headers that belong to test specs' do
+          coconut_spec = fixture_spec('coconut-lib/CoconutLib.podspec')
+          coconut_test_spec = coconut_spec.test_specs.first
+          coconut_pod_target = fixture_pod_target_with_specs([coconut_spec, coconut_test_spec], false)
+          public_headers_root = config.sandbox.public_headers.root
+          private_headers_root = coconut_pod_target.build_headers.root
+          header_linker = SandboxHeaderLinker.new(config.sandbox, [coconut_pod_target])
+          header_linker.link!
+          (public_headers_root + 'CoconutLib/Coconut.h').should.exist
+          (public_headers_root + 'CoconutLib/CoconutTestHeader.h').should.not.exist
+          (private_headers_root + 'CoconutLib/Coconut.h').should.exist
+          (private_headers_root + 'CoconutLib/CoconutTestHeader.h').should.not.exist
+        end
+
+        it 'links the public headers meant for the user for a vendored framework' do
+          pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec', true)
+          pod_target_two = fixture_pod_target('monkey/monkey.podspec', true)
+          header_linker = SandboxHeaderLinker.new(config.sandbox, [pod_target_one, pod_target_two])
+          header_linker.link!
+          headers_root = config.sandbox.public_headers.root
+          banana_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
+          banana_headers.each { |banana_header| banana_header.should.not.exist }
+          monkey_header = headers_root + 'monkey/monkey.h'
+          monkey_header.should.exist # since it lives outside of the vendored framework
+          config.sandbox.public_headers.search_paths(pod_target_one.platform).should == %w(
+            ${PODS_ROOT}/Headers/Public
+            ${PODS_ROOT}/Headers/Public/monkey
+          )
+        end
+
+        it 'links the headers required for building the pod target' do
+          @linker.link!
+          headers_root = @pod_target.build_headers.root
+          public_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
+          private_header = headers_root + 'BananaLib/BananaPrivate.h'
+          framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
+          public_headers.each { |public_header| public_header.should.exist }
+          private_header.should.exist
+          framework_header.should.not.exist
+        end
+
+        it 'links the public headers meant for the user' do
+          @linker.link!
+          headers_root = config.sandbox.public_headers.root
+          public_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
+          private_header = headers_root + 'BananaLib/BananaPrivate.h'
+          framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
+          framework_subdir_header = headers_root + 'BananaLib/Bananalib/SubDir/SubBananalib.h'
+          public_headers.each { |public_header| public_header.should.exist }
+          private_header.should.not.exist
+          framework_header.should.not.exist
+          framework_subdir_header.should.not.exist
+        end
+
+        it 'does not link public headers from vendored framework, when frameworks required' do
+          @pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
+          @linker.link!
+          headers_root = config.sandbox.public_headers.root
+          framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
+          framework_header.should.not.exist
+        end
+      end
+      describe '#header_mappings' do
+        before do
+          spec = fixture_spec('banana-lib/BananaLib.podspec')
+          @pod_target = fixture_pod_target(spec)
+          @file_accessor = @pod_target.file_accessors.first
+          @sandbox_header_linker = SandboxHeaderLinker.new(config.sandbox, [@pod_target])
+        end
+
+        it 'returns the correct public header mappings' do
+          headers_sandbox = Pathname.new('BananaLib')
+          headers = [Pathname.new('Banana.h')]
+          mappings = @sandbox_header_linker.send(:header_mappings, headers_sandbox, @file_accessor, headers)
+          mappings.should == {
+            Pathname.new('BananaLib') => [Pathname.new('Banana.h')],
+          }
+        end
+
+        it 'takes into account the header dir specified in the spec for public headers' do
+          headers_sandbox = Pathname.new('BananaLib')
+          headers = [Pathname.new('Banana.h')]
+          @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
+          mappings = @sandbox_header_linker.send(:header_mappings, headers_sandbox, @file_accessor, headers)
+          mappings.should == {
+            Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
+          }
+        end
+
+        it 'takes into account the header dir specified in the spec for private headers' do
+          headers_sandbox = Pathname.new('BananaLib')
+          headers = [Pathname.new('Banana.h')]
+          @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
+          mappings = @sandbox_header_linker.send(:header_mappings, headers_sandbox, @file_accessor, headers)
+          mappings.should == {
+            Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
+          }
+        end
+
+        it 'takes into account the header mappings dir specified in the spec' do
+          headers_sandbox = Pathname.new('BananaLib')
+          header_1 = @file_accessor.root + 'BananaLib/sub_dir/dir_1/banana_1.h'
+          header_2 = @file_accessor.root + 'BananaLib/sub_dir/dir_2/banana_2.h'
+          headers = [header_1, header_2]
+          @file_accessor.spec_consumer.stubs(:header_mappings_dir).returns('BananaLib/sub_dir')
+          mappings = @sandbox_header_linker.send(:header_mappings, headers_sandbox, @file_accessor, headers)
+          mappings.should == {
+            (headers_sandbox + 'dir_1') => [header_1],
+            (headers_sandbox + 'dir_2') => [header_2],
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -69,73 +69,6 @@ module Pod
               file_ref.path.should == 'Sample.xcdatamodel'
               file_ref.source_tree.should == '<group>'
             end
-
-            it 'links the headers required for building the pod target' do
-              @installer.install!
-              headers_root = @pod_target.build_headers.root
-              public_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
-              private_header = headers_root + 'BananaLib/BananaPrivate.h'
-              framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
-              public_headers.each { |public_header| public_header.should.exist }
-              private_header.should.exist
-              framework_header.should.not.exist
-            end
-
-            it 'links the public headers meant for the user' do
-              @installer.install!
-              headers_root = config.sandbox.public_headers.root
-              public_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
-              private_header = headers_root + 'BananaLib/BananaPrivate.h'
-              framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
-              framework_subdir_header = headers_root + 'BananaLib/Bananalib/SubDir/SubBananalib.h'
-              public_headers.each { |public_header| public_header.should.exist }
-              private_header.should.not.exist
-              framework_header.should.not.exist
-              framework_subdir_header.should.not.exist
-            end
-
-            it 'links the public headers meant for the user for a vendored framework' do
-              pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec', true)
-              pod_target_two = fixture_pod_target('monkey/monkey.podspec', true)
-              project = Project.new(config.sandbox.project_path)
-              project.add_pod_group('BananaLib', fixture('banana-lib'))
-              project.add_pod_group('monkey', fixture('monkey'))
-              installer = FileReferencesInstaller.new(config.sandbox, [pod_target_one, pod_target_two], project)
-              installer.install!
-              headers_root = config.sandbox.public_headers.root
-              banana_headers = [headers_root + 'BananaLib/Banana.h', headers_root + 'BananaLib/MoreBanana.h']
-              banana_headers.each { |banana_header| banana_header.should.not.exist }
-              monkey_header = headers_root + 'monkey/monkey.h'
-              monkey_header.should.exist # since it lives outside of the vendored framework
-              config.sandbox.public_headers.search_paths(pod_target_one.platform).should == %w(
-                ${PODS_ROOT}/Headers/Public
-                ${PODS_ROOT}/Headers/Public/monkey
-              )
-            end
-
-            it 'does not link public headers from vendored framework, when frameworks required' do
-              @pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
-              @installer.install!
-              headers_root = config.sandbox.public_headers.root
-              framework_header = headers_root + 'BananaLib/Bananalib/Bananalib.h'
-              framework_header.should.not.exist
-            end
-
-            it 'does not symlink headers that belong to test specs' do
-              coconut_spec = fixture_spec('coconut-lib/CoconutLib.podspec')
-              coconut_test_spec = coconut_spec.test_specs.first
-              coconut_pod_target = fixture_pod_target_with_specs([coconut_spec, coconut_test_spec], false)
-              public_headers_root = config.sandbox.public_headers.root
-              private_headers_root = coconut_pod_target.build_headers.root
-              project = Project.new(config.sandbox.project_path)
-              project.add_pod_group('CoconutLib', fixture('coconut-lib'))
-              installer = FileReferencesInstaller.new(config.sandbox, [coconut_pod_target], project)
-              installer.install!
-              (public_headers_root + 'CoconutLib/Coconut.h').should.exist
-              (public_headers_root + 'CoconutLib/CoconutTestHeader.h').should.not.exist
-              (private_headers_root + 'CoconutLib/Coconut.h').should.exist
-              (private_headers_root + 'CoconutLib/CoconutTestHeader.h').should.not.exist
-            end
           end
 
           #-------------------------------------------------------------------------#
@@ -224,50 +157,6 @@ module Pod
                 pod_target_1 = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [stub('Spec', :test_specification? => false, :library_specification? => true, :app_specification? => false, :spec_type => :library)], [fixture_target_definition], [])
                 installer = FileReferencesInstaller.new(config.sandbox, [pod_target_1], @project)
                 installer.send(:file_accessors).should == []
-              end
-            end
-
-            describe '#header_mappings' do
-              it 'returns the correct public header mappings' do
-                headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('Banana.h')]
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  Pathname.new('BananaLib') => [Pathname.new('Banana.h')],
-                }
-              end
-
-              it 'takes into account the header dir specified in the spec for public headers' do
-                headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('Banana.h')]
-                @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
-                }
-              end
-
-              it 'takes into account the header dir specified in the spec for private headers' do
-                headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('Banana.h')]
-                @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
-                }
-              end
-
-              it 'takes into account the header mappings dir specified in the spec' do
-                headers_sandbox = Pathname.new('BananaLib')
-                header_1 = @file_accessor.root + 'BananaLib/sub_dir/dir_1/banana_1.h'
-                header_2 = @file_accessor.root + 'BananaLib/sub_dir/dir_2/banana_2.h'
-                headers = [header_1, header_2]
-                @file_accessor.spec_consumer.stubs(:header_mappings_dir).returns('BananaLib/sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  (headers_sandbox + 'dir_1') => [header_1],
-                  (headers_sandbox + 'dir_2') => [header_2],
-                }
               end
             end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -62,6 +62,7 @@ module Pod
         @installer.stubs(:resolve_dependencies)
         @installer.stubs(:download_dependencies)
         @installer.stubs(:validate_targets)
+        @installer.stubs(:link_sandbox_files)
         @installer.stubs(:generate_pods_project)
         @installer.stubs(:integrate_user_project)
         @installer.stubs(:run_plugins_post_install_hooks)


### PR DESCRIPTION
The motivation behind this change is to update the state of the sandbox before project generation so that we can analyze and compare properties on pod targets that depend on the state of the sandbox. For example, trying to grab the `HEADER_SEARCH_PATHS` build settings before linking headers into the sandbox will not include any dependent headers.