### PR TITLE
Fix crash in deterministic_uuids due to incorrect refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix crash in deterministic_uuids due to incorrect refactor  
+  [igor-makarov](https://github.com/igor-makarov)
+
 * Do not force 64-bit architectures on Xcode 10  
   [Eric Amorde](https://github.com/amorde)
   [#8242](https://github.com/CocoaPods/CocoaPods/issues/8242)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
@@ -41,7 +41,7 @@ module Pod
           cleanup_projects(projects)
 
           if installation_options.deterministic_uuids?
-            UI.message('- Generating deterministic UUIDs') { Xcodeproj::Project.predictabilize_uuids(projects) }
+            UI.message('- Generating deterministic UUIDs') { projects.each(&:predictabilize_uuids) }
           end
 
           projects.each do |project|


### PR DESCRIPTION
This PR fixes a crash that occurs due to the refactor made in commit 2ac5934 which crashed when deterministic_uuids == true.