### PR TITLE
Allow overriding pod build directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,8 @@
 	url = https://github.com/tonymillion/Reachability.git
 [submodule "spec/cocoapods-integration-specs"]
 	path = spec/cocoapods-integration-specs
-	url = https://github.com/CocoaPods/cocoapods-integration-specs.git
+	url = https://github.com/philippelatulippe/cocoapods-integration-specs.git
+        branch = allow-overriding-pod-build-dir
 [submodule "spec/fixtures/spec-repos/test_repo"]
 	path = spec/fixtures/spec-repos/test_repo
 	url = https://github.com/CocoaPods/cocoapods-test-specs.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8916](https://github.com/CocoaPods/CocoaPods/pull/8916)
 
+* Support overriding the pod build directory by overriding `PODS_BUILD_DIR`  
+  [Philippe Latulippe](https://github.com/philippelatulippe)
+  [#issue_number](https://github.com/CocoaPods/CocoaPods/pull/8722)
+
 ##### Bug Fixes
 
 * Fix set `cache_root` from config file error  

--- a/examples/Alamofire Example/iOS Example.xcodeproj/project.pbxproj
+++ b/examples/Alamofire Example/iOS Example.xcodeproj/project.pbxproj
@@ -173,7 +173,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iOS Example/Pods-iOS Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App/Pods-App-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HeaderMappingsDirPod/HeaderMappingsDirPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/HeaderMappingsDirPod/HeaderMappingsDirPod.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/examples/Modules Example/iOS Modules.xcodeproj/project.pbxproj
+++ b/examples/Modules Example/iOS Modules.xcodeproj/project.pbxproj
@@ -264,11 +264,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Abstract Target-iOS Pods-Dynamic/Pods-Abstract Target-iOS Pods-Dynamic-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire-framework-iOS/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/CustomModuleMapPod-framework-iOS/CustomModuleMapPod.framework",
-				"${BUILT_PRODUCTS_DIR}/MixedPod-framework-iOS/MixedPod.framework",
-				"${BUILT_PRODUCTS_DIR}/ObjCPod-framework-iOS/ObjCPod.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftPod-framework-iOS/SwiftPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire-framework-iOS/Alamofire.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomModuleMapPod-framework-iOS/CustomModuleMapPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/MixedPod-framework-iOS/MixedPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ObjCPod-framework-iOS/ObjCPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SwiftPod-framework-iOS/SwiftPod.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/examples/Modules Example/macOS Modules.xcodeproj/project.pbxproj
+++ b/examples/Modules Example/macOS Modules.xcodeproj/project.pbxproj
@@ -228,11 +228,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Abstract Target-macOS Pods-Dynamic/Pods-Abstract Target-macOS Pods-Dynamic-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire-framework-macOS/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/CustomModuleMapPod-framework-macOS/CustomModuleMapPod.framework",
-				"${BUILT_PRODUCTS_DIR}/MixedPod-framework-macOS/MixedPod.framework",
-				"${BUILT_PRODUCTS_DIR}/ObjCPod-framework-macOS/ObjCPod.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftPod-framework-macOS/SwiftPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire-framework-macOS/Alamofire.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomModuleMapPod-framework-macOS/CustomModuleMapPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/MixedPod-framework-macOS/MixedPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ObjCPod-framework-macOS/ObjCPod.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SwiftPod-framework-macOS/SwiftPod.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
+++ b/examples/Resource Bundle Example/Resource Bundle Example.xcodeproj/project.pbxproj
@@ -197,10 +197,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Resource Bundle Example/Pods-Resource Bundle Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/ResourceAssetsExample/ResourceAssetsExample.framework",
-				"${BUILT_PRODUCTS_DIR}/ResourceExample/ResourceExample.framework",
-				"${BUILT_PRODUCTS_DIR}/ResourcesBundleExample/ResourcesBundleExample.framework",
-				"${BUILT_PRODUCTS_DIR}/ResourcesExample/ResourcesExample.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ResourceAssetsExample/ResourceAssetsExample.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ResourceExample/ResourceExample.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ResourcesBundleExample/ResourcesBundleExample.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ResourcesExample/ResourcesExample.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/project.pbxproj
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/project.pbxproj
@@ -183,8 +183,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-InstallMultipleTestSpecs/Pods-InstallMultipleTestSpecs-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HostedTestLib/HostedTestLib.framework",
-				"${BUILT_PRODUCTS_DIR}/TestLib/TestLib.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/HostedTestLib/HostedTestLib.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/TestLib/TestLib.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
+++ b/examples/watchOS Example/watchOSsample.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-watchOSsample WatchKit Extension/Pods-watchOSsample WatchKit Extension-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire-watchOS/Alamofire.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire-watchOS/Alamofire.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -388,7 +388,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-watchOSsample/Pods-watchOSsample-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire-iOS/Alamofire.framework",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire-iOS/Alamofire.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -75,10 +75,10 @@ module Pod
           # Copies and strips a vendored framework
           install_framework()
           {
-            if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
-              local source="${BUILT_PRODUCTS_DIR}/$1"
-            elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
-              local source="${BUILT_PRODUCTS_DIR}/$(basename "$1")"
+            if [ -r "${PODS_CONFIGURATION_BUILD_DIR}/$1" ]; then
+              local source="${PODS_CONFIGURATION_BUILD_DIR}/$1"
+            elif [ -r "${PODS_CONFIGURATION_BUILD_DIR}/$(basename "$1")" ]; then
+              local source="${PODS_CONFIGURATION_BUILD_DIR}/$(basename "$1")"
             elif [ -r "$1" ]; then
               local source="$1"
             fi
@@ -157,7 +157,7 @@ module Pod
           # Copies the bcsymbolmap files of a vendored framework
           install_bcsymbolmap() {
               local bcsymbolmap_path="$1"
-              local destination="${BUILT_PRODUCTS_DIR}"
+              local destination="${PODS_CONFIGURATION_BUILD_DIR}"
               echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
               rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"
           }

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -373,7 +373,7 @@ module Pod
             FrameworkPaths.new(framework_source, dsym_source, bcsymbolmap_paths)
           end
           if !file_accessor.spec.test_specification? && should_build? && build_as_dynamic_framework?
-            frameworks << FrameworkPaths.new(build_product_path('${BUILT_PRODUCTS_DIR}'))
+            frameworks << FrameworkPaths.new(build_product_path('${PODS_CONFIGURATION_BUILD_DIR}'))
           end
           hash[file_accessor.spec.name] = frameworks
         end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -453,7 +453,7 @@ module Pod
                 @watermelon_pod_target.user_build_configurations.keys.each do |configuration|
                   script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "#{configuration}" ]]; then
-          install_framework "${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework"
+          install_framework "${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLib.framework"
         fi
                   eos
                 end
@@ -467,7 +467,7 @@ module Pod
                 @watermelon_pod_target.user_build_configurations.keys.each do |configuration|
                   script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "#{configuration}" ]]; then
