### PR TITLE
[Generator] Add annotations of unused test host delegate method arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#8451](https://github.com/CocoaPods/CocoaPods/issues/8451)
 
+* Fixed test host delegate methods to not warn about unused arguments.
+  [Jacek Suliga](https://github.com/jmkk)
 
 ## 1.6.0 (2019-02-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Samuel Giddins](https://github.com/segiddins)
   [#8451](https://github.com/CocoaPods/CocoaPods/issues/8451)
 
-* Fixed test host delegate methods to not warn about unused arguments.
+* Fixed test host delegate methods to not warn about unused arguments.  
   [Jacek Suliga](https://github.com/jmkk)
 
 ## 1.6.0 (2019-02-07)

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -260,7 +260,7 @@ module Pod
 
 @implementation CPTestAppHostAppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (BOOL)application:(UIApplication *)__unused application didFinishLaunchingWithOptions:(NSDictionary *)__unused launchOptions
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [UIViewController new];


### PR DESCRIPTION
This fixes build warnings for projects that use strict Clang build settings.

Integration spec change that goes with it: https://github.com/CocoaPods/cocoapods-integration-specs/pull/214