### PR TITLE
[Analyzer] Set default user build configurations when not integrating targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Itay Brenner](https://github.com/itaybre)
   [#8648](https://github.com/CocoaPods/CocoaPods/issues/8648)
 
+* Set default build configurations for app / test specs when installing with
+  `integrate_targets: false`, ensuring the `Embed Frameworks` and
+  `Copy Resources` scripts will copy the necessary build artifacts.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.7.0.beta.3 (2019-03-28)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -298,7 +298,7 @@ module Pod
             host_target_uuids = Set.new(aggregate_target.user_project.host_targets_for_embedded_target(embedded_user_target).map(&:uuid))
             !aggregate_user_target_uuids.intersection(host_target_uuids).empty?
           end
-          embedded_aggregate_target.user_build_configurations.keys.each do |configuration_name|
+          embedded_aggregate_target.user_build_configurations.each_key do |configuration_name|
             pod_target_names = Set.new(aggregate_target.pod_targets_for_build_configuration(configuration_name).map(&:name))
             embedded_pod_targets = embedded_aggregate_target.pod_targets_for_build_configuration(configuration_name).select do |pod_target|
               if !pod_target_names.include?(pod_target.name) &&

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -729,7 +729,7 @@ module Pod
                     target_inspections.flat_map(&:archs).compact.uniq.sort
                   end
         else
-          user_build_configurations = {}
+          user_build_configurations = Target::DEFAULT_BUILD_CONFIGURATIONS
           archs = target_requires_64_bit ? ['$(ARCHS_STANDARD_64_BIT)'] : []
         end
         host_requires_frameworks = target_definitions.any?(&:uses_frameworks?)

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -194,7 +194,7 @@ module Pod
     #
     def specs_by_build_configuration
       result = {}
-      user_build_configurations.keys.each do |build_configuration|
+      user_build_configurations.each_key do |build_configuration|
         result[build_configuration] = pod_targets_for_build_configuration(build_configuration).
           flat_map(&:specs)
       end
@@ -232,7 +232,7 @@ module Pod
     def framework_paths_by_config
       @framework_paths_by_config ||= begin
         framework_paths_by_config = {}
-        user_build_configurations.keys.each do |config|
+        user_build_configurations.each_key do |config|
           relevant_pod_targets = pod_targets_for_build_configuration(config)
           framework_paths_by_config[config] = relevant_pod_targets.flat_map do |pod_target|
             library_specs = pod_target.library_specs.map(&:name)
@@ -250,7 +250,7 @@ module Pod
         relevant_pod_targets = pod_targets.reject do |pod_target|
           pod_target.should_build? && pod_target.build_as_dynamic_framework?
         end
-        user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
+        user_build_configurations.each_key.each_with_object({}) do |config, resources_by_config|
           targets = relevant_pod_targets & pod_targets_for_build_configuration(config)
           resources_by_config[config] = targets.flat_map do |pod_target|
             library_specs = pod_target.library_specs.map(&:name)

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -1213,6 +1213,9 @@ module Pod
         target.user_target_uuids.should == []
         target.user_build_configurations.should == { 'Release' => :release, 'Debug' => :debug }
         target.platform.to_s.should == 'iOS 6.0'
+
+        pod_target = target.pod_targets.first
+        pod_target.user_build_configurations.should == { 'Release' => :release, 'Debug' => :debug }
       end
 
       describe 'no-integrate platform validation' do


### PR DESCRIPTION
Set default build configurations for app / test specs when installing with `integrate_targets: false`, ensuring the `Embed Frameworks` and  `Copy Resources` scripts will copy the necessary biuld artifacts.