### PR TITLE
Do not warn that `--swift-version` parameter is deprecated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not warn that `--swift-version` parameter is deprecated.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8586](https://github.com/CocoaPods/CocoaPods/pull/8586)
+
 * Include `bcsymbolmap` file output paths into script phase.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8563](https://github.com/CocoaPods/CocoaPods/pull/8563)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -506,7 +506,7 @@ module Pod
                 'The validator used ' \
                 "Swift `#{DEFAULT_SWIFT_VERSION}` by default because no Swift version was specified. " \
                 'To specify a Swift version during validation, add the `swift_versions` attribute in your podspec. ' \
-                'Note that usage of the `--swift-version` parameter or a `.swift-version` file is now deprecated.')
+                'Note that usage of a `.swift-version` file is now deprecated.')
       end
     end
 

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1076,7 +1076,7 @@ module Pod
         result.message.should == 'The validator used ' \
         'Swift `4.0` by default because no Swift version was specified. ' \
         'To specify a Swift version during validation, add the `swift_versions` attribute in your podspec. ' \
-        'Note that usage of the `--swift-version` parameter or a `.swift-version` file is now deprecated.'
+        'Note that usage of a `.swift-version` file is now deprecated.'
       end
 
       it 'warns when a dot swift version file is used instead of the swift_versions attribute' do


### PR DESCRIPTION
This was wrongly assumed it will be deprecated but with Multiple Swift Versions in 1.7.0 it is not.