### PR TITLE
Update project cache analyzer.

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -279,9 +279,10 @@ module Pod
 
       create_and_save_projects(pod_targets_to_generate, aggregate_targets_to_generate,
                                cache_analysis_result.build_configurations, cache_analysis_result.project_object_version)
+      SandboxDirCleaner.new(sandbox, pod_targets, aggregate_targets).clean!
+
       update_project_cache(cache_analysis_result, target_installation_results)
       write_lockfiles
-      SandboxDirCleaner.new(sandbox, pod_targets, aggregate_targets).clean!
     end
 
     def create_and_save_projects(pod_targets_to_generate, aggregate_targets_to_generate, build_configurations, project_object_version)

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -150,7 +150,7 @@ module Pod
       root.join('.project_cache', 'version')
     end
 
-    # @param [PodTarget] pod_target_name
+    # @param [String] pod_target_name
     # Name of the pod target used to generate the path of its Xcode project.
     #
     # @return [Pathname] the path of the project for a pod target.


### PR DESCRIPTION
In addition to checking each target's cache key to determine if it's dirty, we should also check the state of its sandbox to protect against a possible case where the user modifies the sandbox and moves or deletes directories.

This change also moves `SandboxDirCleaner` before updating the project cache and Podfile.lock.