### PR TITLE
1.7.0.rc.2 regression - library test spec resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix 1.7.0.rc.2 regression - Resources need to be added for test specs in library builds  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#8812](https://github.com/CocoaPods/CocoaPods/pull/8812)
 
 
 ## 1.7.0.rc.2 (2019-05-15)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -371,13 +371,13 @@ module Pod
 
     # @return [Hash{String=>Array<String>}] The resource and resource bundle paths this target depends upon keyed by
     #         spec name. Resources for app specs and test specs are directly added to “Copy Bundle Resources” phase
-    #         from the generated targets therefore they are not part of the resource paths.
+    #         from the generated targets for frameworks, but not libraries. Therefore they are not part of the resource paths.
     #
     def resource_paths
       @resource_paths ||= begin
         file_accessors.each_with_object({}) do |file_accessor, hash|
           resource_paths = file_accessor.resources.map { |res| "${PODS_ROOT}/#{res.relative_path_from(sandbox.project_path.dirname)}" }
-          resource_paths = [] if file_accessor.spec.non_library_specification?
+          resource_paths = [] if file_accessor.spec.non_library_specification? && build_as_framework?
           prefix = Pod::Target::BuildSettings::CONFIGURATION_BUILD_DIR_VARIABLE
           prefix = configuration_build_dir unless file_accessor.spec.test_specification?
           resource_bundle_paths = file_accessor.resource_bundles.keys.map { |name| "#{prefix}/#{name.shellescape}.bundle" }

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -473,26 +473,28 @@ module Pod
                 end
               end
 
-              it 'adds the resources bundles for to the copy resources script for test target' do
+              it 'adds the resources bundles to the copy resources script for test target' do
                 @installer.install!
                 script_path = @watermelon_pod_target.copy_resources_script_path_for_spec(@watermelon_spec.test_specs.first)
                 script = script_path.read
                 @watermelon_pod_target.user_build_configurations.keys.each do |configuration|
                   script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "#{configuration}" ]]; then
+          install_resource "${PODS_ROOT}/../../spec/fixtures/watermelon-lib/App/resource.txt"
           install_resource "${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLibTestResources.bundle"
         fi
                   eos
                 end
               end
 
-              it 'adds the resources bundles for to the copy resources script for app target' do
+              it 'adds the resources bundles to the copy resources script for app target' do
                 @installer.install!
                 script_path = @watermelon_pod_target.copy_resources_script_path_for_spec(@watermelon_spec.app_specs.first)
                 script = script_path.read
                 @watermelon_pod_target.user_build_configurations.keys.each do |configuration|
                   script.should.include <<-eos.strip_heredoc
         if [[ "$CONFIGURATION" == "#{configuration}" ]]; then
+          install_resource "${PODS_ROOT}/../../spec/fixtures/watermelon-lib/App/resource.txt"
           install_resource "${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLibExampleAppResources.bundle"
         fi
                   eos

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -709,6 +709,18 @@ module Pod
           }
         end
 
+        it 'returns the correct resource paths for use_libraries' do
+          @watermelon_pod_target.stubs(:build_as_framework?).returns(false)
+          @watermelon_pod_target.resource_paths.should == {
+            'WatermelonLib' => [],
+            'WatermelonLib/Tests' => ['${PODS_ROOT}/../../spec/fixtures/watermelon-lib/App/resource.txt',
+                                      '${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLibTestResources.bundle'],
+            'WatermelonLib/SnapshotTests' => [],
+            'WatermelonLib/App' => ['${PODS_ROOT}/../../spec/fixtures/watermelon-lib/App/resource.txt',
+                                    '${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLibExampleAppResources.bundle'],
+          }
+        end
+
         it 'returns the correct framework paths' do
           @watermelon_pod_target.framework_paths.should == {
             'WatermelonLib' => [


### PR DESCRIPTION
Resources need to be added for test specs in library builds since libraries are excluded from the resource copy part of `add_files_to_build_phases`.

This fixes a regression introduced in #8782