-          install_framework "${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework"
+          install_framework "${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLib.framework"
         fi
                   eos
                 end

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -151,10 +151,10 @@ module Pod
           @pod_target.stubs(:should_build?).returns(true)
           @pod_target.stubs(:build_type).returns(Target::BuildType.dynamic_framework)
           @target.framework_paths_by_config['Debug'].should == [
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/BananaLib.framework'),
           ]
           @target.framework_paths_by_config['Release'].should == [
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/BananaLib.framework'),
           ]
         end
 
@@ -188,11 +188,11 @@ module Pod
           @target.stubs(:pod_targets).returns([@pod_target, @pod_target_release])
           framework_paths_by_config = @target.framework_paths_by_config
           framework_paths_by_config['Debug'].should == [
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/BananaLib.framework'),
           ]
           framework_paths_by_config['Release'].should == [
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/CoconutLib/CoconutLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/BananaLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/CoconutLib/CoconutLib.framework'),
           ]
         end
 
@@ -214,10 +214,10 @@ module Pod
           @pod_target.stubs(:should_build?).returns(true)
           @pod_target.stubs(:build_type => Target::BuildType.dynamic_framework)
           @target.framework_paths_by_config['Debug'].should == [
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/BananaLib.framework'),
           ]
           @target.framework_paths_by_config['Release'].should == [
-            Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework'),
+            Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/BananaLib/BananaLib.framework'),
           ]
         end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -739,12 +739,12 @@ module Pod
         it 'returns the correct framework paths' do
           @watermelon_pod_target.framework_paths.should == {
             'WatermelonLib' => [
-              Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework'),
+              Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLib.framework'),
             ],
             'WatermelonLib/Tests' => [],
             'WatermelonLib/SnapshotTests' => [],
             'WatermelonLib/App' => [
-              Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework'),
+              Target::FrameworkPaths.new('${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLib.framework'),
             ],
           }
         end


### PR DESCRIPTION
This is my attempt to support the use-case I described in #7146: building the pods and project targets separately on CI, in order to build pods once for multiple targets. This is almost possible by overriding`PODS_BUILD_DIR`, except that *Embed Pods Frameworks* script hardcodes the framework path to `BUILT_PRODUCTS_DIR`, which is computed by xcode. Changing the script to use `PODS_CONFIGURATION_BUILD_DIR` instead (computed from `PODS_BUILD_DIR`) fixes the issue and makes this use-case possible.

This merge request changes `${BUILT_PRODUCTS_DIR}` to `${PODS_CONFIGURATION_BUILD_DIR}` in `PodTarget.framework_paths`. The result is that this line in the "Embed Pods Frameworks" scripts goes from:

    install_framework "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework"

to become:

    install_framework "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.framework"


I'm hoping these variables are always equivalent unless overridden, but I don't have enough knowledge about xcode building and CocoaPods to know if this assumption correct. But it seems to be the case in the configurations I have tested.

I have updated the tests in this sister merge request: https://github.com/CocoaPods/cocoapods-integration-specs/pull/221. `.gitmodules` will need to be updated if it is merged.

