### PR TITLE
Stabilize Product Reference UUIDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Stabilize product reference UUIDs to fix Xcode crashing with incremental installation.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#8845](https://github.com/CocoaPods/CocoaPods/pull/8845)
+
 * Fix a 1.7.0 regression in header directory paths when using static libraries  
   [Eric Amorde](https://github.com/amorde)
   [#8836](https://github.com/CocoaPods/CocoaPods/issues/8836)

--- a/lib/cocoapods/installer/target_uuid_generator.rb
+++ b/lib/cocoapods/installer/target_uuid_generator.rb
@@ -20,8 +20,7 @@ module Pod
           project.targets.each do |target|
             @paths_by_object[target] = Digest::MD5.hexdigest(project_basename + target.name).upcase
             if target.is_a? Xcodeproj::Project::Object::PBXNativeTarget
-              target_product_reference = target.product_reference
-              @paths_by_object[target_product_reference] = Digest::MD5.hexdigest(project_basename + 'product_reference' + target_product_reference.display_name).upcase
+              @paths_by_object[target.product_reference] = Digest::MD5.hexdigest(project_basename + 'product_reference' + target.name).upcase
             end
           end
         end

--- a/lib/cocoapods/version_metadata.rb
+++ b/lib/cocoapods/version_metadata.rb
@@ -1,6 +1,6 @@
 module Pod
   module VersionMetadata
-    CACHE_VERSION = '001'.freeze
+    CACHE_VERSION = '002'.freeze
 
     def self.gem_version
       Pod::VERSION

--- a/spec/unit/installer/target_uuid_generator_spec.rb
+++ b/spec/unit/installer/target_uuid_generator_spec.rb
@@ -10,7 +10,9 @@ module Pod
       end
 
       it 'generates stable UUIDs for native targets and its product references' do
-        Digest::MD5.stubs(:hexdigest).returns('CLEANSOAP')
+        Digest('MD5').expects(:hexdigest).with('Project.xcodeprojNativeTarget1').returns('CLEANSOAP')
+        Digest('MD5').expects(:hexdigest).with('Project.xcodeprojproduct_referenceNativeTarget1').returns('CLEANSOAP')
+
         @target_uuid_generator.generate!
         @project.targets.each do |target|
           target.uuid.should.equal 'CLEANSOAP'

--- a/spec/unit/installer/target_uuid_generator_spec.rb
+++ b/spec/unit/installer/target_uuid_generator_spec.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  class Installer
+    describe TargetUUIDGenerator do
+      before do
+        @project = Project.new('Project.xcodeproj')
+        @project.new_target(:static_library, 'NativeTarget1', :ios)
+        @target_uuid_generator = TargetUUIDGenerator.new(@project)
+      end
+
+      it 'generates stable UUIDs for native targets and its product references' do
+        Digest::MD5.stubs(:hexdigest).returns('CLEANSOAP')
+        @target_uuid_generator.generate!
+        @project.targets.each do |target|
+          target.uuid.should.equal 'CLEANSOAP'
+          target.product_reference.uuid.should.equal 'CLEANSOAP'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In addition to `PBXNativeTarget` UUIDs being referenced via `remoteGlobalIDString` from other projects, so can the `PBXFileReference` that points to the binaries under the `Products` group. If these UUIDs are not deterministic, then during incremental installation, the UUID for the file reference that pointed to the binary can be changed, resulting in parent project crashing because its `remoteGlobalIDString` might end up pointing to a different object entirely.