### PR TITLE
Fix target definition display name for inhibit warnings message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Fix target definition display name for inhibit warnings message.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8935](https://github.com/CocoaPods/CocoaPods/pull/8935)
+
 * Allow using an application defined by an app spec as the app host for a test spec.  
   [jkap](https://github.com/jkap)
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -698,7 +698,7 @@ module Pod
         whitelists.first
       else
         UI.warn "The pod `#{pod_name}` is linked to different targets " \
-          "(#{target_definitions.map { |td| "`#{td.label}`" }.to_sentence}), which contain different " \
+          "(#{target_definitions.map { |td| "`#{td.name}`" }.to_sentence}), which contain different " \
           'settings to inhibit warnings. CocoaPods does not currently ' \
           'support different settings and will fall back to your preference ' \
           'set in the root target definition.'


### PR DESCRIPTION
Also adds tests for `PodTarget#inhibit_warnings?` method.

The real change is this diff in the warning message:
```diff
-The pod `BananaLib` is linked to different targets (`Pods-App1` and `Pods-App2`)...
+The pod `BananaLib` is linked to different targets (`App1` and `App2`)...
```