### PR TITLE
Update ISSUE_TEMPLATE.md for Xcode 10.1

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@ Issues are for feature requests, and bugs; questions should go to Stack Overflow
 
 Using CocoaPods <= 0.39: https://blog.cocoapods.org/Sharding/
 
-Using Xcode 8: Requires CocoaPods 1.1.0 or above.
+Using Xcode 10.1: Requires CocoaPods 1.6.0 or above.
 
 Issue with Nanaimo not loading:
 Please run `[sudo] gem uninstall nanaimo` and remove all but the latest version.


### PR DESCRIPTION
- [AppStore requires Xcode 10.1+ when building for iOS.](https://help.apple.com/xcode/mac/current/#/devf16aefe3b)
- And [CocoaPods 1.6.0 is the earliest version with guaranteed support for Xcode 10.1](https://github.com/CocoaPods/CocoaPods/pull/8203): using an older version would require specific environment conditions, like some `gem update fourflusher`, and we don't need to do extra support for that, so it's time to move forward and mention CocoaPods 1.6.0 instead of 1.1.0.

I'm aware that tvOS and macOS targets don't need Xcode 10.1 yet, but it's not worth mentioning in the issue template.
