### PR TITLE
Prevent warning with optional #include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   `Copy Resources` scripts will copy the necessary build artifacts.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* No longer show a warning when using an optional include (`#include?`) to
+  include the Pods .xcconfig from the base .xcconfig file
+  [Rob Hudson](https://github.com/robtimp)
 
 ## 1.7.0.beta.3 (2019-03-28)
 

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator/xcconfig_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator/xcconfig_integrator.rb
@@ -112,7 +112,7 @@ module Pod
             regex = %r{
               ^(
                 (\s*                                  # Possible, but unlikely, space before include statement
-                  \#include\s+                        # Include statement
+                  \#include(\?)?\s+                   # Include statement
                   ['"]                                # Open quote
                   (.*\/)?                             # Possible prefix to path
                   #{Regexp.quote(target_config_path)} # The path should end in the target_config_path


### PR DESCRIPTION
Optional include statements are possible in .xcconfig files:

`#include? "/Target Support Files/Pods-SampleProject/Pods-SampleProject.debug.xcconfig"`

However, this currently generates a warning:

```
[!] CocoaPods did not set the base configuration of your project because your project already has a custom config set. In order for CocoaPods integration to work at all, please either set the base configurations of the target `SampleProject` to `Target Support Files/Pods-SampleProject/Pods-SampleProject.debug.xcconfig` or include the `Target Support Files/Pods-SampleProject/Pods-SampleProject.debug.xcconfig` in your build configuration (`SampleProject.xcconfig`).
```

The warning is inaccurate, because the integration does succeed. Adding an optional question mark to the regex pattern should prevent this.