### PR TITLE
[repo push] Use current repo branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Using `repo push` now pushes to the current repo branch (`HEAD`) instead of `master`  
+  [Jhonatan Avalos](https://github.com/baguio)
+  [#8630](https://github.com/CocoaPods/CocoaPods/pull/8630)  
+
 * Add support for UI test specs with `test_type` value `:ui`  
   [Yavuz Nuzumlali](https://github.com/manuyavuz)
   [#9002](https://github.com/CocoaPods/CocoaPods/pull/9002)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -231,7 +231,7 @@ module Pod
         #
         def push_repo
           UI.puts "\nPushing the `#{@repo}' repo\n".yellow
-          repo_git('push', 'origin', 'master')
+          repo_git('push', 'origin', 'HEAD')
         end
 
         #---------------------------------------------------------------------#


### PR DESCRIPTION
The current implementation of "repo push" can only push changes to a master branch. If the developer is using a private spec repository, a different branch could be needed.