### PR TITLE
Creates a stage sandbox and sandbox dir cleaner step.

### DIFF
--- a/lib/cocoapods/installer/sandbox_dir_cleaner.rb
+++ b/lib/cocoapods/installer/sandbox_dir_cleaner.rb
@@ -1,0 +1,89 @@
+module Pod
+  class Installer
+    # Cleans up the sandbox directory by removing stale target support files and headers.
+    #
+    class SandboxDirCleaner
+      # @return [Sandbox] The sandbox directory that will be cleaned.
+      #
+      attr_reader :sandbox
+
+      # @return [Array<PodTarget>]
+      #         The list of all pod targets that will be installed into the Sandbox.
+      #
+      attr_reader :pod_targets
+
+      # @return [Array<AggregateTarget>]
+      #         The list of all aggregate targets that will be installed into the Sandbox.
+      #
+      attr_reader :aggregate_targets
+
+      # Initialize a new instance
+      #
+      # @param [Sandbox] sandbox @see #sandbox
+      # @param [Array<PodTarget>] pod_targets @see #pod_targets
+      # @param [Array<AggregateTarget>] aggregate_targets @see #aggregate_targets
+      #
+      def initialize(sandbox, pod_targets, aggregate_targets)
+        @sandbox = sandbox
+        @pod_targets = pod_targets
+        @aggregate_targets = aggregate_targets
+      end
+
+      def clean!
+        UI.message('Cleaning up sandbox directory') do
+          # Clean up Target Support Files Directory
+          target_support_dirs_to_install = (pod_targets + aggregate_targets).map(&:support_files_dir)
+          target_support_dirs = sandbox_target_support_dirs
+
+          removed_target_support_dirs = target_support_dirs - target_support_dirs_to_install
+          removed_target_support_dirs.each { |dir| remove_dir(dir) }
+
+          # Clean up Sandbox Headers Directory
+          sandbox_private_headers_to_install = pod_targets.flat_map do |pod_target|
+            if pod_target.header_mappings_by_file_accessor.empty?
+              []
+            else
+              [pod_target.build_headers.root.join(pod_target.headers_sandbox)]
+            end
+          end
+          sandbox_public_headers_to_install = pod_targets.flat_map do |pod_target|
+            if pod_target.public_header_mappings_by_file_accessor.empty?
+              []
+            else
+              [sandbox.public_headers.root.join(pod_target.headers_sandbox)]
+            end
+          end
+
+          removed_sandbox_public_headers = sandbox_public_headers - sandbox_public_headers_to_install
+          removed_sandbox_public_headers.each { |path| remove_dir(path) }
+
+          removed_sandbox_private_headers = sandbox_private_headers(pod_targets) - sandbox_private_headers_to_install
+          removed_sandbox_private_headers.each { |path| remove_dir(path) }
+        end
+      end
+
+      private
+
+      def sandbox_target_support_dirs
+        child_directories_of(sandbox.target_support_files_root)
+      end
+
+      def sandbox_private_headers(pod_targets)
+        pod_targets.flat_map { |pod_target| child_directories_of(pod_target.build_headers.root) }.uniq
+      end
+
+      def sandbox_public_headers
+        child_directories_of(sandbox.public_headers.root)
+      end
+
+      def child_directories_of(dir)
+        return [] unless dir.exist?
+        dir.children.select(&:directory?)
+      end
+
+      def remove_dir(path)
+        FileUtils.rm_rf(path)
+      end
+    end
+  end
+end

