### PR TITLE
Fix default framework type to be dynamic

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -480,7 +480,7 @@ module Pod
                                                                                        resolver_specs_by_target,
                                                                                        build_configurations)
 
-        build_type = target_definition.uses_frameworks? ? Target::BuildType.static_framework : Target::BuildType.static_library
+        build_type = target_definition.uses_frameworks? ? Target::BuildType.dynamic_framework : Target::BuildType.static_library
         AggregateTarget.new(sandbox, target_definition.uses_frameworks?, user_build_configurations, archs, platform,
                             target_definition, client_root, user_project, user_target_uuids,
                             pod_targets_for_build_configuration, :build_type => build_type)


### PR DESCRIPTION
This was a regression here 0b0e8dadd2dae796667e7969c95287efb02ca39f and specifically here https://github.com/CocoaPods/CocoaPods/pull/8232/files#diff-f5c3fee776e864ada6541431a1532b00R477

I do not think we should change the linking style by default to static.

Only affects master.

edit: I was wrong it is not a regression per se because we are still using `host_requires_frameworks?` everywhere else, which we should delete.