### PR TITLE
Added option to only download Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8983](https://github.com/CocoaPods/CocoaPods/pull/8983)
 
+* Added option to skip Pods.xcodeproj generation
+  [Itay Brenner](https://github.com/itaybre)
+  [8872](https://github.com/CocoaPods/CocoaPods/pull/8872)
+
 ##### Bug Fixes
 
 * Make CDNSource show up in `pod repo env`  
@@ -118,7 +122,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* None.
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8983](https://github.com/CocoaPods/CocoaPods/pull/8983)
 
-* Added option to skip Pods.xcodeproj generation
+* Added option to skip Pods.xcodeproj generation  
   [Itay Brenner](https://github.com/itaybre)
   [8872](https://github.com/CocoaPods/CocoaPods/pull/8872)
 
@@ -122,7 +122,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.
+* None.  
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -156,13 +156,26 @@ module Pod
       resolve_dependencies
       download_dependencies
       validate_targets
+      if installation_options.skip_pods_project_generation?
+        show_skip_pods_project_generation_message
+      else
+        integrate
+      end
+      perform_post_install_actions
+    end
+
+    def show_skip_pods_project_generation_message
+      UI.section 'Skipping Pods Project Creation'
+      UI.section 'Skipping User Project Integration'
+    end
+
+    def integrate
       generate_pods_project
       if installation_options.integrate_targets?
         integrate_user_project
       else
         UI.section 'Skipping User Project Integration'
       end
-      perform_post_install_actions
     end
 
     def analyze_project_cache

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -181,6 +181,10 @@ module Pod
       # since the previous installation.
       #
       option :incremental_installation, false
+
+      # Whether to skip generating the `Pods.xcodeproj` and perform only dependency resolution and downloading.
+      #
+      option :skip_pods_project_generation, false
     end
   end
 end

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -70,6 +70,7 @@ module Pod
           'preserve_pod_file_structure' => false,
           'generate_multiple_pod_projects' => false,
           'incremental_installation' => false,
+          'skip_pods_project_generation' => false,
         }
       end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -288,16 +288,15 @@ module Pod
 
       it "doesn't generate Pods.xcodeproj if skip_pods_project_generation is true" do
         @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new(:skip_pods_project_generation => true))
-        @installer.expects(:regular_intergration).never
+        @installer.expects(:integrate).never
         @installer.install!
-        UI.output.should.include 'Just Download option enabled'
         UI.output.should.include 'Skipping Pods Project Creation'
         UI.output.should.include 'Skipping User Project Integration'
       end
 
       it 'generates Pods.xcodeproj if skip_pods_project_generation is not set' do
         @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new)
-        @installer.expects(:regular_intergration).once
+        @installer.expects(:integrate).once
         @installer.install!
       end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -286,6 +286,21 @@ module Pod
         UI.output.should.include 'Skipping User Project Integration'
       end
 
+      it "doesn't generate Pods.xcodeproj if skip_pods_project_generation is true" do
+        @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new(:skip_pods_project_generation => true))
+        @installer.expects(:regular_intergration).never
+        @installer.install!
+        UI.output.should.include 'Just Download option enabled'
+        UI.output.should.include 'Skipping Pods Project Creation'
+        UI.output.should.include 'Skipping User Project Integration'
+      end
+
+      it 'generates Pods.xcodeproj if skip_pods_project_generation is not set' do
+        @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new)
+        @installer.expects(:regular_intergration).once
+        @installer.install!
+      end
+
       it 'prints a list of deprecated pods' do
         spec = Spec.new
         spec.name = 'RestKit'


### PR DESCRIPTION
This new option `just_download` skips the Pods.xcodeproj generation

**How to use**
In the Podfile add:
```
install! 'cocoapods', just_download: true
```

Fix: #8683