--- a/lib/cocoapods/installer/sandbox_header_paths_installer.rb
+++ b/lib/cocoapods/installer/sandbox_header_paths_installer.rb
@@ -1,0 +1,45 @@
+module Pod
+  class Installer
+    # Adds all the search paths into the sandbox HeaderStore and each pod target's HeaderStore.
+    #
+    class SandboxHeaderPathsInstaller
+      # @return [Sandbox] The sandbox to use for this analysis.
+      #
+      attr_reader :sandbox
+
+      # @return [Array<PodTarget>] The list of pod targets to analyze.
+      #
+      attr_reader :pod_targets
+
+      # Initialize a new instance
+      #
+      # @param  [Sandbox] sandbox @see #sandbox
+      # @param  [Array<PodTarget>] pod_targets @see #pod_targets
+      #
+      def initialize(sandbox, pod_targets)
+        @pod_targets = pod_targets
+        @sandbox = sandbox
+      end
+
+      def install!
+        # Link all pod target header search paths into the HeaderStore.
+        pod_targets.each do |pod_target|
+          next if pod_target.build_as_framework? && pod_target.should_build?
+          install_target(pod_target)
+        end
+      end
+
+      private
+
+      def install_target(pod_target)
+        pod_target_header_mappings = pod_target.header_mappings_by_file_accessor.values
+        public_header_mappings = pod_target.public_header_mappings_by_file_accessor.values
+        added_build_headers = !pod_target_header_mappings.all?(&:empty?)
+        added_public_headers = !public_header_mappings.all?(&:empty?)
+
+        pod_target.build_headers.add_search_path(pod_target.headers_sandbox, pod_target.platform) if added_build_headers
+        sandbox.public_headers.add_search_path(pod_target.headers_sandbox, pod_target.platform) if added_public_headers
+      end
+    end
+  end
+end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -146,29 +146,19 @@ module Pod
                 # sandbox.
                 next if pod_target.build_as_framework? && pod_target.should_build?
 
-                headers_sandbox = Pathname.new(pod_target.pod_name)
-                added_build_headers = false
-                added_public_headers = false
-
-                file_accessors = pod_target.file_accessors.reject { |fa| fa.spec.non_library_specification? }
-                file_accessors.each do |file_accessor|
-                  # Private headers will always end up in Pods/Headers/Private/PodA/*.h
-                  # This will allow for `""` imports to work.
-                  header_mappings(headers_sandbox, file_accessor, file_accessor.headers).each do |namespaced_path, files|
-                    added_build_headers = true
+                pod_target_header_mappings = pod_target.header_mappings_by_file_accessor.values
+                pod_target_header_mappings.each do |header_mappings|
+                  header_mappings.each do |namespaced_path, files|
                     pod_target.build_headers.add_files(namespaced_path, files)
-                  end
-
-                  # Public headers on the other hand will be added in Pods/Headers/Public/PodA/PodA/*.h
-                  # The extra folder is intentional in order for `<>` imports to work.
-                  header_mappings(headers_sandbox, file_accessor, file_accessor.public_headers).each do |namespaced_path, files|
-                    added_public_headers = true
-                    sandbox.public_headers.add_files(namespaced_path, files)
                   end
                 end
 
-                pod_target.build_headers.add_search_path(headers_sandbox, pod_target.platform) if added_build_headers
-                sandbox.public_headers.add_search_path(headers_sandbox, pod_target.platform) if added_public_headers
+                public_header_mappings = pod_target.public_header_mappings_by_file_accessor.values
+                public_header_mappings.each do |header_mappings|
+                  header_mappings.each do |namespaced_path, files|
+                    sandbox.public_headers.add_files(namespaced_path, files)
+                  end
+                end
               end
             end
           end
@@ -292,44 +282,6 @@ module Pod
             result = Pathname.new(min[0...idx].join('/'))
             # Don't consider "/" a common path
             return result unless result.to_s == '' || result.to_s == '/'
-          end
-
-          # Computes the destination sub-directory in the sandbox
-          #
-          # @param  [Pathname] headers_sandbox
-          #         The sandbox where the header links should be stored for this
-          #         Pod.
-          #
-          # @param  [Sandbox::FileAccessor] file_accessor
-          #         The consumer file accessor for which the headers need to be
-          #         linked.
-          #
-          # @param  [Array<Pathname>] headers
-          #         The absolute paths of the headers which need to be mapped.
-          #
-          # @return [Hash{Pathname => Array<Pathname>}] A hash containing the
-          #         headers folders as the keys and the absolute paths of the
-          #         header files as the values.
-          #
-          def header_mappings(headers_sandbox, file_accessor, headers)
-            consumer = file_accessor.spec_consumer
-            header_mappings_dir = consumer.header_mappings_dir
-            dir = headers_sandbox
-            dir += consumer.header_dir if consumer.header_dir
-
-            mappings = {}
-            headers.each do |header|
-              next if header.to_s.include?('.framework/')
-
-              sub_dir = dir
-              if header_mappings_dir
-                relative_path = header.relative_path_from(file_accessor.path_list.root + header_mappings_dir)
-                sub_dir += relative_path.dirname
-              end
-              mappings[sub_dir] ||= []
-              mappings[sub_dir] << header
-            end
-            mappings
           end
 
           #-----------------------------------------------------------------------#

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -102,8 +102,6 @@ module Pod
     # be regenerated and ensuring that the directories exists.
     #
     def prepare
