### PR TITLE
Ensure sources specified with the `:source` option are always updated if `--repo-update` is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Always update sources specified with the `:source` option when `--repo-update` is specified  
+  [Eric Amorde](https://github.com/amorde)
+  [#8421](https://github.com/CocoaPods/CocoaPods/issues/8421) 
+
 * Set `showEnvVarsInLog` for script phases only when its disabled.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8400](https://github.com/CocoaPods/CocoaPods/pull/8400)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -164,7 +164,7 @@ module Pod
           if all_dependencies_have_sources
             sources = dependency_sources
           elsif has_dependencies? && sources.empty? && plugin_sources.empty?
-            sources = ['https://github.com/CocoaPods/Specs.git']
+            sources = ['https://github.com/CocoaPods/Specs.git'] + dependency_sources
           else
             sources += dependency_sources
           end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -114,15 +114,11 @@ module Pod
           pod 'BananaLib', '1.0', :source => repo_url
           pod 'JSONKit', :source => repo_url
         end
-        config.verbose = true
 
         # Note that we are explicitly ignoring 'repo_1' since it isn't used.
-        source = mock
-        source.stubs(:name).returns('repo_2')
-        source.stubs(:repo).returns('/repo/cache/path')
+        source = mock('source', :name => 'repo_2', :git? => true)
         config.sources_manager.expects(:find_or_create_source_with_url).with(repo_url).returns(source)
-        source.stubs(:git?).returns(true)
-        config.sources_manager.expects(:update).once.with(source.name, true)
+        config.sources_manager.expects(:update).once.with('repo_2', true)
 
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)
         analyzer.update_repositories
@@ -134,15 +130,11 @@ module Pod
           pod 'BananaLib', '1.0'
           pod 'JSONKit', :source => repo_url
         end
-        config.verbose = true
 
-        source = mock
-        source.stubs(:name).returns('repo_2')
-        source.stubs(:repo).returns('/repo/cache/path')
+        source = mock('source', :name => 'mock_repo', :git? => true)
         config.sources_manager.expects(:find_or_create_source_with_url).with(repo_url).returns(source)
         config.sources_manager.expects(:find_or_create_source_with_url).with('https://github.com/CocoaPods/Specs.git').returns(config.sources_manager.master.first)
-        source.stubs(:git?).returns(true)
-        config.sources_manager.expects(:update).once.with(source.name, true)
+        config.sources_manager.expects(:update).once.with('mock_repo', true)
         config.sources_manager.expects(:update).once.with('master', true)
 
         analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile, nil)


### PR DESCRIPTION
Closes #8421