### PR TITLE
Fix a regression in static library header dir paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix a 1.7.0 regression in header directory paths when using static libraries  
+  [Eric Amorde](https://github.com/amorde)
+  [#8836](https://github.com/CocoaPods/CocoaPods/issues/8836)
 
 
 ## 1.7.0 (2019-05-22)

--- a/lib/cocoapods/installer/sandbox_dir_cleaner.rb
+++ b/lib/cocoapods/installer/sandbox_dir_cleaner.rb
@@ -50,7 +50,10 @@ module Pod
             if pod_target.public_header_mappings_by_file_accessor.empty?
               []
             else
-              [sandbox.public_headers.root.join(pod_target.headers_sandbox)]
+              [
+                sandbox.public_headers.root.join(pod_target.headers_sandbox),
+                pod_target.module_map_path.dirname,
+              ].uniq
             end
           end
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -153,11 +153,7 @@ module Pod
     # @return [Pathname] the pathname for headers in the sandbox.
     #
     def headers_sandbox
-      if root_spec.consumer(platform).header_dir
-        Pathname.new(pod_name)
-      else
-        Pathname.new(product_module_name)
-      end
+      Pathname.new(pod_name)
     end
 
     # @return [Hash{FileAccessor => Hash}] Hash of file accessors by header mappings.

--- a/spec/unit/installer/sandbox_dir_cleaner_spec.rb
+++ b/spec/unit/installer/sandbox_dir_cleaner_spec.rb
@@ -4,13 +4,17 @@ module Pod
   describe Installer::SandboxDirCleaner do
     before do
       @pod_target = fixture_pod_target('banana-lib/BananaLib.podspec')
+      spec = fixture_spec('coconut-lib/CoconutLib.podspec')
+      spec.module_name = 'CoconutLibModule'
+      @other_pod_target = fixture_pod_target_with_specs([spec])
       @aggregate_target = AggregateTarget.new(config.sandbox, false, {}, [], Platform.ios,
                                               fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
                                               nil, {})
-      @cleaner = Installer::SandboxDirCleaner.new(config.sandbox, [@pod_target], [@aggregate_target])
+      @cleaner = Installer::SandboxDirCleaner.new(config.sandbox, [@pod_target, @other_pod_target], [@aggregate_target])
       @project = Project.new(config.sandbox.project_path)
       @sandbox = config.sandbox
       FileUtils.mkdir_p(@sandbox.target_support_files_dir(@pod_target.name))
+      FileUtils.mkdir_p(@sandbox.target_support_files_dir(@other_pod_target.name))
       FileUtils.mkdir_p(@sandbox.target_support_files_dir(@aggregate_target.name))
     end
 
@@ -32,15 +36,25 @@ module Pod
       random_pod_public_headers = @sandbox.public_headers.root.join('PublicPod')
       banana_lib_public_headers = @sandbox.public_headers.root.join('BananaLib')
       banana_lib_private_headers = @pod_target.build_headers.root.join('BananaLib')
+      coconut_lib_public_headers = @sandbox.public_headers.root.join('CoconutLibModule')
+      coconut_lib_private_headers = @pod_target.build_headers.root.join('CoconutLibModule')
       FileUtils.mkdir_p(random_pod_private_headers)
       FileUtils.mkdir_p(random_pod_public_headers)
       FileUtils.mkdir_p(banana_lib_public_headers)
       FileUtils.mkdir_p(banana_lib_private_headers)
+      FileUtils.mkdir_p(coconut_lib_public_headers)
+      FileUtils.mkdir_p(coconut_lib_private_headers)
       @cleaner.expects(:remove_dir).with(random_pod_private_headers)
       @cleaner.expects(:remove_dir).with(random_pod_public_headers)
+      @cleaner.expects(:remove_dir).with(coconut_lib_public_headers).never
+      @cleaner.expects(:remove_dir).with(coconut_lib_private_headers)
       @cleaner.clean!
-      banana_lib_public_headers.should.exist?
-      banana_lib_private_headers.should.exist?
+      FileUtils.rm_rf(random_pod_private_headers)
+      FileUtils.rm_rf(random_pod_public_headers)
+      FileUtils.rm_rf(banana_lib_public_headers)
+      FileUtils.rm_rf(banana_lib_private_headers)
+      FileUtils.rm_rf(coconut_lib_public_headers)
+      FileUtils.rm_rf(coconut_lib_private_headers)
     end
   end
 end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -102,7 +102,7 @@ module Pod
 
         it 'returns the correct path when a custom module name is set' do
           @pod_target.stubs(:product_module_name).returns('BananaLibModule')
-          @pod_target.headers_sandbox.should == Pathname.new('BananaLibModule')
+          @pod_target.headers_sandbox.should == Pathname.new('BananaLib')
         end
 
         it 'returns the correct path when headers_dir is set' do


### PR DESCRIPTION
Closes #8836

Original implementation in #8706 was a bit heavy handed - we can get the same bug fix by adjusting the behavior of the sandbox cleaner.