-      FileUtils.rm_rf(headers_root)
-
       FileUtils.mkdir_p(headers_root)
       FileUtils.mkdir_p(sources_root)
       FileUtils.mkdir_p(specifications_root)

--- a/lib/cocoapods/sandbox/headers_store.rb
+++ b/lib/cocoapods/sandbox/headers_store.rb
@@ -66,13 +66,24 @@ module Pod
         end.tap(&:uniq!).freeze
       end
 
-      # Removes the directory as it is regenerated from scratch during each
-      # installation.
+      # Removes the entire root directory.
       #
       # @return [void]
       #
       def implode!
         root.rmtree if root.exist?
+      end
+
+      # Removes the directory at the given path relative to the root.
+      #
+      # @param [Pathname] path
+      #        The path used to join with #root and remove.
+      #
+      # @return [void]
+      #
+      def implode_path!(path)
+        path = root.join(path)
+        path.rmtree if path.exist?
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/unit/installer/sandbox_dir_cleaner_spec.rb
+++ b/spec/unit/installer/sandbox_dir_cleaner_spec.rb
@@ -1,0 +1,46 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  describe Installer::SandboxDirCleaner do
+    before do
+      @pod_target = fixture_pod_target('banana-lib/BananaLib.podspec')
+      @aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios,
+                                              fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
+                                              nil, {})
+      @cleaner = Installer::SandboxDirCleaner.new(config.sandbox, [@pod_target], [@aggregate_target])
+      @project = Project.new(config.sandbox.project_path)
+      @sandbox = config.sandbox
+      FileUtils.mkdir_p(@sandbox.target_support_files_dir(@pod_target.name))
+      FileUtils.mkdir_p(@sandbox.target_support_files_dir(@aggregate_target.name))
+    end
+
+    it 'Cleans up stale target support directories' do
+      unknown_target_path = @sandbox.target_support_files_dir('Pods-Unknown')
+      FileUtils.mkdir_p(unknown_target_path)
+
+      @cleaner.expects(:remove_dir).with(unknown_target_path)
+      @cleaner.clean!
+    end
+
+    it 'does not remove pod or aggregate target support directories' do
+      @cleaner.expects(:remove_dir).never
+      @cleaner.clean!
+    end
+
+    it 'cleans up stale headers and keeps pod target headers' do
+      random_pod_private_headers = @pod_target.build_headers.root.join('RandomPod')
+      random_pod_public_headers = @sandbox.public_headers.root.join('PublicPod')
+      banana_lib_public_headers = @sandbox.public_headers.root.join('BananaLib')
+      banana_lib_private_headers = @pod_target.build_headers.root.join('BananaLib')
+      FileUtils.mkdir_p(random_pod_private_headers)
+      FileUtils.mkdir_p(random_pod_public_headers)
+      FileUtils.mkdir_p(banana_lib_public_headers)
+      FileUtils.mkdir_p(banana_lib_private_headers)
+      @cleaner.expects(:remove_dir).with(random_pod_private_headers)
+      @cleaner.expects(:remove_dir).with(random_pod_public_headers)
+      @cleaner.clean!
+      banana_lib_public_headers.should.exist?
+      banana_lib_private_headers.should.exist?
+    end
+  end
+end

