### PR TITLE
Podfile: Add a CDNSource automatically if it's not present, just like git Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Podfile: Add a CDNSource automatically if it's not present, just like git Source  
+  Convenience for CDNSource when specified as `source 'https://cdn.jsdelivr.net/cocoa/'`.  
+  If source doesn't exist, it will be created.  
+  [igor-makarov](https://github.com/igor-makarov)
+
 * Scheme configuration support.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7577](https://github.com/CocoaPods/CocoaPods/issues/7577)

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -21,8 +21,13 @@ module Pod
           previous_title_level = UI.title_level
           UI.title_level = 0
           begin
-            if name =~ /^master(-\d+)?$/
+            case
+            when name =~ /^master(-\d+)?$/
               Command::Setup.parse([]).run
+            when url =~ /\.git$/
+              Command::Repo::Add.parse([name, url]).run
+            when url =~ %r{^https:\/\/}
+              Command::Repo::AddCDN.parse([name, url]).run
             else
               Command::Repo::Add.parse([name, url]).run
             end

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -47,10 +47,24 @@ module Pod
               should == 'url'
           end
 
+          it 'runs `pod setup` when there is no matching source for master repo' do
+            Command::Setup.any_instance.stubs(:run).once
+            @sources_manager.stubs(:source_with_url).returns(nil).then.returns(MasterSource.new('master'))
+            @sources_manager.find_or_create_source_with_url('https://github.com/CocoaPods/Specs.git').name.
+              should == 'master'
+          end
+
           it 'runs `pod repo add` when there is no matching source' do
             Command::Repo::Add.any_instance.stubs(:run).once
             @sources_manager.stubs(:source_with_url).returns(nil).then.returns(Source.new('Source'))
             @sources_manager.find_or_create_source_with_url('https://github.com/artsy/Specs.git').name.
+              should == 'Source'
+          end
+
+          it 'runs `pod repo add-cdn` when there is no matching source and url is web' do
+            Command::Repo::AddCDN.any_instance.stubs(:run).once
+            @sources_manager.stubs(:source_with_url).returns(nil).then.returns(Source.new('Source'))
+            @sources_manager.find_or_create_source_with_url('https://website.com/Specs/').name.
               should == 'Source'
           end
 


### PR DESCRIPTION
Currently, if you specify in your Podfile `source 'https://github.com/artsy/Specs.git'`, it would clone the spec repo for you.  
This PR adds the same convenience for CDNSource when specified as `source 'https://cdn.jsdelivr.net/cocoa/'`.

The way the new code determines whether the URL is git or not, is by examining whether it ends with `.git`. 
I've added tests for the new case and also another for master repo add.