### PR TITLE
Order SPECS key by sorting according to downcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix target cache key SPECS key ordering.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#8657](https://github.com/CocoaPods/CocoaPods/issues/8657)
+
 * Deintegrate deleted targets even if `incremental_installation` is turned on.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso) & [Doug Mead](https://github.com/dmead28)
   [#8638](https://github.com/CocoaPods/CocoaPods/pull/8638)

--- a/lib/cocoapods/installer/project_cache/target_cache_key.rb
+++ b/lib/cocoapods/installer/project_cache/target_cache_key.rb
@@ -74,9 +74,11 @@ module Pod
         def self.from_cache_hash(key_hash)
           cache_hash = key_hash.dup
           if files = cache_hash['FILES']
-            cache_hash['FILES'] = files.sort
+            cache_hash['FILES'] = files.sort_by(&:downcase)
           end
-          cache_hash['SPECS'] = cache_hash['SPECS'].sort_by(&:downcase)
+          if specs = cache_hash['SPECS']
+            cache_hash['SPECS'] = specs.sort_by(&:downcase)
+          end
           type = cache_hash['CHECKSUM'] ? :pod_target : :aggregate
           TargetCacheKey.new(type, cache_hash)
         end
@@ -109,7 +111,7 @@ module Pod
             'SPECS' => pod_target.specs.map(&:to_s).sort_by(&:downcase),
             'BUILD_SETTINGS_CHECKSUM' => build_settings,
           }
-          contents['FILES'] = pod_target.all_files.sort if is_local_pod
+          contents['FILES'] = pod_target.all_files.sort_by(&:downcase) if is_local_pod
           contents['CHECKOUT_OPTIONS'] = checkout_options if checkout_options
           TargetCacheKey.new(:pod_target, contents)
         end

--- a/lib/cocoapods/installer/project_cache/target_cache_key.rb
+++ b/lib/cocoapods/installer/project_cache/target_cache_key.rb
@@ -76,6 +76,7 @@ module Pod
           if files = cache_hash['FILES']
             cache_hash['FILES'] = files.sort
           end
+          cache_hash['SPECS'] = cache_hash['SPECS'].sort_by(&:downcase)
           type = cache_hash['CHECKSUM'] ? :pod_target : :aggregate
           TargetCacheKey.new(type, cache_hash)
         end
@@ -105,7 +106,7 @@ module Pod
 
           contents = {
             'CHECKSUM' => pod_target.root_spec.checksum,
-            'SPECS' => pod_target.specs.map(&:to_s).sort,
+            'SPECS' => pod_target.specs.map(&:to_s).sort_by(&:downcase),
             'BUILD_SETTINGS_CHECKSUM' => build_settings,
           }
           contents['FILES'] = pod_target.all_files.sort if is_local_pod

--- a/spec/unit/installer/project_cache/target_cache_key_specs.rb
+++ b/spec/unit/installer/project_cache/target_cache_key_specs.rb
@@ -15,8 +15,8 @@ module Pod
         describe 'cache key structure' do
           it 'should order subspecs alphabetically' do
             root_spec = fixture_spec('banana-lib/BananaLib.podspec')
-            subspec1 = Pod::Specification.new(root_spec, "MUS")
-            subspec2 = Pod::Specification.new(root_spec, "Module")
+            subspec1 = Pod::Specification.new(root_spec, 'MUS')
+            subspec2 = Pod::Specification.new(root_spec, 'Module')
 
             pod_target = fixture_pod_target_with_specs([root_spec, subspec1, subspec2], true)
             cache_key = TargetCacheKey.from_pod_target(pod_target)

--- a/spec/unit/installer/project_cache/target_cache_key_specs.rb
+++ b/spec/unit/installer/project_cache/target_cache_key_specs.rb
@@ -12,6 +12,18 @@ module Pod
           @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(@aggregate_target)
         end
 
+        describe 'cache key structure' do
+          it 'should order subspecs alphabetically' do
+            root_spec = fixture_spec('banana-lib/BananaLib.podspec')
+            subspec1 = Pod::Specification.new(root_spec, "MUS")
+            subspec2 = Pod::Specification.new(root_spec, "Module")
+
+            pod_target = fixture_pod_target_with_specs([root_spec, subspec1, subspec2], true)
+            cache_key = TargetCacheKey.from_pod_target(pod_target)
+            cache_key.to_h['SPECS'].should.equal(['BananaLib (1.0)', 'BananaLib/Module (1.0)', 'BananaLib/MUS (1.0)'])
+          end
+        end
+
         describe 'key_difference with pod targets' do
           it 'should return equality for the same pod targets' do
             @banana_cache_key.key_difference(@banana_cache_key).should.equal(:none)


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/8657

* Writing to the yaml file sorts entries by downcase, so reading from the cache and then from a `PodTarget` instance would always produce a "dirty" target since the array orders would be different.
* Apply sort_by operator on files in the target cache key.
