### PR TITLE
Skip the "install_framework" step for "Debug" configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Add support for pods in abstract-only targets to be installed.  
   [Samuel Giddins](https://github.com/segiddins)
+  
+  * Skip the "install_framework" step for "Debug" configuration  
+  [icecrystal23](https://github.com/icecrystal23)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -207,7 +207,7 @@ module Pod
         SH
         script << "\n" unless frameworks_by_config.values.all?(&:empty?)
         frameworks_by_config.each do |config, frameworks_with_dsyms|
-          next if frameworks_with_dsyms.empty?
+          next if frameworks_with_dsyms.empty? || config == "Debug"
           script << %(if [[ "$CONFIGURATION" == "#{config}" ]]; then\n)
           frameworks_with_dsyms.each do |framework_with_dsym|
             script << %(  install_framework "#{framework_with_dsym.source_path}"\n)

--- a/spec/unit/generator/embed_frameworks_script_spec.rb
+++ b/spec/unit/generator/embed_frameworks_script_spec.rb
@@ -4,13 +4,13 @@ module Pod
   describe Generator::EmbedFrameworksScript do
     it 'returns the embed frameworks script' do
       frameworks = {
-        'Debug' => [Target::FrameworkPaths.new('Pods/Loopback.framework', 'Pods/Loopback.framework.dSYM', ['7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap', 'B724D6B4-C7DD-31F0-80C6-EE818ED30B0B.bcsymbolmap']),
+        'Release' => [Target::FrameworkPaths.new('Pods/Loopback.framework', 'Pods/Loopback.framework.dSYM', ['7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap', 'B724D6B4-C7DD-31F0-80C6-EE818ED30B0B.bcsymbolmap']),
                     Target::FrameworkPaths.new('Reveal.framework')],
-        'Release' => [Target::FrameworkPaths.new('CrashlyticsFramework.framework')],
+        'Debug' => [Target::FrameworkPaths.new('CrashlyticsFramework.framework')],
       }
       generator = Pod::Generator::EmbedFrameworksScript.new(frameworks)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        if [[ "$CONFIGURATION" == "Debug" ]]; then
+        if [[ "$CONFIGURATION" == "Release" ]]; then
           install_framework "Pods/Loopback.framework"
           install_dsym "Pods/Loopback.framework.dSYM"
           install_bcsymbolmap "7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap"
@@ -18,8 +18,8 @@ module Pod
           install_framework "Reveal.framework"
         fi
       SH
-      generator.send(:script).should.include <<-SH.strip_heredoc
-        if [[ "$CONFIGURATION" == "Release" ]]; then
+      generator.send(:script).should.not.include <<-SH.strip_heredoc
+        if [[ "$CONFIGURATION" == "Debug" ]]; then
           install_framework "CrashlyticsFramework.framework"
         fi
       SH

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -451,6 +451,7 @@ module Pod
                 script_path = @watermelon_pod_target.embed_frameworks_script_path_for_spec(@watermelon_pod_target.test_specs.first)
                 script = script_path.read
                 @watermelon_pod_target.user_build_configurations.keys.each do |configuration|
+                  next if configuration == "Debug"
                   script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "#{configuration}" ]]; then
           install_framework "${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework"
@@ -465,6 +466,7 @@ module Pod
                 script_path = @watermelon_pod_target.embed_frameworks_script_path_for_spec(@watermelon_pod_target.app_specs.first)
                 script = script_path.read
                 @watermelon_pod_target.user_build_configurations.keys.each do |configuration|
+                  next if configuration == "Debug"
                   script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "#{configuration}" ]]; then
           install_framework "${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework"


### PR DESCRIPTION
The "install_framework" step is not necessary for running Debug builds.  Skipping this script in "Debug" configuration saves us a lot of time when running Debug builds, as we have a lot of frameworks included.