### PR TITLE
Allow insecure loads in requires_app_host's Info.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Allow insecure loads in requires_app_host's Info.plist  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#8747](https://github.com/CocoaPods/CocoaPods/pull/8747)
+
 * Fix a regression for static libraries with a custom module name  
   [Eric Amorde](https://github.com/amorde)
   [#8695](https://github.com/CocoaPods/CocoaPods/issues/8695)

--- a/lib/cocoapods/generator/info_plist_file.rb
+++ b/lib/cocoapods/generator/info_plist_file.rb
@@ -94,6 +94,10 @@ module Pod
           output << indent << "</dict>\n"
         when String
           output << indent << "<string>#{value}</string>\n"
+        when true
+          output << indent << "<true/>\n"
+        when false
+          output << indent << "<false/>\n"
         end
         output
       end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
@@ -74,7 +74,7 @@ module Pod
 
             Pod::Generator::AppTargetHelper.add_app_host_main_file(project, app_host_target, platform_name, @group, app_target_label) if add_main
             Pod::Generator::AppTargetHelper.add_launchscreen_storyboard(project, app_host_target, @group, deployment_target, app_target_label) if platform == :ios
-            additional_entries = platform == :ios ? ADDITIONAL_IOS_INFO_PLIST_ENTRIES : {}
+            additional_entries = ADDITIONAL_INFO_PLIST_ENTRIES.merge(platform == :ios ? ADDITIONAL_IOS_INFO_PLIST_ENTRIES : {})
             create_info_plist_file_with_sandbox(sandbox, app_host_info_plist_path, app_host_target, '1.0.0', platform,
                                                 :appl, additional_entries)
             @group.new_file(app_host_info_plist_path)
@@ -82,6 +82,12 @@ module Pod
           end
 
           private
+
+          ADDITIONAL_INFO_PLIST_ENTRIES = {
+            'NSAppTransportSecurity' => {
+              'NSAllowsArbitraryLoads' => true,
+            },
+          }.freeze
 
           ADDITIONAL_IOS_INFO_PLIST_ENTRIES = {
             'UILaunchStoryboardName' => 'LaunchScreen',

--- a/spec/unit/generator/info_plist_file_spec.rb
+++ b/spec/unit/generator/info_plist_file_spec.rb
@@ -105,6 +105,26 @@ module Pod
       PLIST
     end
 
+    it 'includes boolean values' do
+      generator = Generator::InfoPlistFile.new('1.0.0', Platform.new(:ios, '6.0'))
+      generator.send(:to_plist, 'MyDictionary' => { 'MyTrue' => true, 'MyFalse' => false
+                                                  }).should == <<-PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>MyDictionary</key>
+  <dict>
+    <key>MyFalse</key>
+    <false/>
+    <key>MyTrue</key>
+    <true/>
+  </dict>
+</dict>
+</plist>
+      PLIST
+    end
+
     it 'uses the specified bundle_package_type' do
       generator = Generator::InfoPlistFile.new('1.0.0', Platform.new(:ios, '6.0'), :bndl)
       file = temporary_directory + 'Info.plist'


### PR DESCRIPTION
Allow insecure loads in requires_app_host's Info.plist so that tests that depend http loading will pass.

This is necessary for the GULNetworkTests in GoogleUtilities.podspec to pass when using test_spec's. See https://github.com/firebase/firebase-ios-sdk/pull/2908

More context in https://stackoverflow.com/a/31807139/556617

If this is an acceptable solution, I'll follow up with the Changelog and integration test updates. 