### PR TITLE
Set `showEnvVarsInLog` for script phases only when its disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Set `showEnvVarsInLog` for script phases only when its disabled.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8400](https://github.com/CocoaPods/CocoaPods/pull/8400)
+
 * Fix runpath_search_paths for `inherit! search_path` targets  
   [Paul Beusterien](https://github.com/paulb777)
   [#8337](https://github.com/CocoaPods/CocoaPods/issues/8337)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: ac6493bb51448059a2f13fcf7c0fa8708420c7a3
+  revision: 4ee4a1af41000cdf0765dd83b7591c95350d015a
   branch: master
   specs:
     xcodeproj (1.7.0)


### PR DESCRIPTION
It turns out that at least with Xcode 10 `showEnvVarsInLog` never gets set to '1' when it gets set. It is just deleted.

This fixes a case in which Xcode 10 re-writes certain script phases and causes a dirty `.xcodeproj`.

See more detail here https://github.com/CocoaPods/Xcodeproj/pull/652#issue-243849364 