### PR TITLE
Refactor MultiXcode proj structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Replace Pods project `Dependencies` group with `Development Pods` and `Pods` groups.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#8659](https://github.com/CocoaPods/CocoaPods/issues/8659)
+
 * Adds support for referring to other podspecs during validation  
   [Orta Therox](https://github.com/orta)
   [#8536](https://github.com/CocoaPods/CocoaPods/pull/8536)

--- a/lib/cocoapods/installer/xcode/multi_pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/multi_pods_project_generator.rb
@@ -71,7 +71,7 @@ module Pod
         def pod_name_from_grouping(pod_targets)
           # The presumption here for multi pods project is that we group by `pod_name`, thus the grouping of `pod_targets`
           # should share the same `pod_name`.
-          raise '[BUG] Expected at least 1 pod target' if pod_targets.size == 0
+          raise '[BUG] Expected at least 1 pod target' if pod_targets.empty?
           pod_targets.first.pod_name
         end
       end

--- a/lib/cocoapods/installer/xcode/multi_pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/multi_pods_project_generator.rb
@@ -46,7 +46,9 @@ module Pod
           # the file reference can use so that we only have to call `save` once for all projects.
           project.path.mkpath
           if parent_project
-            parent_project.add_subproject_reference(project, parent_project.dependencies_group)
+            pod_name = pod_name_from_grouping(pod_targets)
+            is_local = sandbox.local?(pod_name)
+            parent_project.add_pod_subproject(project, is_local)
           end
 
           install_file_references(project, pod_targets)
@@ -64,6 +66,13 @@ module Pod
         def install_aggregate_targets_into_project(project, aggregate_targets)
           return {} unless project
           install_aggregate_targets(project, aggregate_targets)
+        end
+
+        def pod_name_from_grouping(pod_targets)
+          # The presumption here for multi pods project is that we group by `pod_name`, thus the grouping of `pod_targets`
+          # should share the same `pod_name`.
+          raise '[BUG] Expected at least 1 pod target' if pod_targets.size == 0
+          pod_targets.first.pod_name
         end
       end
     end

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -182,10 +182,10 @@ module Pod
           pod_target_installation_results_hash = target_installation_results.pod_target_installation_results
           aggregate_target_installation_results_hash = target_installation_results.aggregate_target_installation_results
 
-          AggregateTargetDependencyInstaller.new(aggregate_target_installation_results_hash,
+          AggregateTargetDependencyInstaller.new(sandbox, aggregate_target_installation_results_hash,
                                                  pod_target_installation_results_hash, metadata_cache).install!
 
-          PodTargetDependencyInstaller.new(pod_target_installation_results_hash, metadata_cache).install!
+          PodTargetDependencyInstaller.new(sandbox, pod_target_installation_results_hash, metadata_cache).install!
         end
 
         # @param  [String] pod The root name of the development pod.

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_dependency_installer.rb
@@ -18,13 +18,19 @@ module Pod
         #
         attr_reader :metadata_cache
 
+        # @return [Sandbox] The sandbox used for this installation.
+        #
+        attr_reader :sandbox
+
         # Initialize a new instance.
         #
+        # @param [Sandbox] sandbox @see #sandbox
         # @param [Hash{String => TargetInstallationResult}] aggregate_target_installation_results @see #aggregate_target_installation_results
         # @param [Hash{String => TargetInstallationResult}] pod_target_installation_results @see #pod_target_installation_results
         # @param [ProjectMetadataCache] metadata_cache @see #metadata_cache
         #
-        def initialize(aggregate_target_installation_results, pod_target_installation_results, metadata_cache)
+        def initialize(sandbox, aggregate_target_installation_results, pod_target_installation_results, metadata_cache)
+          @sandbox = sandbox
           @aggregate_target_installation_results = aggregate_target_installation_results
           @pod_target_installation_results = pod_target_installation_results
           @metadata_cache = metadata_cache
@@ -45,6 +51,7 @@ module Pod
             end
             # Wire up all pod target dependencies to aggregate target.
             aggregate_target.pod_targets.each do |pod_target|
+              is_local = sandbox.local?(pod_target.pod_name)
               if pod_target_installation_result = pod_target_installation_results[pod_target.name]
                 pod_target_native_target = pod_target_installation_result.native_target
                 aggregate_native_target.add_dependency(pod_target_native_target)
@@ -52,7 +59,7 @@ module Pod
               else
                 # Hit the cache
                 cached_dependency = metadata_cache.target_label_by_metadata[pod_target.label]
-                project.add_cached_subproject_reference(cached_dependency, project.dependencies_group)
+                project.add_cached_pod_subproject(cached_dependency, is_local)
                 Project.add_cached_dependency(aggregate_native_target, cached_dependency)
               end
             end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_dependency_installer.rb
@@ -51,13 +51,13 @@ module Pod
             end
             # Wire up all pod target dependencies to aggregate target.
             aggregate_target.pod_targets.each do |pod_target|
-              is_local = sandbox.local?(pod_target.pod_name)
               if pod_target_installation_result = pod_target_installation_results[pod_target.name]
                 pod_target_native_target = pod_target_installation_result.native_target
                 aggregate_native_target.add_dependency(pod_target_native_target)
                 configure_app_extension_api_only_to_native_target(pod_target_native_target) if is_app_extension
               else
                 # Hit the cache
+                is_local = sandbox.local?(pod_target.pod_name)
                 cached_dependency = metadata_cache.target_label_by_metadata[pod_target.label]
                 project.add_cached_pod_subproject(cached_dependency, is_local)
                 Project.add_cached_dependency(aggregate_native_target, cached_dependency)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -14,12 +14,18 @@ module Pod
         #
         attr_reader :metadata_cache
 
+        # @return [Sandbox] The sandbox used for this installation.
+        #
+        attr_reader :sandbox
+
         # Initialize a new instance.
         #
+        # @param [Sandbox] sandbox @see #sandbox
         # @param [TargetInstallationResults] pod_target_installation_results @see #pod_target_installation_results
         # @param [ProjectMetadataCache] metadata_cache @see #metadata_cache
         #
-        def initialize(pod_target_installation_results, metadata_cache)
+        def initialize(sandbox, pod_target_installation_results, metadata_cache)
+          @sandbox = sandbox
           @pod_target_installation_results = pod_target_installation_results
           @metadata_cache = metadata_cache
         end
@@ -68,17 +74,18 @@ module Pod
                                      pod_target_installation_results, metadata_cache, frameworks_group)
           dependent_targets = pod_target.dependent_targets
           dependent_targets.each do |dependent_target|
+            is_local = sandbox.local?(dependent_target.pod_name)
             if installation_result = pod_target_installation_results[dependent_target.name]
               dependent_project = installation_result.native_target.project
               if dependent_project != project
-                project.add_subproject_reference(dependent_project, project.dependencies_group)
+                project.add_pod_subproject(dependent_project, is_local)
               end
               native_target.add_dependency(installation_result.native_target)
               add_framework_file_reference_to_native_target(native_target, pod_target, dependent_target, frameworks_group)
             else
               # Hit the cache
               cached_dependency = metadata_cache.target_label_by_metadata[dependent_target.label]
-              project.add_cached_subproject_reference(cached_dependency, project.dependencies_group)
+              project.add_cached_pod_subproject(cached_dependency, is_local)
               Project.add_cached_dependency(native_target, cached_dependency)
             end
           end
@@ -93,17 +100,18 @@ module Pod
 
             test_dependent_targets = pod_target.test_dependent_targets_by_spec_name.fetch(test_spec.name, []).unshift(pod_target).uniq
             test_dependent_targets.each do |test_dependent_target|
+              is_local = sandbox.local?(test_dependent_target.pod_name)
               if dependency_installation_result = pod_target_installation_results[test_dependent_target.name]
                 dependent_test_project = dependency_installation_result.native_target.project
                 if dependent_test_project != project
-                  project.add_subproject_reference(dependent_test_project, project.dependencies_group)
+                  project.add_pod_subproject(dependent_test_project, is_local)
                 end
                 test_native_target.add_dependency(dependency_installation_result.native_target)
                 add_framework_file_reference_to_native_target(test_native_target, pod_target, test_dependent_target, frameworks_group)
               else
                 # Hit the cache
                 cached_dependency = metadata_cache.target_label_by_metadata[test_dependent_target.label]
-                project.add_cached_subproject_reference(cached_dependency, project.dependencies_group)
+                project.add_cached_pod_subproject(cached_dependency, is_local)
                 Project.add_cached_dependency(test_native_target, cached_dependency)
               end
             end
@@ -119,6 +127,7 @@ module Pod
 
             app_dependent_targets = pod_target.app_dependent_targets_by_spec_name.fetch(app_spec.name, []).unshift(pod_target).uniq
             app_dependent_targets.each do |app_dependent_target|
+              is_local = sandbox.local?(app_dependent_target.pod_name)
               if dependency_installation_result = pod_target_installation_results[app_dependent_target.name]
                 resource_bundle_native_targets = dependency_installation_result.app_resource_bundle_targets[app_spec.name]
                 unless resource_bundle_native_targets.nil?
@@ -128,14 +137,14 @@ module Pod
                 end
                 dependency_project = dependency_installation_result.native_target.project
                 if dependency_project != project
-                  project.add_subproject_reference(dependency_project, project.dependencies_group)
+                  project.add_pod_subproject(dependency_project, is_local)
                 end
                 app_native_target.add_dependency(dependency_installation_result.native_target)
                 add_framework_file_reference_to_native_target(app_native_target, pod_target, app_dependent_target, frameworks_group)
               else
                 # Hit the cache
                 cached_dependency = metadata_cache.target_label_by_metadata[app_dependent_target.label]
-                project.add_cached_subproject_reference(cached_dependency, project.dependencies_group)
+                project.add_cached_pod_subproject(cached_dependency, is_local)
                 Project.add_cached_dependency(native_target, cached_dependency)
               end
             end

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -143,19 +143,14 @@ module Pod
     # @return [PBXFileReference] The new file reference.
     #
     def add_pod_subproject(project, development = false)
-      parent_group =
-        if pod_target_subproject
-          dependencies_group
-        else
-          development ? development_pods : pods
-        end
+      parent_group = group_for_subproject_reference(development)
       add_subproject_reference(project, parent_group)
     end
 
     # Creates a new subproject reference for the given cached metadata and configures its
     # group location.
     #
-    # @param [ProjectMetadataCache] metadata
+    # @param [TargetMetadata] metadata
     #        The project metadata to be added.
     #
     # @param [Bool] development
@@ -165,13 +160,8 @@ module Pod
     # @return [PBXFileReference] The new file reference.
     #
     def add_cached_pod_subproject(metadata, development = false)
-      parent_group =
-        if pod_target_subproject
-          dependencies_group
-        else
-          development ? development_pods : pods
-        end
-      add_cached_subproject_reference(metadata.container_project_path, parent_group)
+      parent_group = group_for_subproject_reference(development)
+      add_cached_subproject_reference(metadata, parent_group)
     end
 
     # @return [Array<PBXGroup>] Returns all the group of the Pods.
@@ -531,6 +521,16 @@ module Pod
       root_object.project_references << project_reference
       refs_by_absolute_path[project_path.to_s] = ref
       ref
+    end
+
+    # Returns the parent group a new subproject reference should belong to.
+    #
+    def group_for_subproject_reference(development)
+      if pod_target_subproject
+        dependencies_group
+      else
+        development ? development_pods : pods
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -130,6 +130,50 @@ module Pod
       group
     end
 
+    # Creates a new subproject reference for the given project and configures its
+    # group location.
+    #
+    # @param [Project] project
+    #        The subproject to be added.
+    #
+    # @param [Bool] development
+    #        Whether the project should be added to the Development Pods group.
+    #        For projects where `pod_target_subproject` is enabled, all subprojects are added into the Dependencies group.
+    #
+    # @return [PBXFileReference] The new file reference.
+    #
+    def add_pod_subproject(project, development = false)
+      parent_group =
+        if pod_target_subproject
+          dependencies_group
+        else
+          development ? development_pods : pods
+        end
+      add_subproject_reference(project, parent_group)
+    end
+
+    # Creates a new subproject reference for the given cached metadata and configures its
+    # group location.
+    #
+    # @param [ProjectMetadataCache] metadata
+    #        The project metadata to be added.
+    #
+    # @param [Bool] development
+    #        Whether the project should be added to the Development Pods group.
+    #        For projects where `pod_target_subproject` is enabled, all subprojects are added into the Dependencies group.
+    #
+    # @return [PBXFileReference] The new file reference.
+    #
+    def add_cached_pod_subproject(metadata, development = false)
+      parent_group =
+        if pod_target_subproject
+          dependencies_group
+        else
+          development ? development_pods : pods
+        end
+      add_cached_subproject_reference(metadata.container_project_path, parent_group)
+    end
+
     # @return [Array<PBXGroup>] Returns all the group of the Pods.
     #
     def pod_groups

--- a/lib/cocoapods/version_metadata.rb
+++ b/lib/cocoapods/version_metadata.rb
@@ -1,11 +1,13 @@
 module Pod
   module VersionMetadata
+    CACHE_VERSION = '001'.freeze
+
     def self.gem_version
       Pod::VERSION
     end
 
     def self.project_cache_version
-      VersionMetadata.gem_version
+      "#{VersionMetadata.gem_version}.project-cache.#{CACHE_VERSION}"
     end
   end
 end

--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -618,6 +618,7 @@ module Pod
             end
 
             it 'project cleans up empty groups' do
+              @generator.sandbox.store_local_path('BananaLib', fixture('banana-lib/BananaLib.podspec'))
               pod_generator_result = @generator.generate!
               pods_project = pod_generator_result.project
               projects_by_pod_targets = pod_generator_result.projects_by_pod_targets
@@ -625,9 +626,9 @@ module Pod
               Xcode::PodsProjectWriter.new(@generator.sandbox, generated_projects,
                                            pod_generator_result.target_installation_results.pod_target_installation_results,
                                            @generator.installation_options).write!
-              pods_project.main_group['Pods'].should.be.nil
-              pods_project.main_group['Development Pods'].should.be.nil
-              pods_project.main_group['Dependencies'].should.not.be.nil
+              pods_project.main_group['Pods'].should.not.be.nil
+              pods_project.main_group['Development Pods'].should.not.be.nil
+              pods_project.main_group['Dependencies'].should.be.nil
 
               projects_by_pod_targets.keys.each do |project|
                 project.main_group['Pods'].should.be.nil


### PR DESCRIPTION
Previously `Pods.xcodeproj` held all pod subprojects under a `Dependencies` grouping. This change restructures the grouping for just `Pods.xcodeproj` to share a similar format as a single project generation by putting local pod projects under the `Development Pods` group and remote pods under the `Pods` group. Pod subprojects do not share this format and put all subproject dependencies under the `Dependencies` group.