### PR TITLE
Do not re-write sandbox files if they have not changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8916](https://github.com/CocoaPods/CocoaPods/pull/8916)
 
+* Do not re-write sandbox files if they have not changed.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8983](https://github.com/CocoaPods/CocoaPods/pull/8983)
+
 ##### Bug Fixes
 
 * Fix set `cache_root` from config file error  
@@ -82,6 +86,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Fix inheriting search paths for test targets in `init` command.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8868](https://github.com/CocoaPods/CocoaPods/issues/8868)
+
 
 ## 1.7.4 (2019-07-09)
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -740,13 +740,15 @@ module Pod
       @lockfile = generate_lockfile
 
       UI.message "- Writing Lockfile in #{UI.path config.lockfile_path}" do
+        # No need to invoke Sandbox#update_changed_file here since this logic already handles checking if the
+        # contents of the file are the same.
         @lockfile.write_to_disk(config.lockfile_path)
       end
 
       UI.message "- Writing Manifest in #{UI.path sandbox.manifest_path}" do
-        sandbox.manifest_path.open('w') do |f|
-          f.write config.lockfile_path.read
-        end
+        # No need to invoke Sandbox#update_changed_file here since this logic already handles checking if the
+        # contents of the file are the same.
+        @lockfile.write_to_disk(sandbox.manifest_path)
       end
     end
 

--- a/lib/cocoapods/installer/project_cache/project_cache_version.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_version.rb
@@ -35,7 +35,7 @@ module Pod
         #        The path of the project cache to save.
         #
         def save_as(path)
-          open(path, 'w') { |f| f.puts version.to_s }
+          Sandbox.update_changed_file(path, version.to_s)
         end
       end
     end

--- a/lib/cocoapods/installer/project_cache/project_installation_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_installation_cache.rb
@@ -47,7 +47,7 @@ module Pod
 
         def save_as(path)
           Pathname(path).dirname.mkpath
-          path.open('w') { |f| f.puts YAMLHelper.convert(to_hash) }
+          Sandbox.update_changed_file(path, YAMLHelper.convert(to_hash))
         end
 
         def self.from_file(path)

--- a/lib/cocoapods/installer/project_cache/project_metadata_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_metadata_cache.rb
@@ -32,7 +32,7 @@ module Pod
         # @return [void]
         #
         def save_as(path)
-          path.open('w') { |f| f.puts YAMLHelper.convert_hash(to_hash, nil) }
+          Sandbox.update_changed_file(path, YAMLHelper.convert_hash(to_hash, nil))
         end
 
         # Updates the metadata cache based on installation results.


### PR DESCRIPTION
A fix here is that the `Manifest.lock` file is used as an input file for the `Check Pods Manifest Lock` script phase. Each time `pod install` runs this file is re-written causing the script phase to run again.