### PR TITLE
Fix 1.7.0.rc.1 static library regression for header_dir attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix 1.7.0.rc.1 static library regression for pods with `header_dir` attribute  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#8765](https://github.com/CocoaPods/CocoaPods/issues/8765)
+
 * Ensure all embedded pod targets are copied over to the host target.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
-  [#8608](https://github.com/CocoaPods/CocoaPods/issues/8608) 
-
+  [#8608](https://github.com/CocoaPods/CocoaPods/issues/8608)
 
 ## 1.7.0.rc.1 (2019-05-02)
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -150,7 +150,11 @@ module Pod
     # @return [Pathname] the pathname for headers in the sandbox.
     #
     def headers_sandbox
-      Pathname.new(product_module_name)
+      if root_spec.attributes_hash.key?('header_dir')
+        Pathname.new(pod_name)
+      else
+        Pathname.new(product_module_name)
+      end
     end
 
     # @return [Hash{FileAccessor => Hash}] Hash of file accessors by header mappings.

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -150,7 +150,7 @@ module Pod
     # @return [Pathname] the pathname for headers in the sandbox.
     #
     def headers_sandbox
-      if root_spec.attributes_hash.key?('header_dir')
+      if root_spec.consumer(platform).header_dir
         Pathname.new(pod_name)
       else
         Pathname.new(product_module_name)

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -467,8 +467,9 @@ module Pod
           @analysis_result = Installer::Analyzer::AnalysisResult.new(Pod::Installer::Analyzer::SpecsState.new, {}, {},
                                                                      [], Pod::Installer::Analyzer::SpecsState.new, [], [],
                                                                      Installer::Analyzer::PodfileDependencyCache.from_podfile(@installer.podfile))
+          @consumer = stub(:header_dir => 'myDir')
           @spec = stub(:name => 'Spec', :test_specification? => false, :library_specification? => true, :non_library_specification? => false,
-                       :app_specification? => false, :attributes_hash => {})
+                       :app_specification? => false, :consumer => @consumer)
           @spec.stubs(:root => @spec)
           @spec.stubs(:spec_type).returns(:library)
           @spec.stubs(:module_name => 'Spec')

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -467,7 +467,8 @@ module Pod
           @analysis_result = Installer::Analyzer::AnalysisResult.new(Pod::Installer::Analyzer::SpecsState.new, {}, {},
                                                                      [], Pod::Installer::Analyzer::SpecsState.new, [], [],
                                                                      Installer::Analyzer::PodfileDependencyCache.from_podfile(@installer.podfile))
-          @spec = stub(:name => 'Spec', :test_specification? => false, :library_specification? => true, :non_library_specification? => false, :app_specification? => false)
+          @spec = stub(:name => 'Spec', :test_specification? => false, :library_specification? => true, :non_library_specification? => false,
+                       :app_specification? => false, :attributes_hash => {})
           @spec.stubs(:root => @spec)
           @spec.stubs(:spec_type).returns(:library)
           @spec.stubs(:module_name => 'Spec')

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -107,7 +107,8 @@ module Pod
 
         it 'returns the correct path when headers_dir is set' do
           @pod_target.stubs(:product_module_name).returns('BananaLibModule')
-          @banana_spec.attributes_hash.stubs(:key?).returns(true)
+          @file_accessor = @pod_target.file_accessors.first
+          @file_accessor.spec_consumer.stubs(:header_dir).returns('Sub_dir')
           @pod_target.headers_sandbox.should == Pathname.new('BananaLib')
         end
       end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -104,6 +104,12 @@ module Pod
           @pod_target.stubs(:product_module_name).returns('BananaLibModule')
           @pod_target.headers_sandbox.should == Pathname.new('BananaLibModule')
         end
+
+        it 'returns the correct path when headers_dir is set' do
+          @pod_target.stubs(:product_module_name).returns('BananaLibModule')
+          @banana_spec.attributes_hash.stubs(:key?).returns(true)
+          @pod_target.headers_sandbox.should == Pathname.new('BananaLib')
+        end
       end
 
       describe '#build_settings_for_spec' do


### PR DESCRIPTION
Fix #8765

#8706 introduced a bug building pods with the `header_dir` attribute as static libraries. This is a minimal fix for that issue.