### PR TITLE
[RFC] Default to making installations quieter

### DIFF
--- a/lib/cocoapods/external_sources/path_source.rb
+++ b/lib/cocoapods/external_sources/path_source.rb
@@ -8,7 +8,7 @@ module Pod
       #
       def fetch(sandbox)
         title = "Fetching podspec for `#{name}` #{description}"
-        UI.titled_section(title,  :verbose_prefix => '-> ') do
+        UI.section(title, '-> ') do
           podspec = podspec_path
           unless podspec.exist?
             raise Informative, "No podspec found for `#{name}` in " \

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -496,7 +496,7 @@ module Pod
             install_source_of_pod(spec.name)
           end
         else
-          UI.titled_section("Using #{spec}", title_options) do
+          UI.section("Using #{spec}", title_options[:verbose_prefix]) do
             create_pod_installer(spec.name)
           end
         end


### PR DESCRIPTION
Copied from changes in Bundler 3

Before:

```
Installing...
Fetching podspec for `Blueprint` from `../../Frameworks/Blueprint/Blueprint.podspec`
Using Blueprint (1.0.0.LOCAL)
Pod installation complete! There are 2 dependencies from the Podfile and 1 total pod installed.
```

After:

```
Installing...
Pod installation complete! There are 2 dependencies from the Podfile and 1 total pod installed.
```

This makes a _huge_ difference when you have hundreds of local dependencies, and makes it much more likely that `pod install` output is concise and contains mostly actionable information.

I'm opening this PR up as sort of a request for comment, this obviously is a change in UX, but it's one I'd very much like to see. Let me know what you think!