--- a/spec/unit/installer/sandbox_header_paths_installer_spec.rb
+++ b/spec/unit/installer/sandbox_header_paths_installer_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  class Installer
+    describe SandboxHeaderPathsInstaller do
+      describe 'In general' do
+        it 'add the public headers meant for the user to the header search paths' do
+          pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec', true)
+          pod_target_two = fixture_pod_target('monkey/monkey.podspec', true)
+          installer = SandboxHeaderPathsInstaller.new(config.sandbox, [pod_target_one, pod_target_two])
+          installer.install!
+          config.sandbox.public_headers.search_paths(pod_target_one.platform).should == %w(
+            ${PODS_ROOT}/Headers/Public
+            ${PODS_ROOT}/Headers/Public/monkey
+          )
+        end
+
+        it 'includes headers in the search paths for libraries' do
+          pod_target_one = fixture_pod_target('banana-lib/BananaLib.podspec', false)
+          pod_target_two = fixture_pod_target('monkey/monkey.podspec', false)
+          installer = SandboxHeaderPathsInstaller.new(config.sandbox, [pod_target_one, pod_target_two])
+          installer.install!
+          config.sandbox.public_headers.search_paths(pod_target_one.platform).should == %w(
+            ${PODS_ROOT}/Headers/Public
+            ${PODS_ROOT}/Headers/Public/BananaLib
+            ${PODS_ROOT}/Headers/Public/monkey
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -107,10 +107,6 @@ module Pod
               banana_headers.each { |banana_header| banana_header.should.not.exist }
               monkey_header = headers_root + 'monkey/monkey.h'
               monkey_header.should.exist # since it lives outside of the vendored framework
-              config.sandbox.public_headers.search_paths(pod_target_one.platform).should == %w(
-                ${PODS_ROOT}/Headers/Public
-                ${PODS_ROOT}/Headers/Public/monkey
-              )
             end
 
             it 'does not link public headers from vendored framework, when frameworks required' do
@@ -224,50 +220,6 @@ module Pod
                 pod_target_1 = PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [stub('Spec', :test_specification? => false, :library_specification? => true, :app_specification? => false, :spec_type => :library)], [fixture_target_definition], [])
                 installer = FileReferencesInstaller.new(config.sandbox, [pod_target_1], @project)
                 installer.send(:file_accessors).should == []
-              end
-            end
-
-            describe '#header_mappings' do
-              it 'returns the correct public header mappings' do
-                headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('Banana.h')]
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  Pathname.new('BananaLib') => [Pathname.new('Banana.h')],
-                }
-              end
-
-              it 'takes into account the header dir specified in the spec for public headers' do
-                headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('Banana.h')]
-                @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
-                }
-              end
-
-              it 'takes into account the header dir specified in the spec for private headers' do
-                headers_sandbox = Pathname.new('BananaLib')
-                headers = [Pathname.new('Banana.h')]
-                @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
-                }
-              end
-
-              it 'takes into account the header mappings dir specified in the spec' do
-                headers_sandbox = Pathname.new('BananaLib')
-                header_1 = @file_accessor.root + 'BananaLib/sub_dir/dir_1/banana_1.h'
-                header_2 = @file_accessor.root + 'BananaLib/sub_dir/dir_2/banana_2.h'
-                headers = [header_1, header_2]
-                @file_accessor.spec_consumer.stubs(:header_mappings_dir).returns('BananaLib/sub_dir')
-                mappings = @installer.send(:header_mappings, headers_sandbox, @file_accessor, headers)
-                mappings.should == {
-                  (headers_sandbox + 'dir_1') => [header_1],
-                  (headers_sandbox + 'dir_2') => [header_2],
-                }
               end
             end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -62,6 +62,8 @@ module Pod
         @installer.stubs(:resolve_dependencies)
         @installer.stubs(:download_dependencies)
         @installer.stubs(:validate_targets)
+        @installer.stubs(:stage_sandbox)
+        @installer.stubs(:clean_sandbox)
         @installer.stubs(:generate_pods_project)
         @installer.stubs(:integrate_user_project)
         @installer.stubs(:run_plugins_post_install_hooks)
@@ -378,72 +380,18 @@ module Pod
 
         it 'cleans the header stores' do
           FileUtils.mkdir_p(config.sandbox.target_support_files_root)
-          config.sandbox.public_headers.expects(:implode!)
           @installer.pod_targets.each do |pods_target|
-            pods_target.build_headers.expects(:implode!)
+            pods_target.build_headers.expects(:implode_path!)
+            config.sandbox.public_headers.expects(:implode_path!).with(pods_target.headers_sandbox)
           end
-          @installer.send(:clean_sandbox)
+          @installer.send(:clean_sandbox, @installer.pod_targets)
         end
 
         it 'deletes the sources of the removed Pods' do
           FileUtils.mkdir_p(config.sandbox.target_support_files_root)
           @analysis_result.sandbox_state.add_name('Deleted-Pod', :deleted)
           config.sandbox.expects(:clean_pod).with('Deleted-Pod')
