### PR TITLE
[Resolver] Speed up w/ many requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Orta Therox](https://github.com/orta)
   [#8536](https://github.com/CocoaPods/CocoaPods/pull/8536)
 
+* Speed up dependency resolution when there are many requirements for the same pod
+  or many versions that do not satisfy the given requirements.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Fix set `cache_root` from config file error  

--- a/lib/cocoapods/resolver/lazy_specification.rb
+++ b/lib/cocoapods/resolver/lazy_specification.rb
@@ -42,17 +42,26 @@ module Pod
       end
 
       class External
-        def all_specifications(_warn_for_multiple_pod_sources)
-          [specification]
+        def all_specifications(_warn_for_multiple_pod_sources, requirement)
+          if requirement.satisfied_by? specification.version
+            [specification]
+          else
+            []
+          end
         end
       end
 
       # returns the highest versioned spec last
-      def all_specifications(warn_for_multiple_pod_sources)
-        @all_specifications ||= begin
+      def all_specifications(warn_for_multiple_pod_sources, requirement)
+        @all_specifications ||= {}
+        @all_specifications[requirement] ||= begin
           sources_by_version = {}
           versions_by_source.each do |source, versions|
-            versions.each { |v| (sources_by_version[v] ||= []) << source }
+            versions.each do |v|
+              next unless requirement.satisfied_by?(v)
+
+              (sources_by_version[v] ||= []) << source
+            end
           end
 
           if warn_for_multiple_pod_sources


### PR DESCRIPTION
`.uniq`ing the requirements reduces state space, and pruning before going through all source reduces object allocation.

Further, freezing `@ podfile_requirements_by_root_name` means the list of requirements for a pod can't keep on growing every time it's searched for