### PR TITLE
Do not use spaces around variable assignment in generated embed framework script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Do not use spaces around variable assignment in generated embed framework script  
+  [florianbuerger](https://github.com/florianbuerger)
+  [#8548](https://github.com/CocoaPods/CocoaPods/pull/8548) 
 
 ## 1.7.0.beta.1 (2019-02-22)
 
@@ -75,10 +76,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [guides.cocoapods.org #142](https://github.com/CocoaPods/guides.cocoapods.org/issues/142)
 
 ##### Bug Fixes
-
-* Do not use spaces around variable assignment in generated embed framework script
-  [florianbuerger](https://github.com/florianbuerger)
-  [#8548](https://github.com/CocoaPods/CocoaPods/issues/8548)
 
 * Clean up old integrated framework references.  
   [Dimitris Koutsogiorgas](https://github.com/dnkouts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not use spaces around variable assignment in generated embed framework script
+  [florianbuerger](https://github.com/florianbuerger)
+  [#8548](https://github.com/CocoaPods/CocoaPods/issues/8548)
+
 * Clean up old integrated framework references.  
   [Dimitris Koutsogiorgas](https://github.com/dnkouts)
   [#8296](https://github.com/CocoaPods/CocoaPods/issues/8296)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -156,7 +156,7 @@ module Pod
 
           # Copies the bcsymbolmap files of a vendored framework
           install_bcsymbolmap() {
-              local bcsymbolmap_path = "$1"
+              local bcsymbolmap_path="$1"
               local destination="${TARGET_BUILD_DIR}"
               echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
               rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"


### PR DESCRIPTION
🌈 😃 

`local var = something` does not work in bash. Xcode build will fail with an error like

```
/Users/florian/Projects/Flighty_LLC/flighty-ios/Pods/Target Support Files/Pods-Flighty/Pods-Flighty-frameworks.sh: line 114: local: `=': not a valid identifier
/Users/florian/Projects/Flighty_LLC/flighty-ios/Pods/Target Support Files/Pods-Flighty/Pods-Flighty-frameworks.sh: line 114: local: `/Users/florian/Projects/Flighty_LLC/flighty-ios/Pods/Mapbox-iOS-SDK/dynamic/F8207D73-7248-3A6B-8A81-8EE831BAC4E6.bcsymbolmap': not a valid identifier
Command PhaseScriptExecution failed with a nonzero exit code
```

Only happens if the vendored binary framework includes a `.bcsymbolmap` file I think.

It has to be `local var=something`.

---

I don't know if I did the correct thing (I hope so 😃), seems the integration spec need changes as well. I did that here https://github.com/CocoaPods/cocoapods-integration-specs/pull/219 