### PR TITLE
Complementary PR to #480 in CocoaPods/Core: Fix --deployment flag incorrectly erroring on GoogleSignIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix --deployment flag incorrectly erroring on GoogleSignIn  
+  [igor-makarov](https://github.com/igor-makarov)
+  
 * Do not force 64-bit architectures on Xcode 10  
   [Eric Amorde](https://github.com/amorde)
   [#8242](https://github.com/CocoaPods/CocoaPods/issues/8242)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -357,9 +357,9 @@ module Pod
     #
     def verify_no_lockfile_changes!
       new_lockfile = generate_lockfile
-      return if new_lockfile == lockfile
 
       diff = Xcodeproj::Differ.hash_diff(lockfile.to_hash, new_lockfile.to_hash, :key_1 => 'Old Lockfile', :key_2 => 'New Lockfile')
+      return if diff.nil?
       pretty_diff = YAMLHelper.convert_hash(diff, Lockfile::HASH_KEY_ORDER, "\n\n")
       pretty_diff.gsub!(':diff:', 'diff:'.yellow)
 


### PR DESCRIPTION
This PR complements [Core#480](https://github.com/CocoaPods/Core/pull/480) and both are required to fix the issue that occurs.  
See the Core PR for more details.