### PR TITLE
Dedup pod targets to be generated from the cache analyzer.

### DIFF
--- a/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
@@ -87,7 +87,7 @@ module Pod
           dirty_targets = compute_dirty_targets(pod_targets + aggregate_targets)
           dirty_pod_targets, dirty_aggregate_targets = dirty_targets.partition { |target| target.is_a?(PodTarget) }
 
-          pod_targets_to_generate = changed_pod_targets + added_pod_targets + dirty_pod_targets
+          pod_targets_to_generate = (changed_pod_targets + added_pod_targets + dirty_pod_targets).uniq
 
           # We either return the full list of aggregate targets or none since the aggregate targets go into the Pods.xcodeproj
           # and so we need to regenerate all aggregate targets when regenerating Pods.xcodeproj.

--- a/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
+++ b/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
@@ -146,6 +146,21 @@ module Pod
             result.pod_targets_to_generate.should.equal([@orange_lib])
             result.aggregate_targets_to_generate.should.be.nil
           end
+
+          it 'returns the correct set of pod targets when adding a new one' do
+            cache_pod_targets = [@banana_lib, @orange_lib]
+            FileUtils.rm_rf @sandbox.pod_target_project_path(@monkey_lib.pod_name)
+
+            cache_key_by_pod_target_labels = Hash[cache_pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
+            cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
+
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, @pod_targets, [@main_aggregate_target])
+            result = analyzer.analyze
+            result.pod_targets_to_generate.should.equal([@monkey_lib])
+            result.aggregate_targets_to_generate.should.equal(nil)
+          end
         end
       end
     end


### PR DESCRIPTION
Pod targets that are marked as dirty by different steps of the analyzer are concatenated into the full list of pod targets to generate without being deduped.
An easy example of this is simply adding a target. I've added a spec to cover this case.