### PR TITLE
Fix for AppIcon on Lib Lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Sebastian Shanus](https://github.com/sebastianv1)
   [#8636](https://github.com/CocoaPods/CocoaPods/pull/8636)
 
+* Fix: AppIcon not found when executing `pod lib lint`
+  [Itay Brenner](https://github.com/itaybre)
+  [#8648](https://github.com/CocoaPods/CocoaPods/issues/8648)
+
 
 ## 1.7.0.beta.2 (2019-03-08)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -555,11 +555,10 @@ module Pod
       app_project = Xcodeproj::Project.new(validation_dir + 'App.xcodeproj')
       app_target = Pod::Generator::AppTargetHelper.add_app_target(app_project, consumer.platform_name, deployment_target)
       Pod::Generator::AppTargetHelper.add_swift_version(app_target, derived_swift_version)
-      if consumer.platform_name == :ios ||  consumer.platform_name == :tvos
-        # Lint will fail if a AppIcon is set but no image is found with such name
-        app_target.build_configurations.each do |config|
-          config.build_settings.delete('ASSETCATALOG_COMPILER_APPICON_NAME')
-        end
+      # Lint will fail if a AppIcon is set but no image is found with such name
+      # Happens only with Static Frameworks enabled but shouldn't be set anyway
+      app_target.build_configurations.each do |config|
+        config.build_settings.delete('ASSETCATALOG_COMPILER_APPICON_NAME')
       end
       app_project.save
       app_project.recreate_user_schemes

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -555,6 +555,12 @@ module Pod
       app_project = Xcodeproj::Project.new(validation_dir + 'App.xcodeproj')
       app_target = Pod::Generator::AppTargetHelper.add_app_target(app_project, consumer.platform_name, deployment_target)
       Pod::Generator::AppTargetHelper.add_swift_version(app_target, derived_swift_version)
+      if consumer.platform_name == :ios ||  consumer.platform_name == :tvos
+        # Lint will fail if a AppIcon is set but no image is found with such name
+        app_target.build_configurations.each do |config|
+          config.build_settings.delete('ASSETCATALOG_COMPILER_APPICON_NAME')
+        end
+      end
       app_project.save
       app_project.recreate_user_schemes
     end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1418,6 +1418,64 @@ module Pod
           debug_configuration_two.build_settings['SWIFT_VERSION'].should == '3.2'
         end
       end
+
+      # Given a validator and a consumer, creates an App project and returns it's main target
+      def create_target_with_validator_consumer(validator, consumer)
+        validator.instance_variable_set(:@consumer, consumer)
+        validator.send(:setup_validation_environment)
+        validator.send(:create_app_project)
+        project = Xcodeproj::Project.open(validator.validation_dir + 'App.xcodeproj')
+
+        project.native_targets.find { |t| t.name == 'App' }
+      end
+
+      describe 'check appicon key deleted' do
+        before do
+          @validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
+          @validator.stubs(:validate_url)
+        end
+
+        after do
+          @validator.send(:tear_down_validation_environment)
+        end
+
+        it 'ios platform deletes AppIcon key' do
+          consumer = Specification.from_file(podspec_path).consumer(:ios)
+          target = create_target_with_validator_consumer(@validator,consumer)
+
+          target.build_configurations.each do |config|
+            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+          end
+        end
+
+        it 'tvos platform deletes AppIcon key' do
+          consumer = Specification.from_file(podspec_path).consumer(:tvos)
+          target = create_target_with_validator_consumer(@validator,consumer)
+
+          target.build_configurations.each do |config|
+            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+          end
+        end
+
+        it 'osx platform deletes AppIcon key' do
+          consumer = Specification.from_file(podspec_path).consumer(:osx)
+          target = create_target_with_validator_consumer(@validator,consumer)
+
+          target.build_configurations.each do |config|
+            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+          end
+        end
+
+        it 'watchos platform deletes AppIcon key' do
+          consumer = Specification.from_file(podspec_path).consumer(:watchos)
+          target = create_target_with_validator_consumer(@validator,consumer)
+
+          target.build_configurations.each do |config|
+            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+          end
+        end
+
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1441,7 +1441,7 @@ module Pod
 
         it 'ios platform deletes AppIcon key' do
           consumer = Specification.from_file(podspec_path).consumer(:ios)
-          target = create_target_with_validator_consumer(@validator,consumer)
+          target = create_target_with_validator_consumer(@validator, consumer)
 
           target.build_configurations.each do |config|
             config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
@@ -1450,7 +1450,7 @@ module Pod
 
         it 'tvos platform deletes AppIcon key' do
           consumer = Specification.from_file(podspec_path).consumer(:tvos)
-          target = create_target_with_validator_consumer(@validator,consumer)
+          target = create_target_with_validator_consumer(@validator, consumer)
 
           target.build_configurations.each do |config|
             config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
@@ -1459,7 +1459,7 @@ module Pod
 
         it 'osx platform deletes AppIcon key' do
           consumer = Specification.from_file(podspec_path).consumer(:osx)
-          target = create_target_with_validator_consumer(@validator,consumer)
+          target = create_target_with_validator_consumer(@validator, consumer)
 
           target.build_configurations.each do |config|
             config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
@@ -1468,13 +1468,12 @@ module Pod
 
         it 'watchos platform deletes AppIcon key' do
           consumer = Specification.from_file(podspec_path).consumer(:watchos)
-          target = create_target_with_validator_consumer(@validator,consumer)
+          target = create_target_with_validator_consumer(@validator, consumer)
 
           target.build_configurations.each do |config|
             config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
           end
         end
-
       end
     end
 


### PR DESCRIPTION
Xcodeproj generates new projects with a default Icon called AppIcon [here](https://github.com/CocoaPods/Xcodeproj/blob/0ec1f7f1a80ab2be8dfa60864fbac54206e25e93/lib/xcodeproj/constants.rb#L307).
So when executing `pod lib lint`, the generated Xcodeproj has a set AppIcon and then picked up by the [copy_resources_script.rb](https://github.com/CocoaPods/CocoaPods/blob/b52a70d50f9e31a247794feac25ec9b4effbd13f/lib/cocoapods/generator/copy_resources_script.rb#L226).
This change deletes the ASSETCATALOG_COMPILER_APPICON_NAME key in the build settings when linting.
I did not add a check inside copy_resources_script.rb because checking all the image assets might take too long on large projects and might hide misconfigurations on normal projects.

Fixes: 
#7617

Todo:
- [x] Tests
- [x] Update changelog