### PR TITLE
Allow abstract-only target definitions to be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   or many versions that do not satisfy the given requirements.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Add support for pods in abstract-only targets to be installed.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Fix set `cache_root` from config file error  

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -42,9 +42,9 @@ module Pod
 
         def verify_no_duplicate_framework_and_library_names
           aggregate_targets.each do |aggregate_target|
-            aggregate_target.user_build_configurations.keys.each do |config|
+            aggregate_target.user_build_configurations.each_key do |config|
               pod_targets = aggregate_target.pod_targets_for_build_configuration(config)
-              file_accessors = pod_targets.flat_map(&:file_accessors)
+              file_accessors = pod_targets.flat_map(&:file_accessors).select { |fa| fa.spec.library_specification? }
 
               frameworks = file_accessors.flat_map(&:vendored_frameworks).uniq.map(&:basename)
               frameworks += pod_targets.select { |pt| pt.should_build? && pt.build_as_framework? }.map(&:product_module_name).uniq
@@ -58,7 +58,7 @@ module Pod
         end
 
         def verify_no_duplicate_names(names, label, type)
-          duplicates = names.map { |n| n.to_s.downcase }.group_by { |f| f }.select { |_, v| v.size > 1 }.keys
+          duplicates = names.group_by { |n| n.to_s.downcase }.select { |_, v| v.size > 1 }.keys
 
           unless duplicates.empty?
             raise Informative, "The '#{label}' target has " \

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -89,7 +89,6 @@ module Pod
       super(sandbox, host_requires_frameworks, user_build_configurations, archs, platform, :build_type => build_type)
       raise "Can't initialize a PodTarget without specs!" if specs.nil? || specs.empty?
       raise "Can't initialize a PodTarget without TargetDefinition!" if target_definitions.nil? || target_definitions.empty?
-      raise "Can't initialize a PodTarget with only abstract TargetDefinitions!" if target_definitions.all?(&:abstract?)
       raise "Can't initialize a PodTarget with an empty string scope suffix!" if scope_suffix == ''
       @specs = specs.dup.freeze
       @target_definitions = target_definitions

--- a/spec/unit/installer/podfile_validator_spec.rb
+++ b/spec/unit/installer/podfile_validator_spec.rb
@@ -76,28 +76,31 @@ module Pod
     end
 
     describe 'abstract-only dependencies' do
-      it 'errors when there is only a root target' do
+      it 'warns when there is only a root target' do
         podfile = Pod::Podfile.new do
+          platform :ios, '11'
           pod 'Alamofire'
         end
         validator = Installer::PodfileValidator.new(podfile)
         validator.validate
 
-        validator.should.not.be.valid
-        validator.errors.should == ['The dependency `Alamofire` is not used in any concrete target.']
+        validator.should.be.valid
+        validator.warnings.should == ["The abstract target Pods is not inherited by a concrete target, so the following dependencies won't make it into any targets in your project:\n    - Alamofire"]
       end
 
-      it 'errors when there are only abstract targets' do
+      it 'warns when there are only abstract targets' do
         podfile = Pod::Podfile.new do
           abstract_target 'Abstract' do
             pod 'Alamofire'
+            pod 'AFNetworking'
           end
         end
         validator = Installer::PodfileValidator.new(podfile)
         validator.validate
 
         validator.should.not.be.valid
-        validator.errors.should == ['The dependency `Alamofire` is not used in any concrete target.']
+        validator.warnings.should == ["The abstract target Abstract is not inherited by a concrete target, so the following dependencies won't make it into any targets in your project:\n    - AFNetworking\n    - Alamofire"]
+        validator.errors.should == ['The abstract target Abstract must specify a platform since its dependencies are not inherited by a concrete target.']
       end
 
       it 'does not error when an abstract target has concrete children with complete inheritance' do
@@ -114,7 +117,7 @@ module Pod
         validator.errors.should.be.empty
       end
 
-      it 'errors when an abstract target has concrete children with no inheritance' do
+      it 'warns when an abstract target has concrete children with no inheritance' do
         podfile = Pod::Podfile.new do
           abstract_target 'Abstract' do
             pod 'Alamofire'
@@ -127,10 +130,11 @@ module Pod
         validator.validate
 
         validator.should.not.be.valid
-        validator.errors.should == ['The dependency `Alamofire` is not used in any concrete target.']
+        validator.warnings.should == ["The abstract target Abstract is not inherited by a concrete target, so the following dependencies won't make it into any targets in your project:\n    - Alamofire"]
+        validator.errors.should == ['The abstract target Abstract must specify a platform since its dependencies are not inherited by a concrete target.']
       end
 
-      it 'errors when an abstract target has concrete children with only search_paths inheritance' do
+      it 'warns when an abstract target has concrete children with only search_paths inheritance' do
         podfile = Pod::Podfile.new do
           abstract_target 'Abstract' do
             pod 'Alamofire'
@@ -143,7 +147,8 @@ module Pod
         validator.validate
 
         validator.should.not.be.valid
-        validator.errors.should == ['The dependency `Alamofire` is not used in any concrete target.']
+        validator.warnings.should == ["The abstract target Abstract is not inherited by a concrete target, so the following dependencies won't make it into any targets in your project:\n    - Alamofire"]
+        validator.errors.should == ['The abstract target Abstract must specify a platform since its dependencies are not inherited by a concrete target.']
       end
 
       it 'does not error when an abstract target has multiple children with varied inheritance' do


### PR DESCRIPTION
This is useful in 2 cases:
1) When using CocoaPods to manage unlinked dependencies, such as a linter
2) When using CocoaPods to manage apps & tests, via app specs and test specs. This way, you don't need to create a "dummy" target in your user project to link the app specs dependencies against. This also has a performance benefit, since you won't need to generate any of the metadata needed for an aggregate target.