### PR TITLE
Resolved an issue that could cause spec repo updates to fail on CI servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ spec/fixtures/chameleon
 spec/fixtures/integration/Headers/
 spec/fixtures/snake
 spec/fixtures/vcr
+spec/fixtures/spec-repos/Spec_Lock
 tmp
 
 # Examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Copy `bcsymbolmap` files into correct destination to avoid invalid app archives  
   [florianbuerger](https://github.com/florianbuerger)
   [#8558](https://github.com/CocoaPods/CocoaPods/pull/8558)
+* Resolved an issue that could cause spec repo updates to fail on CI servers.  
+  [rpecka](https://github.com/rpecka)
+  [#7317](https://github.com/CocoaPods/CocoaPods/issues/7317)
 
 * Fix: unset GIT_DIR and GIT_WORK_TREE for git operations  
   [tripleCC](https://github.com/tripleCC)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Sebastian Shanus](https://github.com/sebastianv1)
   [#8636](https://github.com/CocoaPods/CocoaPods/pull/8636)
 
+* Resolved an issue that could cause spec repo updates to fail on CI servers.  
+  [rpecka](https://github.com/rpecka)
+  [#7317](https://github.com/CocoaPods/CocoaPods/issues/7317)
+
 
 ## 1.7.0.beta.2 (2019-03-08)
 
@@ -72,9 +76,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Do not link specs into user targets that are only used by app specs.  
   [Samuel Giddins](https://github.com/segiddins)
 
-* Resolved an issue that could cause spec repo updates to fail on CI servers.  
-  [rpecka](https://github.com/rpecka)
-  [#7317](https://github.com/CocoaPods/CocoaPods/issues/7317)
 
 ## 1.7.0.beta.1 (2019-02-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Copy `bcsymbolmap` files into correct destination to avoid invalid app archives  
   [florianbuerger](https://github.com/florianbuerger)
   [#8558](https://github.com/CocoaPods/CocoaPods/pull/8558)
-* Resolved an issue that could cause spec repo updates to fail on CI servers.  
-  [rpecka](https://github.com/rpecka)
-  [#7317](https://github.com/CocoaPods/CocoaPods/issues/7317)
 
 * Fix: unset GIT_DIR and GIT_WORK_TREE for git operations  
   [tripleCC](https://github.com/tripleCC)
@@ -75,6 +72,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Do not link specs into user targets that are only used by app specs.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Resolved an issue that could cause spec repo updates to fail on CI servers.  
+  [rpecka](https://github.com/rpecka)
+  [#7317](https://github.com/CocoaPods/CocoaPods/issues/7317)
 
 ## 1.7.0.beta.1 (2019-02-22)
 

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -88,6 +88,8 @@ module Pod
         end
 
         changed_spec_paths = {}
+        f = File.open("#{Config.instance.repos_dir}/Spec_Lock", File::CREAT)
+        f.flock(File::LOCK_EX)
         sources.each do |source|
           UI.section "Updating spec repo `#{source.name}`" do
             changed_source_paths = source.update(show_output)
@@ -95,6 +97,7 @@ module Pod
             source.verify_compatibility!
           end
         end
+        f.close
         # Perform search index update operation in background.
         update_search_index_if_needed_in_background(changed_spec_paths)
       end

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -88,6 +88,8 @@ module Pod
         end
 
         changed_spec_paths = {}
+        # Ceate the Spec_Lock file if needed and lock it so that concurrent
+        # repo updates do not cause each other to fail
         f = File.open("#{Config.instance.repos_dir}/Spec_Lock", File::CREAT)
         f.flock(File::LOCK_EX)
         sources.each do |source|

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -90,16 +90,16 @@ module Pod
         changed_spec_paths = {}
         # Ceate the Spec_Lock file if needed and lock it so that concurrent
         # repo updates do not cause each other to fail
-        f = File.open("#{Config.instance.repos_dir}/Spec_Lock", File::CREAT)
-        f.flock(File::LOCK_EX)
-        sources.each do |source|
-          UI.section "Updating spec repo `#{source.name}`" do
-            changed_source_paths = source.update(show_output)
-            changed_spec_paths[source] = changed_source_paths if changed_source_paths.count > 0
-            source.verify_compatibility!
+        File.open("#{Config.instance.repos_dir}/Spec_Lock", File::CREAT) do |f|
+          f.flock(File::LOCK_EX)
+          sources.each do |source|
+            UI.section "Updating spec repo `#{source.name}`" do
+              changed_source_paths = source.update(show_output)
+              changed_spec_paths[source] = changed_source_paths if changed_source_paths.count > 0
+              source.verify_compatibility!
+            end
           end
         end
-        f.close
         # Perform search index update operation in background.
         update_search_index_if_needed_in_background(changed_spec_paths)
       end

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -50,7 +50,7 @@ module Pod
 
     it 'repo updates do not fail when executed in parallel' do
       repo1 = repo_make('repo1')
-      repo2 = repo_clone('repo1', 'repo2')
+      repo_clone('repo1', 'repo2')
       repo_make_readme_change(repo1, 'Updated')
       Dir.chdir(repo1) { `git commit -a -m "Update"` }
       thread1 = Thread.new do

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -47,5 +47,21 @@ module Pod
       run_command('repo', 'update', 'repo2')
       (repo2 + 'README').read.should.include 'Updated'
     end
+
+    it 'repo updates do not fail when executed in parallel' do
+      repo1 = repo_make('repo1')
+      repo2 = repo_clone('repo1', 'repo2')
+      repo_make_readme_change(repo1, 'Updated')
+      Dir.chdir(repo1) { `git commit -a -m "Update"` }
+      thread1 = Thread.new do
+        lambda { command('repo', 'update', 'repo2').run }.should.not.raise
+      end
+      thread2 = Thread.new do
+        lambda { command('repo', 'update', 'repo2').run }.should.not.raise
+      end
+
+      thread1.join
+      thread2.join
+    end
   end
 end

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -52,7 +52,7 @@ module Pod
       repo1 = repo_make('repo1')
       repo_clone('repo1', 'repo2')
       repo_make_readme_change(repo1, 'Updated')
-      Dir.chdir(repo1) { `git commit -a -m "Update"` }
+      Dir.chdir(repo1) { Pod::Executable.capture_command!('git', %w(commit -a -m Update)) }
       thread1 = Thread.new do
         lambda { command('repo', 'update', 'repo2').run }.should.not.raise
       end


### PR DESCRIPTION
🌈
Resolves #7317 
There is an issue when running CI servers that build more than one instance of a project at a time where if two `pod repo update` commands are issued in quick succession, the build will fail because the updates are attempting to simultaneously modify the git repositories.

To solve this problem, I've added logic to create a `Spec_Lock` file in the spec repo directory and then lock that file until the git updates are complete. This causes successive repo commands to execute one at a time.

This is my time using ruby and contributing to CocoaPods so please let me know if there are best practices I missed or any other issues. In particular, I'm not sure that I wrote the unit test correctly however, I did test it with and without my changes and it worked properly.