### PR TITLE
[Installer] Add 'treat_warnings_as_errors' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Print correct platform name when inferring target platform.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8916](https://github.com/CocoaPods/CocoaPods/pull/8916)
+  
+* Add the installation option 'treat_warnings_as_errors' which causes the installer to
+  terminate with an error if a warning occurs.  
+  [Ezra Berch](https://github.com/ezraberch)
+  [#8155](https://github.com/CocoaPods/CocoaPods/issues/8155)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -193,6 +193,7 @@ module Pod
     end
 
     def prepare
+      UI.treat_warnings_as_errors = installation_options.treat_warnings_as_errors
       # Raise if pwd is inside Pods
       if Dir.pwd.start_with?(sandbox.root.to_path)
         message = 'Command should be run from a directory outside Pods directory.'

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -181,6 +181,10 @@ module Pod
       # since the previous installation.
       #
       option :incremental_installation, false
+
+      # Whether to treat all warnings as though they were errors.
+      #
+      option :treat_warnings_as_errors, false
     end
   end
 end

--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -12,6 +12,7 @@ module Pod
     @title_level       =  0
     @indentation_level =  2
     @treat_titles_as_messages = false
+    @treat_warnings_as_errors = false
     @warnings = []
 
     class << self
@@ -20,6 +21,7 @@ module Pod
       attr_accessor :indentation_level
       attr_accessor :title_level
       attr_accessor :warnings
+      attr_accessor :treat_warnings_as_errors
 
       # @return [IO] IO object to which UI output will be directed.
       #
@@ -372,7 +374,11 @@ module Pod
       # return [void]
       #
       def warn(message, actions = [], verbose_only = false)
-        warnings << { :message => message, :actions => actions, :verbose_only => verbose_only }
+        if treat_warnings_as_errors
+          raise Informative, message
+        else
+          warnings << { :message => message, :actions => actions, :verbose_only => verbose_only }
+        end
       end
 
       # Pipes all output inside given block to a pager.

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -11,6 +11,7 @@ module Pod
         'lock_pod_sources' => true,
         'share_schemes_for_development_pods' => false,
         'preserve_pod_file_structure' => false,
+        'treat_warnings_as_errors' => false,
       }.each do |option, default|
         it "includes `#{option}` defaulting to `#{default}`" do
           Installer::InstallationOptions.defaults.fetch(option).should == default
@@ -70,6 +71,7 @@ module Pod
           'preserve_pod_file_structure' => false,
           'generate_multiple_pod_projects' => false,
           'incremental_installation' => false,
+          'treat_warnings_as_errors' => false,
         }
       end
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -313,6 +313,20 @@ module Pod
         end
       end
 
+      it 'treats warnings as errors if the corresponding config is set' do
+        @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new(:treat_warnings_as_errors => true))
+        @installer.send(:prepare)
+        UI.treat_warnings_as_errors.should.be.true
+      end
+
+      it "doesn't treat warnings as errors if the corresponing config is not set" do
+        @installer.send(:prepare)
+        UI.treat_warnings_as_errors.should.be.false
+        @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new(:treat_warnings_as_errors => false))
+        @installer.send(:prepare)
+        UI.treat_warnings_as_errors.should.be.false
+      end
+
       describe 'handling CocoaPods version updates' do
         it 'does not deintegrate when there is no lockfile' do
           installer = Pod::Installer.new(config.sandbox, generate_podfile, nil)


### PR DESCRIPTION
This PR adds a treat_warnings_as_errors installer option, false by default. When enabled warnings will cause the installer to immediately terminate, just as errors do.

Closes #8155