### PR TITLE
🌈 Fix embedding static frameworks in extensions while using `use_frameworks!`  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8585](https://github.com/CocoaPods/CocoaPods/pull/8585)
 
+* Fix embedding static frameworks in extensions while using `use_frameworks!`  
+  [Martin Fiebig](https://github.com/mfiebig)
 
 ## 1.7.0.rc.1 (2019-05-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Fix embedding static frameworks in extensions while using `use_frameworks!`  
   [Martin Fiebig](https://github.com/mfiebig)
+  [#8798](https://github.com/CocoaPods/CocoaPods/pull/8798)
 
 ## 1.7.0.rc.1 (2019-05-02)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -303,7 +303,8 @@ module Pod
             pod_target_names = Set.new(aggregate_target.pod_targets_for_build_configuration(configuration_name).map(&:name))
             embedded_pod_targets = embedded_aggregate_target.pod_targets_for_build_configuration(configuration_name).select do |pod_target|
               if !pod_target_names.include?(pod_target.name) &&
-                 aggregate_target.pod_targets.none? { |aggregate_pod_target| (pod_target.specs - aggregate_pod_target.specs).empty? }
+                 aggregate_target.pod_targets.none? { |aggregate_pod_target| (pod_target.specs - aggregate_pod_target.specs).empty? } &&
+                 (libraries_only || pod_target.build_as_dynamic?)
                 pod_target.name
               end
             end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -1162,6 +1162,37 @@ module Pod
           ].sort
         end
 
+        it 'does not copy extension pod targets to host target, when use_frameworks! but contained pod is static' do
+          SpecHelper.create_sample_app_copy_from_fixture('Sample Extensions Project')
+          fixture_path = ROOT + 'spec/fixtures'
+          podfile = Pod::Podfile.new do
+            source SpecHelper.test_repo_url
+            platform :ios, '6.0'
+            project 'Sample Extensions Project/Sample Extensions Project'
+            use_frameworks!
+
+            target 'Sample Extensions Project' do
+              pod 'JSONKit', '1.4'
+            end
+
+            target 'Today Extension' do
+              pod 'matryoshka', :path => (fixture_path + 'static-matryoshka').to_s
+            end
+          end
+
+          analyzer = Pod::Installer::Analyzer.new(config.sandbox, podfile)
+          # Create 'Local Podspecs' folder within target project
+          Dir.mkdir(File.join(config.sandbox.root, 'Local Podspecs'))
+          result = analyzer.analyze
+
+          result.targets.flat_map { |at| at.pod_targets.map { |pt| "#{at.name}/#{pt.name}" } }.sort.should == [
+            'Pods-Sample Extensions Project/JSONKit',
+            'Pods-Sample Extensions Project/monkey',
+            'Pods-Today Extension/monkey',
+            'Pods-Today Extension/matryoshka',
+          ].sort
+        end
+
         it 'copies pod targets of frameworks and libraries from within sub projects' do
           podfile = Pod::Podfile.new do
             source SpecHelper.test_repo_url


### PR DESCRIPTION
### Motivation and Context

Using a framework within an extension results in cocoapods linking the framework to the main app target. If the framework is static this should not happen if the framework is only used within the extension.

### Description

I added a unit test `does not copy extension pod targets to host target, when use_frameworks! but contained pod is static` to test the behaviour and changed the code accordingly.

I'm uncertain if the test is written appropriately and if the place for the fix is sufficient. Feedback is very welcome :)
