### PR TITLE
Fix --help option of pod lib create command has no effect

### DIFF
--- a/lib/cocoapods/command/lib/create.rb
+++ b/lib/cocoapods/command/lib/create.rb
@@ -25,12 +25,14 @@ module Pod
         def initialize(argv)
           @name = argv.shift_argument
           @template_url = argv.option('template-url', TEMPLATE_REPO)
+          @help = argv.flag?('help')
           super
           @additional_args = argv.remainder!
         end
 
         def validate!
           super
+          banner! if @help
           help! 'A name for the Pod is required.' unless @name
           help! 'The Pod name cannot contain spaces.' if @name =~ /\s/
           help! 'The Pod name cannot contain plusses.' if @name =~ /\+/


### PR DESCRIPTION
run `pod lib create --help` :

```
[!] A name for the Pod is required.

Usage:

    $ pod lib create NAME

      Creates a scaffold for the development of a new Pod named `NAME` according to
      the CocoaPods best practices. If a `TEMPLATE_URL`, pointing to a git repo
      containing a compatible template, is specified, it will be used in place of the
      default one.

Options:

    --template-url=URL   The URL of the git repo containing a compatible template
    --silent             Show nothing
    --verbose            Show more debugging information
    --no-ansi            Show output without ANSI codes
    --help               Show help banner of specified command
```
`[!] A name for the Pod is required.` should not be printed when I add `--help` option.

It is because `argv.remainder!` clear all argv entries, `validate!` can't get correct help flag

```ruby
# CLAide::Command
def validate!
  banner! if @argv.flag?('help')
  unless @argv.empty?
    argument = @argv.remainder.first
    help! ArgumentSuggester.new(argument, self.class).suggestion
  end
  help! if self.class.abstract_command?
end
```