### PR TITLE
[WIP] Add Swift version variant support.

### DIFF
--- a/lib/cocoapods/installer/analyzer/pod_variant.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant.rb
@@ -23,6 +23,10 @@ module Pod
         #
         attr_reader :build_type
 
+        # @return [String] the Swift version of the target.
+        #
+        attr_reader :swift_version
+
         # @return [Specification] the root specification
         #
         def root_spec
@@ -31,19 +35,22 @@ module Pod
 
         # Initialize a new instance from its attributes.
         #
-        # @param [Array<Specification>] specs      @see #specs
+        # @param [Array<Specification>] specs @see #specs
         # @param [Array<Specification>] test_specs @see #test_specs
-        # @param [Array<Specification>] app_specs  @see #app_specs
-        # @param [Platform] platform               @see #platform
-        # @param [Target::BuildType] build_type    @see #build_type
+        # @param [Array<Specification>] app_specs @see #app_specs
+        # @param [Platform] platform  @see #platform
+        # @param [Target::BuildType] build_type @see #build_type
+        # @param [String] swift_version @see #swift_version
         #
-        def initialize(specs, test_specs, app_specs, platform, build_type = Target::BuildType.static_library)
+        def initialize(specs, test_specs, app_specs, platform, build_type = Target::BuildType.static_library,
+                       swift_version = nil)
           @specs = specs
           @test_specs = test_specs
           @app_specs = app_specs
           @platform = platform
           @build_type = build_type
-          @hash = [specs, platform, build_type].hash
+          @swift_version = swift_version
+          @hash = [specs, platform, build_type, swift_version].hash
         end
 
         # @note Test specs are intentionally not included as part of the equality for pod variants since a
@@ -54,9 +61,10 @@ module Pod
         #
         def ==(other)
           self.class == other.class &&
-          build_type == other.build_type &&
-            platform == other.platform &&
-            specs == other.specs
+              build_type == other.build_type &&
+              swift_version == other.swift_version &&
+              platform == other.platform &&
+              specs == other.specs
         end
         alias_method :eql?, :==
 

--- a/lib/cocoapods/installer/analyzer/pod_variant_set.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant_set.rb
@@ -98,7 +98,16 @@ module Pod
             # => Platform name + SDK version
             platform_name_proc = proc { |v| v.platform.to_s.tr(' ', '') }
           end
-          scope_if_necessary(grouped_variants.map(&:scope_without_suffix), &platform_name_proc)
+          scope_if_necessary(grouped_variants.map(&:scope_by_swift_version), &platform_name_proc)
+        end
+
+        # @private
+        # @return [Hash<PodVariant, String>]
+        #
+        def scope_by_swift_version
+          scope_if_necessary(group_by(&:swift_version).map(&:scope_without_suffix)) do |variant|
+            variant.swift_version ? "Swift#{variant.swift_version}" : ''
+          end
         end
 
         # @private
@@ -113,7 +122,7 @@ module Pod
                      root_spec.default_subspecs.map do |subspec_name|
                        root_spec.subspec_by_name("#{root_spec.name}/#{subspec_name}")
                      end
-          end
+                   end
           default_specs = Set.new(specs)
           grouped_variants = group_by(&:specs)
           all_spec_variants = grouped_variants.map { |set| set.variants.first.specs }

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -70,6 +70,10 @@ module Pod
     #
     attr_reader :app_spec_build_settings
 
+    # @return [String] TODO
+    #
+    attr_reader :swift_version
+
     # Initialize a new instance
     #
     # @param [Sandbox] sandbox @see Target#sandbox
@@ -82,10 +86,12 @@ module Pod
     # @param [Array<Sandbox::FileAccessor>] file_accessors @see #file_accessors
     # @param [String] scope_suffix @see #scope_suffix
     # @param [Target::BuildType] build_type @see #build_type
+    # @param [String] swift_version @see #swift_version
     #
     def initialize(sandbox, host_requires_frameworks, user_build_configurations, archs, platform, specs,
                    target_definitions, file_accessors = [], scope_suffix = nil,
-                   build_type: Target::BuildType.infer_from_spec(specs.first, :host_requires_frameworks => host_requires_frameworks))
+                   build_type: Target::BuildType.infer_from_spec(specs.first, :host_requires_frameworks => host_requires_frameworks),
+                   swift_version: nil)
       super(sandbox, host_requires_frameworks, user_build_configurations, archs, platform, :build_type => build_type)
       raise "Can't initialize a PodTarget without specs!" if specs.nil? || specs.empty?
       raise "Can't initialize a PodTarget without TargetDefinition!" if target_definitions.nil? || target_definitions.empty?
@@ -94,6 +100,7 @@ module Pod
       @target_definitions = target_definitions
       @file_accessors = file_accessors
       @scope_suffix = scope_suffix
+      @swift_version = swift_version
       all_specs_by_type = @specs.group_by(&:spec_type)
       @library_specs = all_specs_by_type[:library] || []
       @test_specs = all_specs_by_type[:test] || []
@@ -184,32 +191,6 @@ module Pod
         # The extra folder is intentional in order for `<>` imports to work.
         [file_accessor, header_mappings(file_accessor, file_accessor.public_headers)]
       end]
-    end
-
-    # @return [String] the Swift version for the target. If the pod author has provided a set of Swift versions
-    #         supported by their pod then the max Swift version across all of target definitions is chosen, unless
-    #         a target definition specifies explicit requirements for supported Swift versions. Otherwise the Swift
-    #         version is derived by the target definitions that integrate this pod as long as they are the same.
-    #
-    def swift_version
-      @swift_version ||= begin
-        if spec_swift_versions.empty?
-          target_definition_swift_version
-        else
-          spec_swift_versions.sort.reverse_each.find do |swift_version|
-            target_definitions.all? do |td|
-              td.supports_swift_version?(swift_version)
-            end
-          end.to_s
-        end
-      end
-    end
-
-    # @return [String] the Swift version derived from the target definitions that integrate this pod. This is used for
-    #         legacy reasons and only if the pod author has not specified the Swift versions their pod supports.
-    #
-    def target_definition_swift_version
-      target_definitions.map(&:swift_version).compact.uniq.first
     end
 
     # @return [Array<Version>] the Swift versions supported. Might be empty if the author has not

--- a/spec/unit/installer/analyzer/pod_variant_set_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_set_spec.rb
@@ -162,6 +162,17 @@ module Pod
           framework-static
         )
       end
+
+      it 'returns scopes based on Swift version' do
+        variants = PodVariantSet.new([
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios, Target::BuildType.dynamic_framework, '3.2'),
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios, Target::BuildType.dynamic_framework, '4.0'),
+        ])
+        variants.scope_suffixes.values.should == %w(
+          Swift3.2
+          Swift4.0
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Currently if a pod supports multiple versions and it is used across 2 different targets CocoaPods will intentionally and correctly prevent this from happening.

This PR splits pod targets across Swift versions and enables integrating a pod across different targets and Swift versions.