-          @installer.send(:clean_sandbox)
-        end
-
-        it 'deletes the target support file dirs of the removed pod targets' do
-          FileUtils.mkdir_p(config.sandbox.target_support_files_root)
-          FileUtils.mkdir_p(@installer.pod_targets.first.support_files_dir)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should == [
-            'Spec',
-          ]
-          @installer.stubs(:pod_targets).returns([])
-          @installer.send(:clean_sandbox)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should.be.empty
-        end
-
-        it 'does not delete the target support file dirs for non removed pod targets' do
-          FileUtils.mkdir_p(config.sandbox.target_support_files_root)
-          FileUtils.mkdir_p(@installer.pod_targets.first.support_files_dir)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should == [
-            'Spec',
-          ]
-          @installer.send(:clean_sandbox)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should == [
-            'Spec',
-          ]
-        end
-
-        it 'deletes the target support file dirs of the removed aggregate targets' do
-          aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios,
-                                                 fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
-                                                 nil, {})
-          @installer.stubs(:aggregate_targets).returns([aggregate_target])
-          FileUtils.mkdir_p(config.sandbox.target_support_files_root)
-          FileUtils.mkdir_p(@installer.aggregate_targets.first.support_files_dir)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should == [
-            'Pods-MyApp',
-          ]
-          @installer.stubs(:aggregate_targets).returns([])
-          @installer.send(:clean_sandbox)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should.be.empty
-        end
-
-        it 'does not delete the target support file dirs for non removed aggregate targets' do
-          aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios,
-                                                 fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
-                                                 nil, {})
-          @installer.stubs(:aggregate_targets).returns([aggregate_target])
-          FileUtils.mkdir_p(config.sandbox.target_support_files_root)
-          FileUtils.mkdir_p(@installer.aggregate_targets.first.support_files_dir)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should == [
-            'Pods-MyApp',
-          ]
-          @installer.send(:clean_sandbox)
-          config.sandbox.target_support_files_root.children.map(&:basename).map(&:to_s).should == [
-            'Pods-MyApp',
-          ]
+          @installer.send(:clean_sandbox, @installer.pod_targets)
         end
       end
     end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -494,6 +494,50 @@ module Pod
         end
       end
 
+      describe '#header_mappings' do
+        before do
+          @file_accessor = @pod_target.file_accessors.first
+        end
+
+        it 'returns the correct public header mappings' do
+          headers = [Pathname.new('Banana.h')]
+          mappings = @pod_target.send(:header_mappings, @file_accessor, headers)
+          mappings.should == {
+            Pathname.new('BananaLib') => [Pathname.new('Banana.h')],
+          }
+        end
+
+        it 'takes into account the header dir specified in the spec for public headers' do
+          headers = [Pathname.new('Banana.h')]
+          @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
+          mappings = @pod_target.send(:header_mappings, @file_accessor, headers)
+          mappings.should == {
+            Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
+          }
+        end
+
+        it 'takes into account the header dir specified in the spec for private headers' do
+          headers = [Pathname.new('Banana.h')]
+          @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
+          mappings = @pod_target.send(:header_mappings, @file_accessor, headers)
+          mappings.should == {
+            Pathname.new('BananaLib/Sub_dir') => [Pathname.new('Banana.h')],
+          }
+        end
+
+        it 'takes into account the header mappings dir specified in the spec' do
+          header_1 = @file_accessor.root + 'BananaLib/sub_dir/dir_1/banana_1.h'
+          header_2 = @file_accessor.root + 'BananaLib/sub_dir/dir_2/banana_2.h'
+          headers = [header_1, header_2]
+          @file_accessor.spec_consumer.stubs(:header_mappings_dir).returns('BananaLib/sub_dir')
+          mappings = @pod_target.send(:header_mappings, @file_accessor, headers)
+          mappings.should == {
+            (@pod_target.headers_sandbox + 'dir_1') => [header_1],
+            (@pod_target.headers_sandbox + 'dir_2') => [header_2],
+          }
+        end
+      end
+
       describe 'With frameworks' do
         before do
           @pod_target = fixture_pod_target('orange-framework/OrangeFramework.podspec', true)


### PR DESCRIPTION
Inside stage sandbox we now add all the respective header search paths to the sandbox `HeaderStore` and each pod target's `HeaderStore`. This sets up the work for incremental pod installation because we would like to analyze each pod target's build settings to determine if it has changed; however, we previously only added the header search paths during installation which is too late in the pipline.

Instead of removing the entire Headers and Target Support Files directory in the Sandbox for every installation, we now only remove the headers and target support files that are stale.

integration specs: https://github.com/CocoaPods/cocoapods-integration-specs/pull/197