### PR TITLE
Fix an issue that prevented deployment targets from being treated as a minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   `Copy Resources` scripts will copy the necessary build artifacts.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Fix a bug that prevented Podspec deployment targets from being
+  treated as a minimum  
+  [Eric Amorde](https://github.com/amorde)
+  [#7314](https://github.com/CocoaPods/CocoaPods/issues/7314)
+
 
 ## 1.7.0.beta.3 (2019-03-28)
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -344,6 +344,28 @@ module Pod
             message.should.include 'b/Tests (1.0) depends upon `b/App (1.0)`, which is a `app` spec'
         end
 
+        describe '#determine_platform' do
+          it 'respects the minimum deployment target' do
+            spec1 = stub('spec1')
+            spec1.stubs(:deployment_target).returns(Pod::Version.new('7.0'))
+            spec2 = stub('spec2')
+            spec2.stubs(:deployment_target).returns(Pod::Version.new('7.0'))
+            specs = [spec1, spec2]
+            result = Installer::Analyzer.send(:determine_platform, specs, :ios, false, Pod::Version.new('9.0'))
+            result.should == Pod::Platform.new(:ios, '9.0')
+          end
+
+          it 'returns 8.0 on iOS when host requires frameworks' do
+            spec1 = stub('spec1')
+            spec1.stubs(:deployment_target).returns(Pod::Version.new('6.0'))
+            spec2 = stub('spec2')
+            spec2.stubs(:deployment_target).returns(Pod::Version.new('6.0'))
+            specs = [spec1, spec2]
+            result = Installer::Analyzer.send(:determine_platform, specs, :ios, true, nil)
+            result.should == Pod::Platform.new(:ios, '8.0')
+          end
+        end
+
         describe 'with deduplicate targets as true' do
           before { Installer::InstallationOptions.any_instance.stubs(:deduplicate_targets? => true) }
 


### PR DESCRIPTION
Closes #7314

With this change, the deployment targets will be bumped to the minimum deployment target of the user targets into which they are installed.

Requires https://github.com/CocoaPods/cocoapods-integration-specs/pull/225