### PR TITLE
Danger fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_script:
 
 script:
   - bundle exec rake spec:all
-  - if [ "$COCOAPODS_CI_TASKS" = "LINT" ]; then bundle exec danger; fi
 
 addons:
  code_climate:

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,13 +2,11 @@
 # ensuring that we don't get green builds based on a subset of tests
 (git.modified_files + git.added_files - %w(Dangerfile)).each do |file|
   next unless File.file?(file)
-  next unless file.end_with? '.rb'
+  next unless file =~ /^spec.*\.rb/
 
   contents = File.read(file)
-  if file.start_with?('spec')
-    fail("`xit` or `fit` left in tests (#{file})") if contents =~ /^\w*[xf]it/
-    fail("`fdescribe` left in tests (#{file})") if contents =~ /^\w*fdescribe/
-  end
+  fail("`xit` or `fit` left in tests (#{file})") if contents =~ /^\s*[xf]it/
+  fail("`fdescribe` left in tests (#{file})") if contents =~ /^\s*fdescribe/
 end
 
 # Ensure a clean commits history

--- a/Rakefile
+++ b/Rakefile
@@ -169,6 +169,11 @@ begin
 
         title 'Running Inch'
         Rake::Task['inch'].invoke
+
+        unless ENV['CI'].nil?
+          title 'Running Danger'
+          Rake::Task['danger'].invoke
+        end
       end
     end
 
@@ -328,6 +333,15 @@ begin
 
   require 'inch_by_inch/rake_task'
   InchByInch::RakeTask.new
+
+  #-- Danger -----------------------------------------------------------------#
+
+  desc 'Run Danger to check PRs'
+  task :danger do
+    sh 'bundle exec danger' do |ok, _status|
+      raise 'Danger has found errors. Please refer to your PR for more information.' unless ok
+    end
+  end
 
 rescue LoadError, NameError => e
   $stderr.puts "\033[0;31m" \


### PR DESCRIPTION
This PR fixes the following issues I encountered with Danger:
1. It was not integrated in the `Rakefile` but rather has its own Travis script line.
2. The regex for triggering on `xit` and similar keywords in spec files was incorrect. 