### PR TITLE
Attempt to use Swift version for dependencies during lint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8880](https://github.com/CocoaPods/CocoaPods/issues/8880)
 
+* Attempt to use Swift version for dependencies during lint.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8764](https://github.com/CocoaPods/CocoaPods/issues/8764)
+
 
 ## 1.7.1 (2019-05-30)
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -186,7 +186,7 @@ module Pod
     def swift_version
       @swift_version ||= begin
         if spec_swift_versions.empty?
-          target_definitions.map(&:swift_version).compact.uniq.first
+          target_definition_swift_version
         else
           spec_swift_versions.sort.reverse_each.find do |swift_version|
             target_definitions.all? do |td|
@@ -195,6 +195,13 @@ module Pod
           end.to_s
         end
       end
+    end
+
+    # @return [String] the Swift version derived from the target definitions that integrate this pod. This is used for
+    #         legacy reasons and only if the pod author has not specified the Swift versions their pod supports.
+    #
+    def target_definition_swift_version
+      target_definitions.map(&:swift_version).compact.uniq.first
     end
 
     # @return [Array<Version>] the Swift versions supported. Might be empty if the author has not

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1302,8 +1302,7 @@ module Pod
           native_target = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration]))
           pod_target = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
           pod_target_installation_one = stub(:target => pod_target, :native_target => native_target,
-                                             :test_native_targets => [],
-                                             :test_specs_by_native_target => {})
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_results = { 'JSONKit' => pod_target_installation_one }
           aggregate_target = stub(:pod_targets => [pod_target])
           installer = stub(:pod_targets => [pod_target])
@@ -1322,8 +1321,7 @@ module Pod
           native_target = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration]))
           pod_target = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
           pod_target_installation_one = stub(:target => pod_target, :native_target => native_target,
-                                             :test_native_targets => [],
-                                             :test_specs_by_native_target => {})
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_results = { 'JSONKit' => pod_target_installation_one }
           aggregate_target = stub(:pod_targets => [pod_target])
           installer = stub(:pod_targets => [pod_target])
@@ -1341,8 +1339,7 @@ module Pod
           native_target = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration]))
           pod_target = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
           pod_target_installation_one = stub(:target => pod_target, :native_target => native_target,
-                                             :test_native_targets => [],
-                                             :test_specs_by_native_target => {})
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_results = { 'JSONKit' => pod_target_installation_one }
           aggregate_target = stub(:pod_targets => [pod_target])
           installer = stub(:pod_targets => [pod_target])
@@ -1360,8 +1357,7 @@ module Pod
           native_target = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration]))
           pod_target = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
           pod_target_installation_one = stub(:target => pod_target, :native_target => native_target,
-                                             :test_native_targets => [],
-                                             :test_specs_by_native_target => {})
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_results = { 'JSONKit' => pod_target_installation_one }
           aggregate_target = stub(:pod_targets => [pod_target])
           installer = stub(:pod_targets => [pod_target])
@@ -1402,13 +1398,12 @@ module Pod
           native_target_one = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration_one]))
           native_target_two = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration_two]))
           pod_target_one = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
-          pod_target_two = stub(:name => 'Dependency', :uses_swift? => true, :pod_name => 'Dependency', :swift_version => '3.2')
+          pod_target_two = stub(:name => 'Dependency', :uses_swift? => true, :pod_name => 'Dependency',
+                                :spec_swift_versions => [], :target_definition_swift_version => '3.2')
           pod_target_installation_one = stub(:target => pod_target_one, :native_target => native_target_one,
-                                             :test_native_targets => [],
-                                             :test_specs_by_native_target => {})
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_two = stub(:target => pod_target_two, :native_target => native_target_two,
-                                             :test_native_targets => [],
-                                             :test_specs_by_native_target => {})
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_results = { 'PodTarget1' => pod_target_installation_one, 'PodTarget2' => pod_target_installation_two }
           aggregate_target = stub(:pod_targets => [pod_target_one, pod_target_two])
           installer = stub(:pod_targets => [pod_target_one, pod_target_two])
@@ -1416,6 +1411,30 @@ module Pod
           validator.send(:configure_pod_targets, [aggregate_target], [pod_target_installation_results], '9.0')
           debug_configuration_one.build_settings['SWIFT_VERSION'].should == '4.0'
           debug_configuration_two.build_settings['SWIFT_VERSION'].should == '3.2'
+        end
+
+        it 'honors the swift version set for dependencies if they support it' do
+          validator = test_swiftpod_with_swift_version_parameter('4.0')
+          consumer = stub(:platform_name => 'iOS')
+          validator.instance_variable_set(:@consumer, consumer)
+          debug_configuration_one = stub(:build_settings => {})
+          debug_configuration_two = stub(:build_settings => {})
+          native_target_one = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration_one]))
+          native_target_two = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration_two]))
+          pod_target_one = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
+          pod_target_two = stub(:name => 'Dependency', :uses_swift? => true, :pod_name => 'Dependency',
+                                :spec_swift_versions => ['4.0'], :target_definition_swift_version => '3.2')
+          pod_target_installation_one = stub(:target => pod_target_one, :native_target => native_target_one,
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
+          pod_target_installation_two = stub(:target => pod_target_two, :native_target => native_target_two,
+                                             :test_native_targets => [], :test_specs_by_native_target => {})
+          pod_target_installation_results = { 'PodTarget1' => pod_target_installation_one, 'PodTarget2' => pod_target_installation_two }
+          aggregate_target = stub(:pod_targets => [pod_target_one, pod_target_two])
+          installer = stub(:pod_targets => [pod_target_one, pod_target_two])
+          validator.instance_variable_set(:@installer, installer)
+          validator.send(:configure_pod_targets, [aggregate_target], [pod_target_installation_results], '9.0')
+          debug_configuration_one.build_settings['SWIFT_VERSION'].should == '4.0'
+          debug_configuration_two.build_settings['SWIFT_VERSION'].should == '4.0'
         end
       end
 


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/8764

During `lint`, pod authors can pass the Swift version their pod should be compiled with. However, this setting does not apply to dependencies which is fine generally. There is also no currently a way to define the `supports_swift_version` DSL since the target is completely generated and we have no way to determine the constraints unless they get passed in somehow.

This change will effectively _try_ to set the Swift version for dependencies _only if_ the original pod author has declared that they support it which should be safe to do so, otherwise we fall back to what we always did.

/cc @cnoon