### PR TITLE
Change the `module_map_path`, to make sure the custom modulemap have the same behavior between use_frameworks and modular_headers

### DIFF
--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -427,9 +427,9 @@ module Pod
       basename = "#{label}.modulemap"
       if build_as_framework?
         super
-      elsif file_accessors.any?(&:module_map)
-        build_headers.root + product_module_name + basename
       else
+        # modulemap should be placed at the same directory with all Public Headers.
+        # To let `export *` works and no Private Headers is exported outside.
         sandbox.public_headers.root + product_module_name + basename
       end
     end


### PR DESCRIPTION
See the issue's background and reason for chancing this:

#8879 

And our Pod who use custom modulemap, which face the issue because of this:

https://github.com/SDWebImage/SDWebImage/pull/2749