### PR TITLE
Revert "Fix runpath_search_paths for inherit search_path targets"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [tripleCC](https://github.com/tripleCC)
   [#8404](https://github.com/CocoaPods/CocoaPods/pull/8404)
 
-* Fix runpath_search_paths for `inherit! search_path` targets  
-  [Paul Beusterien](https://github.com/paulb777)
-  [#8337](https://github.com/CocoaPods/CocoaPods/issues/8337)
-
 * Do not force 64-bit architectures on Xcode 10  
   [Eric Amorde](https://github.com/amorde)
   [#8242](https://github.com/CocoaPods/CocoaPods/issues/8242)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -311,7 +311,7 @@ module Pod
       #
       # @param [Boolean] test_bundle
       #
-      def _ld_runpath_search_paths(requires_host_target: false, test_bundle: false, inherit_search_paths: false)
+      def _ld_runpath_search_paths(requires_host_target: false, test_bundle: false)
         if target.platform.symbolic_name == :osx
           ["'@executable_path/../Frameworks'",
            test_bundle ? "'@loader_path/../Frameworks'" : "'@loader_path/Frameworks'"]
@@ -321,7 +321,6 @@ module Pod
             "'@loader_path/Frameworks'",
           ]
           paths << "'@executable_path/../../Frameworks'" if requires_host_target
-          paths.concat target.build_settings.framework_search_paths if inherit_search_paths
           paths
         end
       end
@@ -1042,15 +1041,10 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :ld_runpath_search_paths, :build_setting => true, :memoized => true, :uniqued => true do
-          inherit_search_paths = !target.search_paths_aggregate_targets.empty? &&
-                                 !target.build_settings.framework_search_paths.empty? &&
-                                 target.platform.symbolic_name != :osx
-          return unless pod_targets.any?(&:build_as_dynamic?) || any_vendored_dynamic_artifacts? || inherit_search_paths
+          return unless pod_targets.any?(&:build_as_dynamic?) || any_vendored_dynamic_artifacts?
           symbol_type = target.user_targets.map(&:symbol_type).uniq.first
           test_bundle = symbol_type == :octest_bundle || symbol_type == :unit_test_bundle || symbol_type == :ui_test_bundle
-          _ld_runpath_search_paths(:requires_host_target => target.requires_host_target?,
-                                   :test_bundle => test_bundle,
-                                   :inherit_search_paths => inherit_search_paths)
+          _ld_runpath_search_paths(:requires_host_target => target.requires_host_target?, :test_bundle => test_bundle)
         end
 
         # @return [Boolean]


### PR DESCRIPTION
This reverts commit b5ee60aa5b64d0697a481f0a4df9bc53c8e7f45f.

The fix for https://github.com/CocoaPods/CocoaPods/issues/8337 is actually not to include `inherit! :search_paths` for the UI test bundles.

UI test bundles work differently and run within the context of a _Runner.app_. Linking dependencies into the UI test bundle should be safe and not cause duplicate symbols because it does not run within the app being tested.

I tried the above into the sample app in https://github.com/CocoaPods/CocoaPods/issues/8337 and confirmed it worked. 

*Note*: _unit_ test bundles _should_ have `inherit! :search_paths` that is because they run within the app they are testing which should be integrating all frameworks and linked libraries instead.