### PR TITLE
[CherryPick] Remove unnecessary linker flags from pod targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Jeff Kelley](https://github.com/SlaunchaMan)
   [#8286](https://github.com/CocoaPods/CocoaPods/pull/8286)
 
+* Remove linker flags that linked dynamic libraries & frameworks from the build
+  settings for pod targets.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#8314](https://github.com/CocoaPods/CocoaPods/pull/8314)
+
 ## 1.6.0.beta.2 (2018-10-17)
 
 ##### Enhancements

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -482,7 +482,7 @@ module Pod
             pod_target.stubs(:build_settings => PodTargetSettings.new(pod_target))
             aggregate_target = fixture_aggregate_target([pod_target])
             @generator = AggregateTargetSettings.new(aggregate_target, 'Release')
-            @generator.other_ldflags.should == %w(-ObjC -l"StaticLibrary" -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "VendoredFramework" -framework "XCTest")
+            @generator.other_ldflags.should == %w(-ObjC -l"VendoredDyld" -l"xml2" -framework "PodTarget" -framework "VendoredFramework" -framework "XCTest")
           end
 
           it 'does propagate system frameworks or system libraries from a non test specification to an aggregate target that uses static libraries' do

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -78,20 +78,20 @@ module Pod
             @xcconfig.to_hash['OTHER_LDFLAGS'].should.include('-no_compact_unwind')
           end
 
-          it 'includes the libraries for the specifications' do
-            @xcconfig.to_hash['OTHER_LDFLAGS'].should.include('-l"xml2"')
+          it 'does not include the libraries for the specifications' do
+            @xcconfig.to_hash['OTHER_LDFLAGS'].should.not.include('-l"xml2"')
           end
 
-          it 'includes the frameworks of the specifications' do
-            @xcconfig.to_hash['OTHER_LDFLAGS'].should.include('-framework "QuartzCore"')
+          it 'should not include the frameworks of the specifications' do
+            @xcconfig.to_hash['OTHER_LDFLAGS'].should.not.include('-framework "QuartzCore"')
           end
 
-          it 'includes the weak-frameworks of the specifications' do
-            @xcconfig.to_hash['OTHER_LDFLAGS'].should.include('-weak_framework "iAd"')
+          it 'does not include the weak-frameworks of the specifications' do
+            @xcconfig.to_hash['OTHER_LDFLAGS'].should.not.include('-weak_framework "iAd"')
           end
 
-          it 'includes the vendored dynamic frameworks for dependency pods of the specification' do
-            @xcconfig.to_hash['OTHER_LDFLAGS'].should.include('-framework "dynamic-monkey"')
+          it 'does not include the vendored dynamic frameworks for dependency pods of the specification' do
+            @xcconfig.to_hash['OTHER_LDFLAGS'].should.not.include('-framework "dynamic-monkey"')
           end
 
           it 'does not include vendored static frameworks for dependency pods of the specification' do
@@ -221,7 +221,7 @@ module Pod
             @generator.spec_consumers.each { |sc| sc.stubs(:frameworks => []) }
             @generator.stubs(:dependent_targets => [pod_target])
             @generator.other_ldflags.should.
-              be == %w(-l"Bananalib" -l"VendoredDyld" -l"xml2" -framework "Bananalib" -framework "VendoredFramework" -framework "XCTest" -weak_framework "iAd")
+              be == %w(-l"Bananalib" -framework "Bananalib")
           end
         end
 


### PR DESCRIPTION
Merge pull request #8314 from CocoaPods/segiddins/remove-linker-flas-from-pod-targets

This cherry-picks https://github.com/CocoaPods/CocoaPods/pull/8314 into `1-6-stable` branch to release 1.6.0 for CocoaPods.

Will need one more after which is https://github.com/CocoaPods/CocoaPods/pull/8334