### PR TITLE
Use `1-7-stable` of Core gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core'
+  cp_gem 'cocoapods-core',        'Core', '1-7-stable'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: bbde7cb7d688d4805a3a771dbc41f1308b668cae
-  branch: master
+  revision: addb56f1f9df0394705045cc17dba88a8ee28f5f
+  branch: 1-7-stable
   specs:
     cocoapods-core (1.7.3)
       activesupport (>= 4.0.2, < 6)


### PR DESCRIPTION
Our release process must be updated to reflect that but so far it does not and we've been lucky that `CocoaPods/1-7-stable` was successfully compiling `Core/master`. This is no longer the case so this PR manually does the right thing. Those two gems (CocoaPods and Core) move in lockstep so each time we cut a stable branch for CocoaPods we must point to the stable branch of Core, e.g. `CocoaPods/1-7-stable` must point to `Core/1-7-stable`.