### PR TITLE
Fix a bug that caused the headers dir for pods containing a custom module map to be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix a regression for static libraries with a custom module name  
+  [Eric Amorde](https://github.com/amorde)
+  [#8695](https://github.com/CocoaPods/CocoaPods/issues/8695)
 
 
 ## 1.7.0.beta.3 (2019-03-28)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -150,7 +150,7 @@ module Pod
     # @return [Pathname] the pathname for headers in the sandbox.
     #
     def headers_sandbox
-      Pathname.new(pod_name)
+      Pathname.new(product_module_name)
     end
 
     # @return [Hash{FileAccessor => Hash}] Hash of file accessors by header mappings.

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -470,6 +470,7 @@ module Pod
           @spec = stub(:name => 'Spec', :test_specification? => false, :library_specification? => true, :non_library_specification? => false, :app_specification? => false)
           @spec.stubs(:root => @spec)
           @spec.stubs(:spec_type).returns(:library)
+          @spec.stubs(:module_name => 'Spec')
           @pod_targets = [PodTarget.new(config.sandbox, false, {}, [], Platform.ios, [@spec],
                                         [fixture_target_definition], nil)]
           @installer.stubs(:analysis_result).returns(@analysis_result)

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -95,6 +95,17 @@ module Pod
         @pod_target.should_build?.should == false
       end
 
+      describe '#headers_sandbox' do
+        it 'returns the correct path' do
+          @pod_target.headers_sandbox.should == Pathname.new('BananaLib')
+        end
+
+        it 'returns the correct path when a custom module name is set' do
+          @pod_target.stubs(:product_module_name).returns('BananaLibModule')
+          @pod_target.headers_sandbox.should == Pathname.new('BananaLibModule')
+        end
+      end
+
       describe '#build_settings_for_spec' do
         before do
           @watermelon_spec = fixture_spec('grapefruits-lib/GrapefruitsLib.podspec')


### PR DESCRIPTION
Closes #8695 

I initially had a workaround in `SandboxDirCleaner` to make sure the directory remained, but it makes more sense for this to be reflected in the value of `headers_sandbox`

For a pod with a different module name, a module map is symlinked to `Pods/Public/[module_name]/[module_name].modulemap`. However, since `headers_sandbox` is set to `Pods/Public/[pod_name]`, this directory was not kept when cleaning the sandbox.

The point at which the directory would be marked as one to keep is in the `else` block here: https://github.com/CocoaPods/CocoaPods/blob/6bd7b5bb2bafe4d78f38bda09b81f7a6bffc407e/lib/cocoapods/installer/sandbox_dir_cleaner.rb#L50-L54