### PR TITLE
Fix incorrect path for Resources group in development pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* Set the path of development pod groups to the top-most shared directory  
+* Set the path of development pod groups to root directory of the Pod 
   [Eric Amorde](https://github.com/amorde)
   [#8445](https://github.com/CocoaPods/CocoaPods/pull/8445)
+  [#8503](https://github.com/CocoaPods/CocoaPods/pull/8503)
 
 * Incremental Pod Installation
   Enables only regenerating projects for pod targets that have changed since the previous installation. 

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -416,7 +416,6 @@ module Pod
       # Add subgroups for directories, but treat .lproj as a file
       if reflect_file_system_structure
         path = relative_base
-        group.set_path(path) unless group.path == path
         relative_dir.each_filename do |name|
           break if name.to_s.downcase.include? '.lproj'
           next if name == '.'

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -280,6 +280,21 @@ module Pod
           end
 
           #-------------------------------------------------------------------------#
+
+          describe 'Installation With Development Pods' do
+            before do
+              @project = Project.new(config.sandbox.project_path)
+              @project.add_pod_group('BananaLib', fixture('banana-lib'), true)
+            end
+
+            it 'sets the path of the Pod group to the installation root' do
+              @installer.install!
+              group = @project.group_for_spec('BananaLib')
+              group.path.should == fixture('banana-lib').relative_path_from(config.sandbox.root).to_s
+            end
+          end
+
+          #-------------------------------------------------------------------------#
         end
       end
     end

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -290,7 +290,7 @@ module Pod
             it 'sets the path of the Pod group to the installation root' do
               @installer.install!
               group = @project.group_for_spec('BananaLib')
-              group.path.should == fixture('banana-lib').relative_path_from(config.sandbox.root).to_s
+              group.path.should == '../../spec/fixtures/banana-lib'
             end
           end
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -204,7 +204,7 @@ module Pod
           Pathname.any_instance.stubs(:realpath).returns(@nested_file)
           ref = @project.add_file_reference(@nested_file, @group, true, base_path)
           ref.hierarchy_path.should == '/Pods/BananaLib/SubDir/nested_file.m'
-          ref.parent.path.should == 'SubDir'
+          ref.parent.path.should == 'Dir/SubDir'
         end
 
         it "it doesn't duplicate file references for a single path" do
@@ -356,17 +356,6 @@ module Pod
           should.raise ArgumentError do
             @project.add_file_reference('relative/path/to/file.m', @group, false)
           end.message.should.match /Paths must be absolute/
-        end
-
-        describe 'when `base_path` is provided' do
-          it 'sets the main group path to the relative base path' do
-            pod_dir = config.sandbox.pod_dir('BananaLib')
-            base_path = pod_dir + 'Dir'
-            base_path.stubs(:realdirpath).returns(base_path)
-            group_1 = @project.group_for_path_in_group(@nested_file, @group, true, base_path)
-            group_1.path.should == 'SubDir'
-            @group.path.should == 'BananaLib/Dir'
-          end
         end
       end
 


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/8496

This PR changes the behavior to set the path of the Pod group to the Pod root, rather than the most common path. This removes a lot of ambiguity between groups that CocoaPods creates and groups created by the existence of a directory.

The downside to removing the common path handling is that folders such as `Source` or `Classes` will show up in Xcode. This seems reasonable to me because it reflects the actual structure on disk.

