### PR TITLE
Fix destination path for bcsymbolmap files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Copy `bcsymbolmap` files into correct destination to avoid invalid app archives    
+  [florianbuerger](https://github.com/florianbuerger)
+  [#8548](https://github.com/CocoaPods/CocoaPods/pull/8548)
+
 * Do not use spaces around variable assignment in generated embed framework script  
   [florianbuerger](https://github.com/florianbuerger)
-  [#8548](https://github.com/CocoaPods/CocoaPods/pull/8548) 
+  [#8558](https://github.com/CocoaPods/CocoaPods/pull/8558)
 
 ## 1.7.0.beta.1 (2019-02-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Copy `bcsymbolmap` files into correct destination to avoid invalid app archives    
   [florianbuerger](https://github.com/florianbuerger)
-  [#8548](https://github.com/CocoaPods/CocoaPods/pull/8548)
+  [#8558](https://github.com/CocoaPods/CocoaPods/pull/8558)
 
 * Do not use spaces around variable assignment in generated embed framework script  
   [florianbuerger](https://github.com/florianbuerger)
-  [#8558](https://github.com/CocoaPods/CocoaPods/pull/8558)
+  [#8548](https://github.com/CocoaPods/CocoaPods/pull/8548)
 
 ## 1.7.0.beta.1 (2019-02-22)
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -157,7 +157,7 @@ module Pod
           # Copies the bcsymbolmap files of a vendored framework
           install_bcsymbolmap() {
               local bcsymbolmap_path="$1"
-              local destination="${TARGET_BUILD_DIR}"
+              local destination="${BUILT_PRODUCTS_DIR}"
               echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
               rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"
           }


### PR DESCRIPTION
As discussed in https://github.com/CocoaPods/CocoaPods/issues/8552

Requires https://github.com/CocoaPods/cocoapods-integration-specs/pull/220 to be merged first.