### PR TITLE
Clean stale local podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Configure schemes regardless if they are being shared or not.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8815](https://github.com/CocoaPods/CocoaPods/pull/8815)
+* Remove stale podspecs from 'Local Podspecs' when installing non-local counterparts.
+  [Pär Strindevall](https://github.com/parski)
 
 
 ## 1.7.0.rc.2 (2019-05-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Configure schemes regardless if they are being shared or not.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8815](https://github.com/CocoaPods/CocoaPods/pull/8815)
-* Remove stale podspecs from 'Local Podspecs' when installing non-local counterparts.
+* Remove stale podspecs from 'Local Podspecs' when installing non-local counterparts.  
   [Pär Strindevall](https://github.com/parski)
 
 

--- a/lib/cocoapods/installer/pod_source_installer.rb
+++ b/lib/cocoapods/installer/pod_source_installer.rb
@@ -61,6 +61,7 @@ module Pod
       def install!
         download_source unless predownloaded? || local?
         PodSourcePreparer.new(root_spec, root).prepare! if local?
+        sandbox.remove_local_podspec(name) unless local?
       end
 
       # Cleans the installations if appropriate.

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -379,6 +379,18 @@ module Pod
       checkout_sources.delete(root_name)
     end
 
+    # Removes local podspec a Pod.
+    #
+    # @param  [String] name
+    #         The name of the Pod.
+    #
+    # @return [void]
+    #
+    def remove_local_podspec(name)
+      local_podspec = specification_path(name)
+      FileUtils.rm(local_podspec) if local_podspec
+    end
+
     # @return [Hash{String=>Hash}] The options necessary to recreate the exact
     #         checkout of a given Pod grouped by its name.
     #

--- a/spec/unit/installer/pod_source_installer_spec.rb
+++ b/spec/unit/installer/pod_source_installer_spec.rb
@@ -28,6 +28,12 @@ module Pod
           pod_folder = config.sandbox.pod_dir('BananaLib')
           pod_folder.should.exist
         end
+
+        it 'removes local podspec' do
+          @spec.source = { :git => SpecHelper.fixture('banana-lib'), :tag => 'v1.0' }
+          config.sandbox.expects(:remove_local_podspec).with('BananaLib').once
+          @installer.install!
+        end
       end
 
       it 'does not show warning if the source is encrypted using https' do

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -175,6 +175,13 @@ module Pod
         @sandbox.checkout_sources.should == { 'BananaLib' => source }
       end
 
+      it 'removes local podspec of a Pod' do
+        local_podspec_path = 'Some Path/Local Pods/BananaLib.podspec'
+        @sandbox.stubs(:specification_path).returns(local_podspec_path)
+        FileUtils.expects(:rm).with(local_podspec_path).once
+        @sandbox.remove_local_podspec('BananaLib')
+      end
+
       #--------------------------------------#
 
       it 'stores the local path of a Pod' do


### PR DESCRIPTION
**Bug**:

When installing a Pod from a local source a podspec appears in `${PODS_ROOT}/Local Podspecs/`.

Example:
```ruby
pod 'Alamofire', :path => '../Alamofire'
```
After a `pod install` leaves you with `<App>/Pods/Local Podspecs/Alamofire.podspec.json`.

Now when you install a non-local version of the same pod the local podspec remains, stale as a driftwood log.