### PR TITLE
Properly escape codesign path with an apostrophe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Properly escape path  
+  [SatbirTanda](https://github.com/SatbirTanda)
+  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number/8703)
+
 * Fix set `cache_root` from config file error  
   [tripleCC](https://github.com/tripleCC)
   [#8515](https://github.com/CocoaPods/CocoaPods/issues/8515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Properly escape path  
+* Properly escape path if target contains an apostrophe
   [SatbirTanda](https://github.com/SatbirTanda)
-  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number/8703)
+  [#8703](https://github.com/CocoaPods/CocoaPods/issues/issue_number/8703)
 
 * Fix set `cache_root` from config file error  
   [tripleCC](https://github.com/tripleCC)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -167,7 +167,7 @@ module Pod
             if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
               # Use the current code_sign_identity
               echo "Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}"
-              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements '$1'"
+              local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements \"$1\""
 
               if [ "${COCOAPODS_PARALLEL_CODE_SIGN}" == "true" ]; then
                 code_sign_cmd="$code_sign_cmd &"


### PR DESCRIPTION
Fixes #8703 
Properly escapes path if it contains an apostrophe