### PR TITLE
Fix HTTPs -> HTTPS in warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   
 * Fix HTTPs -> HTTPS in warning message  
   [CydeWeys](https://github.com/CydeWeys)
-  [#8354](https://github.com/CocoaPods/CocoaPods/pull/8353)
+  [#8354](https://github.com/CocoaPods/CocoaPods/issues/8354)
 
 ## 1.6.0.beta.2 (2018-10-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   settings for pod targets.  
   [Samuel Giddins](https://github.com/segiddins)
   [#8314](https://github.com/CocoaPods/CocoaPods/pull/8314)
+  
+* Fix HTTPs -> HTTPS in warning message  
+  [CydeWeys](https://github.com/CydeWeys)
+  [#8354](https://github.com/CocoaPods/CocoaPods/pull/8353)
 
 ## 1.6.0.beta.2 (2018-10-17)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -467,7 +467,7 @@ module Pod
       return if spec.source.nil? || spec.source[:http].nil?
       url = URI(spec.source[:http])
       return if url.scheme == 'https' || url.scheme == 'file'
-      warning('http', "The URL (`#{url}`) doesn't use the encrypted HTTPs protocol. " \
+      warning('http', "The URL (`#{url}`) doesn't use the encrypted HTTPS protocol. " \
               'It is crucial for Pods to be transferred over a secure protocol to protect your users from man-in-the-middle attacks. '\
               'This will be an error in future releases. Please update the URL to use https.')
     end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -270,10 +270,10 @@ module Pod
             @validator.results.should.be.empty?
           end
 
-          it 'should fail validation if the source URL is not HTTPs encrypted' do
+          it 'should fail validation if the source URL is not HTTPS encrypted' do
             Specification.any_instance.stubs(:source).returns(:http => 'http://orta.io/package.zip')
             @validator.validate
-            @validator.results.map(&:to_s).first.should.match /use the encrypted HTTPs protocol./
+            @validator.results.map(&:to_s).first.should.match /use the encrypted HTTPS protocol./
           end
 
           it 'should not fail validation if the source URL is using file:///' do


### PR DESCRIPTION
The entire word is an acronym, so "HTTPS" is correct.  "HTTPs" would be plural HTTP, which isn't the intended use here.