### PR TITLE
Installation option to skip generating pod schemes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Installation option to skip generating pod schemes.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8528](https://github.com/CocoaPods/CocoaPods/pull/8528)
+
 * Set the path of development pod groups to root directory of the Pod 
   [Eric Amorde](https://github.com/amorde)
   [#8445](https://github.com/CocoaPods/CocoaPods/pull/8445)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -312,13 +312,15 @@ module Pod
                                                        target_installation_results.pod_target_installation_results, installation_options)
         projects_writer.write!
 
-        pods_project_pod_targets = pod_targets_to_generate - projects_by_pod_targets.values.flatten
-        all_projects_by_pod_targets = {}
-        pods_project_by_targets = { pods_project => pods_project_pod_targets } if pods_project
-        all_projects_by_pod_targets.merge!(pods_project_by_targets) if pods_project_by_targets
-        all_projects_by_pod_targets.merge!(projects_by_pod_targets) if projects_by_pod_targets
-        all_projects_by_pod_targets.each do |project, pod_targets|
-          generator.share_development_pod_schemes(project, development_pod_targets(pod_targets))
+        if installation_options.generate_pod_schemes?
+          pods_project_pod_targets = pod_targets_to_generate - projects_by_pod_targets.values.flatten
+          all_projects_by_pod_targets = {}
+          pods_project_by_targets = { pods_project => pods_project_pod_targets } if pods_project
+          all_projects_by_pod_targets.merge!(pods_project_by_targets) if pods_project_by_targets
+          all_projects_by_pod_targets.merge!(projects_by_pod_targets) if projects_by_pod_targets
+          all_projects_by_pod_targets.each do |project, pod_targets|
+            generator.share_development_pod_schemes(project, development_pod_targets(pod_targets))
+          end
         end
       end
     end

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -153,6 +153,10 @@ module Pod
       #
       option :warn_for_multiple_pod_sources, true
 
+      # Whether to generate schemes for the targets for each Pod that was installed.
+      #
+      option :generate_pod_schemes, true
+
       # Whether to share Xcode schemes for development pods.
       #
       # Schemes for development pods are created automatically but are not shared by default.

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
@@ -44,13 +44,15 @@ module Pod
               results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
                 [result.native_target, result]
               end]
-              project.recreate_user_schemes(false) do |scheme, target|
-                next unless target.respond_to?(:symbol_type)
-                next unless library_product_types.include? target.symbol_type
-                installation_result = results_by_native_target[target]
-                next unless installation_result
-                installation_result.test_native_targets.each do |test_native_target|
-                  scheme.add_test_target(test_native_target)
+              if installation_options.generate_pod_schemes?
+                project.recreate_user_schemes(false) do |scheme, target|
+                  next unless target.respond_to?(:symbol_type)
+                  next unless library_product_types.include? target.symbol_type
+                  installation_result = results_by_native_target[target]
+                  next unless installation_result
+                  installation_result.test_native_targets.each do |test_native_target|
+                    scheme.add_test_target(test_native_target)
+                  end
                 end
               end
               project.save

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -65,6 +65,7 @@ module Pod
           'integrate_targets' => true,
           'lock_pod_sources' => true,
           'warn_for_multiple_pod_sources' => true,
+          'generate_pod_schemes' => true,
           'share_schemes_for_development_pods' => false,
           'disable_input_output_paths' => false,
           'preserve_pod_file_structure' => false,


### PR DESCRIPTION
This is useful for very large projects where the number of schemes actually slows down Xcode. This does not change the default integration.

# Tests to be added.