### PR TITLE
Bump UUID prefix count from 4 to 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Reduce the probability of multiple project UUID collisions.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#8636](https://github.com/CocoaPods/CocoaPods/pull/8636)
 
 
 ## 1.7.0.beta.2 (2019-03-08)

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -69,7 +69,7 @@ module Pod
     #
     def generate_available_uuid_list(count = 100)
       start = @generated_uuids.size
-      uniques = Array.new(count) { |i| format('%.4s%07X0', @uuid_prefix, start + i) }
+      uniques = Array.new(count) { |i| format('%.6s%07X0', @uuid_prefix, start + i) }
       @generated_uuids += uniques
       @available_uuids += uniques
     end


### PR DESCRIPTION
Have noticed some collisions happening using 4. For some numbers:
Given 400 projects, there was a ~27% chance that every project's first 4 digits was unique.
Given 400 projects, there is a ~99.5% chance that every project's first 6 digits is unique.
Given 1000 projects, there is a ~97% chance that every project's first 6 digits is unique.