### PR TITLE
Use `git rev-parse` to build CocoaPods with the correct Core branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             }
             trap bundle_env ERR
 
-            bundle check || bundle install --path .bundle
+            bundle install --jobs=3 --retry=3 --deployment --path .bundle
       - save_cache:
           key: v1-gems-{{ checksum "Gemfile.lock" }}
           paths:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: bbde7cb7d688d4805a3a771dbc41f1308b668cae
-  branch: master
+  revision: 733dcd8c638cd818216a147a347d5bcf7953e92b
+  branch: 1-7-stable
   specs:
     cocoapods-core (1.7.3)
       activesupport (>= 4.0.2, < 6)


### PR DESCRIPTION
This solves an issue where, for example, the `1-7-stable` branch of `cocoapods` was running release scripts with the `master` branch of `cocoapods-core`.