### PR TITLE
[PodTargetInstaller] Set Default Module for Storyboards in resource bundle targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   unless repo update was specifically requested.
   [Artem Sheremet](https://github.com/dotdoom)
 
+* Set Default Module for Storyboards in resource bundle targets.  
+   [James Treanor](https://github.com/jtreanor)
+   [#8890](https://github.com/CocoaPods/CocoaPods/pull/8890)
+
 ##### Bug Fixes
 
 * Fix set `cache_root` from config file error  

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -503,6 +503,10 @@ module Pod
                     configuration.build_settings['CONFIGURATION_BUILD_DIR'] = target.configuration_build_dir('$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)')
                   end
 
+                  # Set the 'IBSC_MODULE' build settings for resource bundles so that Storyboards and Xibs can load
+                  # classes from the parent module.
+                  configuration.build_settings['IBSC_MODULE'] = target.product_module_name
+
                   # Set the `SWIFT_VERSION` build setting for resource bundles that could have resources that get
                   # compiled such as an `xcdatamodeld` file which has 'Swift' as its code generation language.
                   if contains_compile_phase_refs && file_accessors.any? { |fa| target.uses_swift_for_spec?(fa.spec) }

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -857,6 +857,14 @@ module Pod
                   end
                 end
 
+                it 'sets the correct default module for storyboards in resource bundle targets' do
+                  @installer.install!
+                  @bundle_target = @project.targets.find { |t| t.name == 'BananaLib-Pods-SampleProject-banana_bundle' }
+                  @bundle_target.build_configurations.each do |bc|
+                    bc.build_settings['IBSC_MODULE'].should == 'BananaLib'
+                  end
+                end
+
                 it 'sets the Swift version build setting when resources bundle contains sources and target has Swift' do
                   @spec.resource_bundles = { 'banana_bundle' => ['Resources/**/*'] }
                   @spec.module_map = nil


### PR DESCRIPTION
🌈 If a storyboard or xib is included in a pod via `resource_bundles` and the bundle does not have the same name as the pod, the app can crash with an error like this:

```
2019-06-07 17:28:34.730781+0100 ResourceBundleIssue[78655:8535426] Unknown class _TtC20WordPressUIResources24FancyAlertViewController in Interface Builder file.
Could not cast value of type 'UIViewController' (0x110579a10) to 'WordPressUI.FancyAlertViewController' (0x103b95f38).
2019-06-07 17:28:34.732146+0100 ResourceBundleIssue[78655:8535426] Could not cast value of type 'UIViewController' (0x110579a10) to 'WordPressUI.FancyAlertViewController' (0x103b95f38).
```

This is because by default storyboards have this option checked for custom classes:

![image](https://user-images.githubusercontent.com/1773641/59119126-e9d24400-8949-11e9-8db5-30e27dcf6b3e.png)

Currently, the workaround is either to name the resource bundle the same as the pod or to uncheck that box and set an explicit module for every object in the Storyboard.

This PR makes using Storyboards from resource bundle's easier by setting the "Default Module" build setting for resource bundle targets to the module of the pod itself. Here is the setting in Xcode:

![image](https://user-images.githubusercontent.com/1773641/59119329-711fb780-894a-11e9-98d9-c6f65b7cea57.png)

