### PR TITLE
Include the commit of CocoaPods in the cache version (when available)

### DIFF
--- a/lib/cocoapods/version_metadata.rb
+++ b/lib/cocoapods/version_metadata.rb
@@ -7,7 +7,20 @@ module Pod
     end
 
     def self.project_cache_version
-      "#{VersionMetadata.gem_version}.project-cache.#{CACHE_VERSION}"
+      [
+        gem_version,
+        cocoapods_sha,
+        'project-cache',
+        CACHE_VERSION,
+      ].compact.join('.')
     end
+
+    def self.cocoapods_sha
+      return unless gemspec = Gem.loaded_specs['cocoapods']
+      return unless source = gemspec.source
+      return unless source.respond_to?(:revision)
+      source.revision
+    end
+    private_class_method :cocoapods_sha
   end
 end


### PR DESCRIPTION
This will cause the cache to be ignore when those consuming CocoaPods via a git dependency in their Gemfile update to a different commit within the same version series