### PR TITLE
Fix inheriting search paths for test targets in `init` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Pär Strindevall](https://github.com/parski)
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#8914](https://github.com/CocoaPods/CocoaPods/pull/8914)
-  
+
+* Fix inheriting search paths for test targets in `init` command.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8868](https://github.com/CocoaPods/CocoaPods/issues/8868)
 
 ## 1.7.4 (2019-07-09)
 

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -7,7 +7,8 @@ module Pod
   class AggregateTarget < Target
     # Product types where the product's frameworks must be embedded in a host target
     #
-    EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :static_library, :messages_extension, :watch_extension, :xpc_service].freeze
+    EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES = [:app_extension, :framework, :static_library, :messages_extension,
+                                             :watch_extension, :xpc_service].freeze
 
     # @return [TargetDefinition] the target definition of the Podfile that
     #         generated this target.
@@ -118,7 +119,9 @@ module Pod
       # that this is a library
       return false if user_project.nil?
       symbol_types = user_targets.map(&:symbol_type).uniq
-      raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}." unless symbol_types.count == 1
+      unless symbol_types.count == 1
+        raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}."
+      end
       [:framework, :dynamic_library, :static_library].include? symbol_types.first
     end
 
@@ -134,7 +137,9 @@ module Pod
       # target that would require a host target
       return false if user_project.nil?
       symbol_types = user_targets.map(&:symbol_type).uniq
-      raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}." unless symbol_types.count == 1
+      unless symbol_types.count == 1
+        raise ArgumentError, "Expected single kind of user_target for #{name}. Found #{symbol_types.join(', ')}."
+      end
       EMBED_FRAMEWORKS_IN_HOST_TARGET_TYPES.include?(symbol_types[0])
     end
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -35,7 +35,7 @@ module Pod
     # @param  [Array<String>] source_urls
     #         the Source URLs to use in creating a {Podfile}.
     #
-    # @param. [Array<String>] platforms
+    # @param  [Array<String>] platforms
     #         the platforms to lint.
     #
     def initialize(spec_or_path, source_urls, platforms = [])

--- a/spec/functional/command/init_spec.rb
+++ b/spec/functional/command/init_spec.rb
@@ -86,7 +86,7 @@ module Pod
       end
     end
 
-    it 'handles hooking up mulitple test targets based on an xcodeproj project' do
+    it 'handles hooking up multiple test targets based on an xcodeproj project' do
       Dir.chdir(temporary_directory) do
         project = Xcodeproj::Project.new(temporary_directory + 'test.xcodeproj')
         project.new_target(:application, 'App', :ios)
@@ -108,7 +108,6 @@ module Pod
             # Pods for App
 
             target 'AppFeatureTests' do
-              inherit! :search_paths
               # Pods for testing
             end
 
@@ -124,6 +123,70 @@ module Pod
             use_frameworks!
 
             # Pods for Swifty App
+
+          end
+        RUBY
+
+        File.read('Podfile').should == expected_podfile
+      end
+    end
+
+    it 'embeds pods into test targets since their parent requires it' do
+      Dir.chdir(temporary_directory) do
+        project = Xcodeproj::Project.new(temporary_directory + 'test.xcodeproj')
+        project.new_target(:application, 'App', :ios)
+        project.new_target(:framework, 'Framework', :ios)
+        project.new_target(:static_library, 'Library', :ios)
+        project.new_target(:unit_test_bundle, 'AppTests', :ios)
+        project.new_target(:ui_test_bundle, 'AppUITests', :ios)
+        project.new_target(:unit_test_bundle, 'FrameworkTests', :ios)
+        project.new_target(:unit_test_bundle, 'LibraryTests', :ios)
+        project.save
+
+        run_command('init')
+
+        expected_podfile = <<-RUBY.strip_heredoc
+          # Uncomment the next line to define a global platform for your project
+          # platform :ios, '9.0'
+
+          target 'App' do
+            # Comment the next line if you don't want to use dynamic frameworks
+            use_frameworks!
+
+            # Pods for App
+
+            target 'AppTests' do
+              inherit! :search_paths
+              # Pods for testing
+            end
+
+            target 'AppUITests' do
+              # Pods for testing
+            end
+
+          end
+
+          target 'Framework' do
+            # Comment the next line if you don't want to use dynamic frameworks
+            use_frameworks!
+
+            # Pods for Framework
+
+            target 'FrameworkTests' do
+              # Pods for testing
+            end
+
+          end
+
+          target 'Library' do
+            # Comment the next line if you don't want to use dynamic frameworks
+            use_frameworks!
+
+            # Pods for Library
+
+            target 'LibraryTests' do
+              # Pods for testing
+            end
 
           end
         RUBY


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/8868

If a unit test target is part of a target that does not support embedding then the test target itself must embed the frameworks in order for it to run successfully. Otherwise, in common cases the app target will embed the frameworks and the unit test target loads them from there.

For UI test targets we _always_ embed because the test bundle gets wrapped in a _different_ app and not the app that is being tested.