### PR TITLE
Set the path of development pod groups to the top-most shared directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Set the path of development pod groups to the top-most shared directory  
+  [Eric Amorde](https://github.com/amorde)
+  [#8445](https://github.com/CocoaPods/CocoaPods/pull/8445)
+
 * Incremental Pod Installation
   Enables only regenerating projects for pod targets that have changed since the previous installation. 
   This feature is gated by the `incremental_installation` option.  

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -416,6 +416,7 @@ module Pod
       # Add subgroups for directories, but treat .lproj as a file
       if reflect_file_system_structure
         path = relative_base
+        group.set_path(path) unless group.path == path
         relative_dir.each_filename do |name|
           break if name.to_s.downcase.include? '.lproj'
           next if name == '.'

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -204,7 +204,7 @@ module Pod
           Pathname.any_instance.stubs(:realpath).returns(@nested_file)
           ref = @project.add_file_reference(@nested_file, @group, true, base_path)
           ref.hierarchy_path.should == '/Pods/BananaLib/SubDir/nested_file.m'
-          ref.parent.path.should == 'Dir/SubDir'
+          ref.parent.path.should == 'SubDir'
         end
 
         it "it doesn't duplicate file references for a single path" do
@@ -356,6 +356,17 @@ module Pod
           should.raise ArgumentError do
             @project.add_file_reference('relative/path/to/file.m', @group, false)
           end.message.should.match /Paths must be absolute/
+        end
+
+        describe 'when `base_path` is provided' do
+          it 'sets the main group path to the relative base path' do
+            pod_dir = config.sandbox.pod_dir('BananaLib')
+            base_path = pod_dir + 'Dir'
+            base_path.stubs(:realdirpath).returns(base_path)
+            group_1 = @project.group_for_path_in_group(@nested_file, @group, true, base_path)
+            group_1.path.should == 'SubDir'
+            @group.path.should == 'BananaLib/Dir'
+          end
         end
       end
 


### PR DESCRIPTION
This fixes an issue that prevents new groups from being placed in the correct directory if all source files are in a nested folder.

For example, if all source code is in `MyLib/Source` directory, then new files or folders should be added within the `Source` folder instead of the `MyLib` folder. For development pods which do not have a common nested directory, the behavior will remain the same.