### PR TITLE
[WIP] Fix post_install hooks when incremental_installation is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix post_install hooks when incremental_installation is enabled.  
+  [giginet](https://github.com/giginet)
+
 * Do not warn of `.swift-version` file being deprecated if pod does not use Swift.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8593](https://github.com/CocoaPods/CocoaPods/pull/8593)

--- a/lib/cocoapods/installer/xcode/multi_pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/multi_pods_project_generator.rb
@@ -26,6 +26,8 @@ module Pod
 
           integrate_targets(target_installation_results.pod_target_installation_results)
           wire_target_dependencies(target_installation_results)
+
+          container_project ||= Pod::Project.new(sandbox.project_path)
           PodsProjectGeneratorResult.new(container_project, projects_by_pod_targets, target_installation_results)
         end
 

--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -580,7 +580,6 @@ module Pod
             @generator.generate!
           end
 
-
           it 'will not create container project for nil parameter to aggregate targets' do
             @generator = MultiPodsProjectGenerator.new(config.sandbox, nil, [@monkey_ios_pod_target], @analysis_result.all_user_build_configurations,
                                                        @installation_options, config, '1')

--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -580,11 +580,13 @@ module Pod
             @generator.generate!
           end
 
+
           it 'will not create container project for nil parameter to aggregate targets' do
             @generator = MultiPodsProjectGenerator.new(config.sandbox, nil, [@monkey_ios_pod_target], @analysis_result.all_user_build_configurations,
                                                        @installation_options, config, '1')
             @generator.expects(:create_container_project).returns(nil)
-            @generator.generate!
+            pod_generator_result = @generator.generate!
+            pod_generator_result.project.should.be.instance_of? Pod::Project
           end
 
           describe '#write' do


### PR DESCRIPTION
# Motivation

When `incremental_installation` option is enabled, `installer#pods_project` returns `nil` in `post_install` hook.

```ruby
install! 'cocoapods',
         :generate_multiple_pod_projects => true,
         :incremental_installation => true

target 'MyApp' do
  use_frameworks!

  pod 'Result'
end

post_install do |installer|
  installer.pods_project.targets.each do |target|
    # do something
  end
end
```

Before submitting this PR, (1.7.0beta.2) this `Podfile` raises following errors.

```
[!] An error occurred while processing the post-install hook of the Podfile.

undefined method `targets' for nil:NilClass

/Users/giginet/myproject/Podfile:12:in `block (2 levels) in from_ruby'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-core-1.7.0.beta.2/lib/cocoapods-core/podfile.rb:179:in `post_install!'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:835:in `run_podfile_post_install_hook'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:823:in `block in run_podfile_post_install_hooks'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/user_interface.rb:145:in `message'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:822:in `run_podfile_post_install_hooks'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:309:in `block in create_and_save_projects'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/user_interface.rb:64:in `section'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:290:in `create_and_save_projects'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:281:in `generate_pods_project'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/installer.rb:159:in `install!'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/command/install.rb:51:in `run'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/lib/cocoapods/command.rb:52:in `run'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/cocoapods-1.7.0.beta.2/bin/pod:55:in `<top (required)>'
/Users/giginet/.rbenv/versions/2.5/bin/pod:23:in `load'
/Users/giginet/.rbenv/versions/2.5/bin/pod:23:in `<top (required)>'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/cli/exec.rb:74:in `load'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/cli/exec.rb:74:in `kernel_load'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/cli/exec.rb:28:in `run'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/cli.rb:463:in `exec'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/cli.rb:27:in `dispatch'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/cli.rb:18:in `start'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/site_ruby/2.5.0/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/Users/giginet/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
/Users/giginet/.rbenv/versions/2.5/bin/bundle:23:in `load'
/Users/giginet/.rbenv/versions/2.5/bin/bundle:23:in `<main>'
```

# Description

When`incremental_installation` is enabled, CocoaPods doesn't generate `Pods.xcodeproj` when there are nothing changes between cached project.
In this case `PodsProjectGeneratorResult#project` become `nil`.

So `installer#pods_project` also become `nil`.

When a new Pods project isn't generated, `MultiPodsProjectGenerator` just opens the existing project and return it.