### PR TITLE
Honor the Swift version set by a dependency pod during lint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Honor the Swift version set by a dependency pod during lint.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8940](https://github.com/CocoaPods/CocoaPods/issues/8940)
 
 
 ## 1.7.2 (2019-06-13)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -612,7 +612,7 @@ module Pod
                             else
                               pod_target.spec_swift_versions.map(&:to_s).find do |v|
                                 v == derived_swift_version
-                              end || pod_target.target_definition_swift_version
+                              end || pod_target.swift_version
                             end
             build_configuration.build_settings['SWIFT_VERSION'] = swift_version
           end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1399,7 +1399,7 @@ module Pod
           native_target_two = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration_two]))
           pod_target_one = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
           pod_target_two = stub(:name => 'Dependency', :uses_swift? => true, :pod_name => 'Dependency',
-                                :spec_swift_versions => [], :target_definition_swift_version => '3.2')
+                                :spec_swift_versions => [], :swift_version => '3.2')
           pod_target_installation_one = stub(:target => pod_target_one, :native_target => native_target_one,
                                              :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_two = stub(:target => pod_target_two, :native_target => native_target_two,
@@ -1423,7 +1423,7 @@ module Pod
           native_target_two = stub(:build_configuration_list => stub(:build_configurations => [debug_configuration_two]))
           pod_target_one = stub(:name => 'JSONKit', :uses_swift? => true, :pod_name => 'JSONKit')
           pod_target_two = stub(:name => 'Dependency', :uses_swift? => true, :pod_name => 'Dependency',
-                                :spec_swift_versions => ['4.0'], :target_definition_swift_version => '3.2')
+                                :spec_swift_versions => ['4.0'], :swift_version => '3.2')
           pod_target_installation_one = stub(:target => pod_target_one, :native_target => native_target_one,
                                              :test_native_targets => [], :test_specs_by_native_target => {})
           pod_target_installation_two = stub(:target => pod_target_two, :native_target => native_target_two,


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/8940

This was a regression in 1.7.2 in which we never honored the `swift_version` set by the dependency spec and always defaulted to target definition Swift version.

The reason it was not caught in the prior PR it was because the test was changed also and got a false positive.