### PR TITLE
Use `HEAD` of Bacon for graceful `Interrupt` handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
 
   gem 'cocoapods-dependencies', '~> 1.0.beta.1'
 
-  gem 'bacon'
+  gem 'bacon', :git => 'https://github.com/leahneukirchen/bacon.git'
   gem 'mocha'
   gem 'mocha-on-bacon'
   gem 'prettybacon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,12 @@ GIT
     cocoapods-try (1.1.0)
 
 GIT
+  remote: https://github.com/leahneukirchen/bacon.git
+  revision: 5e7115d577ebc98f7dc45fe628964751939f294e
+  specs:
+    bacon (1.2.0)
+
+GIT
   remote: https://github.com/segiddins/json.git
   revision: a9588bc4334c2f5bf985f255b61c05eafdcd8907
   branch: seg-1.7.7-ruby-2.2
@@ -137,7 +143,6 @@ GEM
     ast (2.2.0)
     atomos (0.1.3)
     awesome_print (1.6.1)
-    bacon (1.2.0)
     claide-plugins (0.9.2)
       cork
       nap
@@ -263,7 +268,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  bacon
+  bacon!
   bundler (~> 1.3)
   claide!
   clintegracon


### PR DESCRIPTION
When running the full spec suite, it is impossible to interrupt it because [Bacon](https://github.com/leahneukirchen/bacon) doesn't handle `Interrupt` gracefully.

This issue was fixed in the Bacon repo, however, no releases of Bacon were made since 2012.

This PR moves to use the `HEAD` version of Bacon so that local testing can be less painful.