### PR TITLE
Add annotations of unused test host delegate method arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   a git unknown option error.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Fixed test host delegate methods to not warn about unused arguments.  
+  [Jacek Suliga](https://github.com/jmkk)
+  [#8521](https://github.com/CocoaPods/CocoaPods/pull/8521)
+
 
 ## 1.6.0 (2019-02-07)
 

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -260,7 +260,7 @@ module Pod
 
 @implementation CPTestAppHostAppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (BOOL)application:(UIApplication *)__unused application didFinishLaunchingWithOptions:(NSDictionary *)__unused launchOptions
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [UIViewController new];


### PR DESCRIPTION
Supersedes https://github.com/CocoaPods/CocoaPods/pull/8499