### PR TITLE
fix CDN build delay

### DIFF
--- a/examples/Vendored Framework Example/Podfile
+++ b/examples/Vendored Framework Example/Podfile
@@ -1,3 +1,7 @@
+if (repo = ENV['COCOAPODS_SPEC_REPO'])
+  source "#{repo}"
+end
+
 platform :ios, '8.0'
 use_frameworks!
 


### PR DESCRIPTION
Fixes the long build times because `Vendored Framework Example` didn't use CDN source so it reverted to cloning git trunk.