### PR TITLE
Do not generate default `Info.plist` file for test targets if one is already specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not generate default `Info.plist` file for test targets if one is already specified.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8432](https://github.com/CocoaPods/CocoaPods/pull/8432)
+
 * Set `showEnvVarsInLog` for script phases only when its disabled.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8400](https://github.com/CocoaPods/CocoaPods/pull/8400)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -138,7 +138,7 @@ module Pod
           # @return [void]
           #
           def create_info_plist_file(path, native_target, version, platform, bundle_package_type = :fmwk)
-            create_info_plist_file_with_sandbox(@sandbox, path, native_target, version, platform, bundle_package_type)
+            create_info_plist_file_with_sandbox(sandbox, path, native_target, version, platform, bundle_package_type)
             add_file_to_support_group(path)
           end
 


### PR DESCRIPTION
Given:
```
test_spec.pod_target_xcconfig = { 'INFOPLIST_FILE' => '"$(PODS_TARGET_SRCROOT)/MyInfo.plist"' }
```

CocoaPods will stomp over this setting. This takes care of this case.
