### PR TITLE
Fix crash when exec pod update with --sources and --project-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [tripleCC](https://github.com/tripleCC)
   [#7958](https://github.com/CocoaPods/CocoaPods/issues/7958)
 
+* Fix crash when exec pod update with --sources and --project-directory  
+  [tripleCC](https://github.com/tripleCC)
+  [#8565](https://github.com/CocoaPods/CocoaPods/issues/8565)
+
 * Do not use spaces around variable assignment in generated embed framework script  
   [florianbuerger](https://github.com/florianbuerger)
   [#8548](https://github.com/CocoaPods/CocoaPods/pull/8548)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [tripleCC](https://github.com/tripleCC)
   [#7958](https://github.com/CocoaPods/CocoaPods/issues/7958)
 
-* Fix crash when exec pod update with --sources and --project-directory  
+* Fix crash when running `pod update` with `--sources` and `--project-directory`  
   [tripleCC](https://github.com/tripleCC)
   [#8565](https://github.com/CocoaPods/CocoaPods/issues/8565)
 

--- a/lib/cocoapods/command/update.rb
+++ b/lib/cocoapods/command/update.rb
@@ -29,47 +29,45 @@ module Pod
       end
 
       def initialize(argv)
-        @pods = argv.arguments! unless argv.arguments.empty?
+        @pods = argv.arguments!
 
-        source_urls = argv.option('sources', '').split(',')
-        excluded_pods = argv.option('exclude-pods', '').split(',')
+        @source_urls = argv.option('sources', '').split(',')
+        @excluded_pods = argv.option('exclude-pods', '').split(',')
         @clean_install = argv.flag?('clean-install', false)
-        unless source_urls.empty?
-          source_pods = source_urls.flat_map { |url| config.sources_manager.source_with_name_or_url(url).pods }
-          unless source_pods.empty?
-            source_pods = source_pods.select { |pod| config.lockfile.pod_names.include?(pod) }
-            if @pods
-              @pods += source_pods
-            else
-              @pods = source_pods unless source_pods.empty?
-            end
-          end
-        end
-
-        unless excluded_pods.empty?
-          @pods ||= config.lockfile.pod_names.dup
-
-          non_installed_pods = (excluded_pods - @pods)
-          unless non_installed_pods.empty?
-            pluralized_words = non_installed_pods.length > 1 ? %w(Pods are) : %w(Pod is)
-            message = "Trying to skip `#{non_installed_pods.join('`, `')}` #{pluralized_words.first} " \
-                    "which #{pluralized_words.last} not installed"
-            raise Informative, message
-          end
-
-          @pods.delete_if { |pod| excluded_pods.include?(pod) }
-        end
+        @source_pods = @source_urls.flat_map { |url| config.sources_manager.source_with_name_or_url(url).pods }
 
         super
       end
 
+      def run
+        verify_podfile_exists!
+
+        installer = installer_for_config
+        installer.repo_update = repo_update?(:default => true)
+        installer.clean_install = @clean_install
+        if @pods.any? || @excluded_pods.any? || @source_pods.any?
+          verify_lockfile_exists!
+          verify_pods_are_installed!
+          verify_excluded_pods_are_installed!
+
+          @pods += @source_pods.select { |pod| config.lockfile.pod_names.include?(pod) }
+          @pods = config.lockfile.pod_names.dup if @pods.empty?
+          @pods -= @excluded_pods
+
+          installer.update = { :pods => @pods }
+        else
+          UI.puts 'Update all pods'.yellow
+          installer.update = true
+        end
+        installer.install!
+      end
+
+      private
+
       # Check if all given pods are installed
       #
       def verify_pods_are_installed!
-        lockfile_roots = config.lockfile.pod_names.map { |p| Specification.root_name(p) }
-        missing_pods = @pods.map { |p| Specification.root_name(p) }.select do |pod|
-          !lockfile_roots.include?(pod)
-        end
+        missing_pods = lockfile_missing_pods(@pods)
 
         unless missing_pods.empty?
           message = if missing_pods.length > 1
@@ -83,21 +81,22 @@ module Pod
         end
       end
 
-      def run
-        verify_podfile_exists!
+      # Check if excluded pods are installed
+      #
+      def verify_excluded_pods_are_installed!
+        missing_pods = lockfile_missing_pods(@excluded_pods)
 
-        installer = installer_for_config
-        installer.repo_update = repo_update?(:default => true)
-        installer.clean_install = @clean_install
-        if @pods
-          verify_lockfile_exists!
-          verify_pods_are_installed!
-          installer.update = { :pods => @pods }
-        else
-          UI.puts 'Update all pods'.yellow
-          installer.update = true
+        unless missing_pods.empty?
+          pluralized_words = missing_pods.length > 1 ? %w(Pods are) : %w(Pod is)
+          message = "Trying to skip `#{missing_pods.join('`, `')}` #{pluralized_words.first} " \
+                  "which #{pluralized_words.last} not installed"
+          raise Informative, message
         end
-        installer.install!
+      end
+
+      def lockfile_missing_pods(pods)
+        lockfile_roots = config.lockfile.pod_names.map { |pod| Specification.root_name(pod) }
+        pods.map { |pod| Specification.root_name(pod) }.uniq - lockfile_roots
       end
     end
   end

--- a/spec/functional/command/update_spec.rb
+++ b/spec/functional/command/update_spec.rb
@@ -108,9 +108,21 @@ module Pod
         end
       end
 
-      it 'tells the user that no Lockfile was found in the project dir' do
-        exception = lambda { run_command('update', 'BananaLib', '--no-repo-update') }.should.raise Informative
-        exception.message.should.include "No `Podfile.lock' found in the project directory"
+      describe 'tells the user that no lockfile was found in the project dir' do
+        it 'for --no-repo-update' do
+          exception = lambda { run_command('update', 'BananaLib', '--no-repo-update') }.should.raise Informative
+          exception.message.should.include "No `Podfile.lock' found in the project directory"
+        end
+
+        it 'for --exclude-pods' do
+          exception = lambda { run_command('update', '--exclude-pods=BananaLib') }.should.raise Informative
+          exception.message.should.include "No `Podfile.lock' found in the project directory"
+        end
+
+        it 'for --sources' do
+          exception = lambda { run_command('update', '--sources=master') }.should.raise Informative
+          exception.message.should.include "No `Podfile.lock' found in the project directory"
+        end
       end
 
       describe 'tells the user that the Pods cannot be updated unless they are installed' do


### PR DESCRIPTION
fix issue #8565

project directory  option will be invalidated if we use `config.lockfile` in initialize method, because 
`config.installation_root` is set at the end of initialize method.

I think it is more properly to move the code that handles `--sources` and `--project-directory` to run method.