### PR TITLE
Don't add resources to a 2nd pod target build phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Don't add resources to a second test_spec pod target build phase  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#8173](https://github.com/CocoaPods/CocoaPods/issues/8173)
+
 * Fix 1.7.0.rc.1 static library regression for pods with `header_dir` attribute  
   [Paul Beusterien](https://github.com/paulb777)
   [#8765](https://github.com/CocoaPods/CocoaPods/issues/8765)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -367,13 +367,14 @@ module Pod
     end
 
     # @return [Hash{String=>Array<String>}] The resource and resource bundle paths this target depends upon keyed by
-    #         spec name.
+    #         spec name. Resources for app specs and test specs are directly added to “Copy Bundle Resources” phase
+    #         from the generated targets therefore they are not part of the resource paths.
     #
     def resource_paths
       @resource_paths ||= begin
         file_accessors.each_with_object({}) do |file_accessor, hash|
           resource_paths = file_accessor.resources.map { |res| "${PODS_ROOT}/#{res.relative_path_from(sandbox.project_path.dirname)}" }
-          resource_paths = [] if file_accessor.spec.app_specification?
+          resource_paths = [] if file_accessor.spec.non_library_specification?
           prefix = Pod::Target::BuildSettings::CONFIGURATION_BUILD_DIR_VARIABLE
           prefix = configuration_build_dir unless file_accessor.spec.test_specification?
           resource_bundle_paths = file_accessor.resource_bundles.keys.map { |name| "#{prefix}/#{name.shellescape}.bundle" }

--- a/spec/fixtures/watermelon-lib/WatermelonLib.podspec
+++ b/spec/fixtures/watermelon-lib/WatermelonLib.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.test_spec do |test_spec|
     test_spec.source_files = 'Tests/*.{h,m,swift}'
     test_spec.dependency 'OCMock'
+    test_spec.resources = 'App/*.txt'
     test_spec.resource_bundle = { 'WatermelonLibTestResources' => ['Tests/Resources/**/*'] }
   end
 


### PR DESCRIPTION
Fix #8173

test_spec resources are already copied in `Copy Bundle Resources`. Don't copy them in `Copy Pods Resources`.

