### PR TITLE
Add support for UI test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add support for UI test specs with `test_type` value `:ui`  
+  [Yavuz Nuzumlali](https://github.com/manuyavuz)
+  [#9002](https://github.com/CocoaPods/CocoaPods/pull/9002)
+  [Core#562](https://github.com/CocoaPods/Core/pull/562)
+
 * Replace git-based `MasterSource` with CDN-based `TrunkSource`  
   [Igor Makarov](https://github.com/igor-makarov)
   [#8923](https://github.com/CocoaPods/CocoaPods/pull/8923)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -137,11 +137,16 @@ module Pod
             app_host_target_names = app_native_target.resolved_build_setting('PRODUCT_NAME', true)
             test_native_target.build_configurations.each do |configuration|
               app_host_target_name = app_host_target_names[configuration.name] || target.name
-              test_host = "$(BUILT_PRODUCTS_DIR)/#{app_host_target_name}.app/"
-              test_host << 'Contents/MacOS/' if pod_target.platform == :osx
-              test_host << app_host_target_name.to_s
-              configuration.build_settings['BUNDLE_LOADER'] = '$(TEST_HOST)'
-              configuration.build_settings['TEST_HOST'] = test_host
+              case test_native_target.symbol_type
+              when :unit_test_bundle
+                test_host = "$(BUILT_PRODUCTS_DIR)/#{app_host_target_name}.app/"
+                test_host << 'Contents/MacOS/' if pod_target.platform == :osx
+                test_host << app_host_target_name.to_s
+                configuration.build_settings['BUNDLE_LOADER'] = '$(TEST_HOST)'
+                configuration.build_settings['TEST_HOST'] = test_host
+              when :ui_test_bundle
+                configuration.build_settings['TEST_TARGET_NAME'] = app_host_target_name
+              end
             end
             target_attributes = project.root_object.attributes['TargetAttributes'] || {}
             target_attributes[test_native_target.uuid.to_s] = { 'TestTargetID' => app_native_target.uuid.to_s }

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -428,7 +428,13 @@ module Pod
       end
     end
 
-    # @return [String] The label to use for the given test type.
+    # Returns the label to use for the given test type.
+    # This is used to generate native target names for test specs.
+    #
+    # @param  [Symbol] test_type
+    #         The test type to map to provided by the test specification DSL.
+    #
+    # @return [String] The native product type to use.
     #
     def label_for_test_type(test_type)
       case test_type

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -428,6 +428,15 @@ module Pod
       end
     end
 
+    def label_for_test_type(test_type)
+      case test_spec.test_type
+      when :unit
+        'Unit'
+      when :ui
+        'UI'
+      end
+    end
+
     # @return [Specification] The root specification for the target.
     #
     def root_spec
@@ -491,13 +500,7 @@ module Pod
     # @return [String] The derived name of the test target.
     #
     def test_target_label(test_spec)
-      type_string = case test_spec.test_type
-                    when :unit
-                      'Unit'
-                    when :ui
-                      'UI'
-                    end
-      "#{label}-#{type_string}-#{subspec_label(test_spec)}"
+      "#{label}-#{label_for_test_type(test_spec.test_type)}-#{subspec_label(test_spec)}"
     end
 
     # @param  [Specification] app_spec
@@ -520,7 +523,7 @@ module Pod
       if app_spec
         [app_target.name, app_target.app_target_label(app_spec)]
       elsif test_spec.consumer(platform).requires_app_host?
-        [name, "AppHost-#{label}-#{test_spec.test_type.capitalize}-Tests"]
+        [name, "AppHost-#{label}-#{label_for_test_type(test_spec.test_type)}-Tests"]
       end
     end
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -428,12 +428,16 @@ module Pod
       end
     end
 
+    # @return [String] The label to use for the given test type.
+    #
     def label_for_test_type(test_type)
       case test_type
       when :unit
         'Unit'
       when :ui
         'UI'
+      else
+        raise ArgumentError, "Unknown test type `#{test_type}`."
       end
     end
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -429,7 +429,7 @@ module Pod
     end
 
     def label_for_test_type(test_type)
-      case test_spec.test_type
+      case test_type
       when :unit
         'Unit'
       when :ui

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -421,6 +421,8 @@ module Pod
       case test_type
       when :unit
         :unit_test_bundle
+      when :ui
+        :ui_test_bundle
       else
         raise ArgumentError, "Unknown test type `#{test_type}`."
       end
@@ -489,7 +491,13 @@ module Pod
     # @return [String] The derived name of the test target.
     #
     def test_target_label(test_spec)
-      "#{label}-#{test_spec.test_type.capitalize}-#{subspec_label(test_spec)}"
+      type_string = case test_spec.test_type
+                    when :unit
+                      'Unit'
+                    when :ui
+                      'UI'
+                    end
+      "#{label}-#{type_string}-#{subspec_label(test_spec)}"
     end
 
     # @param  [Specification] app_spec

--- a/spec/fixtures/watermelon-lib/UITests/WatermelonUITests.m
+++ b/spec/fixtures/watermelon-lib/UITests/WatermelonUITests.m
@@ -1,23 +1,30 @@
-#import <KIF/KIF.h>
+#import <XCTest/XCTest.h>
 
-@interface WatermelonUITests : KIFTestCase
+
+@interface WatermelonUITests : XCTestCase
 
 @end
 
 @implementation WatermelonUITests
 
 - (void)setUp {
-    [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    self.continueAfterFailure = NO;
+
+    // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+    [[[XCUIApplication alloc] init] launch];
+
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 }
 
 - (void)tearDown {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
 }
 
 - (void)testExample {
-    // This is an example of a functional test case.
+    // Use recording to get started writing UI tests.
     // Use XCTAssert and related functions to verify your tests produce the correct results.
 }
 

--- a/spec/fixtures/watermelon-lib/UITests/WatermelonUITests.m
+++ b/spec/fixtures/watermelon-lib/UITests/WatermelonUITests.m
@@ -1,0 +1,24 @@
+#import <KIF/KIF.h>
+
+@interface WatermelonUITests : KIFTestCase
+
+@end
+
+@implementation WatermelonUITests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+@end

--- a/spec/fixtures/watermelon-lib/WatermelonLib.podspec
+++ b/spec/fixtures/watermelon-lib/WatermelonLib.podspec
@@ -23,6 +23,13 @@ Pod::Spec.new do |s|
     test_spec.resource_bundle = { 'WatermelonLibTestResources' => ['Tests/Resources/**/*'] }
   end
 
+  s.test_spec 'UITests' do |test_spec|
+    test_spec.test_type = :ui
+    test_spec.requires_app_host = true
+    test_spec.source_files = 'UITests/*.{h,m}'
+    test_spec.dependency 'KIF'
+  end
+
   s.test_spec 'SnapshotTests' do |test_spec|
     test_spec.requires_app_host = true
     test_spec.source_files = 'SnapshotTests/*.{h,m}'

--- a/spec/fixtures/watermelon-lib/WatermelonLib.podspec
+++ b/spec/fixtures/watermelon-lib/WatermelonLib.podspec
@@ -27,7 +27,6 @@ Pod::Spec.new do |s|
     test_spec.test_type = :ui
     test_spec.requires_app_host = true
     test_spec.source_files = 'UITests/*.{h,m}'
-    test_spec.dependency 'KIF'
   end
 
   s.test_spec 'SnapshotTests' do |test_spec|

--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -268,16 +268,20 @@ module Pod
             ]
 
             watermelon_project.targets.map(&:name).sort.should == [
+              'AppHost-WatermelonLib-iOS-UI-Tests',
               'AppHost-WatermelonLib-iOS-Unit-Tests',
+              'AppHost-WatermelonLib-macOS-UI-Tests',
               'AppHost-WatermelonLib-macOS-Unit-Tests',
               'WatermelonLib-iOS',
               'WatermelonLib-iOS-App',
+              'WatermelonLib-iOS-UI-UITests',
               'WatermelonLib-iOS-Unit-SnapshotTests',
               'WatermelonLib-iOS-Unit-Tests',
               'WatermelonLib-iOS-WatermelonLibExampleAppResources',
               'WatermelonLib-iOS-WatermelonLibTestResources',
               'WatermelonLib-macOS',
               'WatermelonLib-macOS-App',
+              'WatermelonLib-macOS-UI-UITests',
               'WatermelonLib-macOS-Unit-SnapshotTests',
               'WatermelonLib-macOS-Unit-Tests',
               'WatermelonLib-macOS-WatermelonLibExampleAppResources',

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -187,8 +187,20 @@ module Pod
                   @project.add_file_reference(resource, group)
                 end
 
+                ui_test_file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('watermelon-lib')),
+                                                                  @watermelon_spec.test_specs[1].consumer(:ios))
+                @project.add_pod_group('WatermelonLibUITests', fixture('watermelon-lib'))
+                group = @project.group_for_spec('WatermelonLibUITests')
+                ui_test_file_accessor.source_files.each do |file|
+                  @project.add_file_reference(file, group)
+                end
+                ui_test_file_accessor.resources.each do |resource|
+                  @project.add_file_reference(resource, group)
+                end
+
+
                 snapshot_test_file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('watermelon-lib')),
-                                                                        @watermelon_spec.test_specs[1].consumer(:ios))
+                                                                        @watermelon_spec.test_specs[2].consumer(:ios))
                 @project.add_pod_group('WatermelonLibSnapshotTests', fixture('watermelon-lib'))
                 group = @project.group_for_spec('WatermelonLibSnapshotTests')
                 snapshot_test_file_accessor.source_files.each do |file|
@@ -211,7 +223,7 @@ module Pod
 
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
                 all_specs = [@watermelon_spec, *@watermelon_spec.recursive_subspecs]
-                file_accessors = [file_accessor, unit_test_file_accessor, snapshot_test_file_accessor, app_file_accessor]
+                file_accessors = [file_accessor, unit_test_file_accessor, ui_test_file_accessor, snapshot_test_file_accessor, app_file_accessor]
                 @watermelon_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [],
                                                        Platform.new(:ios, '6.0'), all_specs, [@target_definition],
                                                        file_accessors)
@@ -225,7 +237,7 @@ module Pod
               it 'adds the native test target to the project for iOS targets with correct build settings' do
                 @watermelon_spec.app_specs.each { |s| s.pod_target_xcconfig = {} }
                 installation_result = @installer.install!
-                @project.targets.count.should == 8
+                @project.targets.count.should == 9
                 @project.targets.first.name.should == 'WatermelonLib'
                 unit_test_native_target = @project.targets[1]
                 unit_test_native_target.name.should == 'WatermelonLib-Unit-Tests'
@@ -240,9 +252,6 @@ module Pod
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
                   bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-Tests-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-Tests-prefix.pch'
-                  bc.build_settings['TEST_HOST'].should.be.nil
-                  bc.build_settings['BUNDLE_LOADER'].should.be.nil
-                  bc.build_settings['TEST_TARGET_NAME'].should.be.nil
                 end
                 unit_test_native_target.symbol_type.should == :unit_test_bundle
 
@@ -259,9 +268,6 @@ module Pod
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
                   bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-UI-UITests-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-UI-UITests-prefix.pch'
-                  bc.build_settings['TEST_HOST'].should.be.nil
-                  bc.build_settings['BUNDLE_LOADER'].should.be.nil
-                  bc.build_settings['TEST_TARGET_NAME'].should.be.identical_to 'WatermelonLib-App'
                 end
                 ui_test_native_target.symbol_type.should == :ui_test_bundle
 
@@ -278,12 +284,9 @@ module Pod
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
                   bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-SnapshotTests-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-SnapshotTests-prefix.pch'
-                  bc.build_settings['TEST_HOST'].should.match /WatermelonLib.app\/WatermelonLib-App$/
-                  bc.build_settings['BUNDLE_LOADER'].should.not.be.nil
-                  bc.build_settings['TEST_TARGET_NAME'].should.be.nil
                 end
                 snapshot_test_native_target.symbol_type.should == :unit_test_bundle
-                app_native_target = @project.targets[6]
+                app_native_target = @project.targets[7]
                 app_native_target.name.should == 'WatermelonLib-App'
                 app_native_target.product_reference.name.should == 'WatermelonLib-App'
                 app_native_target.build_configurations.each do |bc|
@@ -307,7 +310,7 @@ module Pod
               it 'adds the native test target to the project for OSX targets with correct build settings' do
                 @watermelon_spec.app_specs.each { |s| s.pod_target_xcconfig = {} }
                 installation_result = @installer2.install!
-                @project.targets.count.should == 7
+                @project.targets.count.should == 9
                 @project.targets.first.name.should == 'WatermelonLib'
                 unit_test_native_target = @project.targets[1]
                 unit_test_native_target.name.should == 'WatermelonLib-Unit-Tests'
@@ -323,7 +326,24 @@ module Pod
                   bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-Tests-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-Tests-prefix.pch'
                 end
-                snapshot_test_native_target = @project.targets[2]
+
+                ui_test_native_target = @project.targets[2]
+                ui_test_native_target.name.should == 'WatermelonLib-UI-UITests'
+                ui_test_native_target.product_reference.name.should == 'WatermelonLib-UI-UITests'
+                ui_test_native_target.build_configurations.each do |bc|
+                  bc.base_configuration_reference.real_path.basename.to_s.should == 'WatermelonLib.ui-uitests.xcconfig'
+                  bc.build_settings['PRODUCT_NAME'].should == 'WatermelonLib-UI-UITests'
+                  bc.build_settings['MACH_O_TYPE'].should.be.nil
+                  bc.build_settings['PRODUCT_MODULE_NAME'].should.be.nil
+                  bc.build_settings['CODE_SIGNING_REQUIRED'].should.be.nil
+                  bc.build_settings['CODE_SIGNING_ALLOWED'].should.be.nil
+                  bc.build_settings['CODE_SIGN_IDENTITY'].should == ''
+                  bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-UI-UITests-Info.plist'
+                  bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-UI-UITests-prefix.pch'
+                end
+                ui_test_native_target.symbol_type.should == :ui_test_bundle
+
+                snapshot_test_native_target = @project.targets[3]
                 snapshot_test_native_target.name.should == 'WatermelonLib-Unit-SnapshotTests'
                 snapshot_test_native_target.product_reference.name.should == 'WatermelonLib-Unit-SnapshotTests'
                 snapshot_test_native_target.build_configurations.each do |bc|
@@ -338,7 +358,7 @@ module Pod
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-SnapshotTests-prefix.pch'
                 end
                 snapshot_test_native_target.symbol_type.should == :unit_test_bundle
-                app_native_target = @project.targets[5]
+                app_native_target = @project.targets[7]
                 app_native_target.name.should == 'WatermelonLib-App'
                 app_native_target.product_reference.name.should == 'WatermelonLib-App'
                 app_native_target.build_configurations.each do |bc|
@@ -384,7 +404,7 @@ module Pod
 
               it 'adds files to build phases correctly depending on the native target' do
                 @installer.install!
-                @project.targets.count.should == 7
+                @project.targets.count.should == 9
                 native_target = @project.targets[0]
                 native_target.source_build_phase.files.count.should == 2
                 native_target.source_build_phase.files.map(&:display_name).sort.should == [
@@ -397,12 +417,17 @@ module Pod
                   'WatermelonSwiftTests.swift',
                   'WatermelonTests.m',
                 ]
-                snapshot_test_native_target = @project.targets[2]
+                ui_test_native_target = @project.targets[2]
+                ui_test_native_target.source_build_phase.files.count.should == 1
+                ui_test_native_target.source_build_phase.files.map(&:display_name).sort.should == [
+                  'WatermelonUITests.m',
+                ]
+                snapshot_test_native_target = @project.targets[3]
                 snapshot_test_native_target.source_build_phase.files.count.should == 1
                 snapshot_test_native_target.source_build_phase.files.map(&:display_name).sort.should == [
                   'WatermelonSnapshotTests.m',
                 ]
-                app_native_target = @project.targets[5]
+                app_native_target = @project.targets[7]
                 app_native_target.source_build_phase.files.count.should == 1
                 app_native_target.source_build_phase.files.map(&:display_name).sort.should == [
                   'main.swift',
@@ -463,7 +488,7 @@ module Pod
               it 'adds test xcconfig file reference for test resource bundle targets' do
                 installation_result = @installer.install!
                 installation_result.resource_bundle_targets.count.should == 0
-                installation_result.test_resource_bundle_targets.count.should == 2
+                installation_result.test_resource_bundle_targets.count.should == 1
                 unit_test_resource_bundle_target = @project.targets.find { |t| t.name == 'WatermelonLib-WatermelonLibTestResources' }
                 unit_test_resource_bundle_target.build_configurations.each do |bc|
                   bc.base_configuration_reference.real_path.basename.to_s.should == 'WatermelonLib.unit-tests.xcconfig'

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -222,7 +222,8 @@ module Pod
 
                 user_build_configurations = { 'Debug' => :debug, 'Release' => :release }
                 all_specs = [@watermelon_spec, *@watermelon_spec.recursive_subspecs]
-                file_accessors = [file_accessor, unit_test_file_accessor, ui_test_file_accessor, snapshot_test_file_accessor, app_file_accessor]
+                file_accessors = [file_accessor, unit_test_file_accessor, ui_test_file_accessor,
+                                  snapshot_test_file_accessor, app_file_accessor]
                 @watermelon_pod_target = PodTarget.new(config.sandbox, false, user_build_configurations, [],
                                                        Platform.new(:ios, '6.0'), all_specs, [@target_definition],
                                                        file_accessors)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -225,7 +225,7 @@ module Pod
               it 'adds the native test target to the project for iOS targets with correct build settings' do
                 @watermelon_spec.app_specs.each { |s| s.pod_target_xcconfig = {} }
                 installation_result = @installer.install!
-                @project.targets.count.should == 7
+                @project.targets.count.should == 8
                 @project.targets.first.name.should == 'WatermelonLib'
                 unit_test_native_target = @project.targets[1]
                 unit_test_native_target.name.should == 'WatermelonLib-Unit-Tests'
@@ -240,8 +240,32 @@ module Pod
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
                   bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-Tests-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-Tests-prefix.pch'
+                  bc.build_settings['TEST_HOST'].should.be.nil
+                  bc.build_settings['BUNDLE_LOADER'].should.be.nil
+                  bc.build_settings['TEST_TARGET_NAME'].should.be.nil
                 end
-                snapshot_test_native_target = @project.targets[2]
+                unit_test_native_target.symbol_type.should == :unit_test_bundle
+
+                ui_test_native_target = @project.targets[2]
+                ui_test_native_target.name.should == 'WatermelonLib-UI-UITests'
+                ui_test_native_target.product_reference.name.should == 'WatermelonLib-UI-UITests'
+                ui_test_native_target.build_configurations.each do |bc|
+                  bc.base_configuration_reference.real_path.basename.to_s.should == 'WatermelonLib.ui-uitests.xcconfig'
+                  bc.build_settings['PRODUCT_NAME'].should == 'WatermelonLib-UI-UITests'
+                  bc.build_settings['MACH_O_TYPE'].should.be.nil
+                  bc.build_settings['PRODUCT_MODULE_NAME'].should.be.nil
+                  bc.build_settings['CODE_SIGNING_REQUIRED'].should == 'YES'
+                  bc.build_settings['CODE_SIGNING_ALLOWED'].should == 'YES'
+                  bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
+                  bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-UI-UITests-Info.plist'
+                  bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-UI-UITests-prefix.pch'
+                  bc.build_settings['TEST_HOST'].should.be.nil
+                  bc.build_settings['BUNDLE_LOADER'].should.be.nil
+                  bc.build_settings['TEST_TARGET_NAME'].should.be.identical_to 'WatermelonLib-App'
+                end
+                ui_test_native_target.symbol_type.should == :ui_test_bundle
+
+                snapshot_test_native_target = @project.targets[3]
                 snapshot_test_native_target.name.should == 'WatermelonLib-Unit-SnapshotTests'
                 snapshot_test_native_target.product_reference.name.should == 'WatermelonLib-Unit-SnapshotTests'
                 snapshot_test_native_target.build_configurations.each do |bc|
@@ -254,9 +278,12 @@ module Pod
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
                   bc.build_settings['INFOPLIST_FILE'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-SnapshotTests-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-Unit-SnapshotTests-prefix.pch'
+                  bc.build_settings['TEST_HOST'].should.match /WatermelonLib.app\/WatermelonLib-App$/
+                  bc.build_settings['BUNDLE_LOADER'].should.not.be.nil
+                  bc.build_settings['TEST_TARGET_NAME'].should.be.nil
                 end
                 snapshot_test_native_target.symbol_type.should == :unit_test_bundle
-                app_native_target = @project.targets[5]
+                app_native_target = @project.targets[6]
                 app_native_target.name.should == 'WatermelonLib-App'
                 app_native_target.product_reference.name.should == 'WatermelonLib-App'
                 app_native_target.build_configurations.each do |bc|
@@ -273,7 +300,7 @@ module Pod
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-App-prefix.pch'
                 end
                 app_native_target.symbol_type.should == :application
-                installation_result.test_native_targets.count.should == 2
+                installation_result.test_native_targets.count.should == 3
                 installation_result.app_native_targets.count.should == 1
               end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -198,7 +198,6 @@ module Pod
                   @project.add_file_reference(resource, group)
                 end
 
-
                 snapshot_test_file_accessor = Sandbox::FileAccessor.new(Sandbox::PathList.new(fixture('watermelon-lib')),
                                                                         @watermelon_spec.test_specs[2].consumer(:ios))
                 @project.add_pod_group('WatermelonLibSnapshotTests', fixture('watermelon-lib'))
@@ -488,7 +487,7 @@ module Pod
               it 'adds test xcconfig file reference for test resource bundle targets' do
                 installation_result = @installer.install!
                 installation_result.resource_bundle_targets.count.should == 0
-                installation_result.test_resource_bundle_targets.count.should == 1
+                installation_result.test_resource_bundle_targets.count.should == 3
                 unit_test_resource_bundle_target = @project.targets.find { |t| t.name == 'WatermelonLib-WatermelonLibTestResources' }
                 unit_test_resource_bundle_target.build_configurations.each do |bc|
                   bc.base_configuration_reference.real_path.basename.to_s.should == 'WatermelonLib.unit-tests.xcconfig'

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -374,7 +374,7 @@ module Pod
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-App-prefix.pch'
                 end
                 app_native_target.symbol_type.should == :application
-                installation_result.test_native_targets.count.should == 2
+                installation_result.test_native_targets.count.should == 3
                 installation_result.app_native_targets.count.should == 1
               end
 

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -163,7 +163,9 @@ module Pod
           it 'installs the correct targets in the project' do
             pod_generator_result = @generator.generate!
             pod_generator_result.project.targets.map(&:name).sort.should == [
+              'AppHost-WatermelonLib-iOS-UI-Tests',
               'AppHost-WatermelonLib-iOS-Unit-Tests',
+              'AppHost-WatermelonLib-macOS-UI-Tests',
               'AppHost-WatermelonLib-macOS-Unit-Tests',
               'BananaLib-iOS',
               'BananaLib-macOS',
@@ -178,12 +180,14 @@ module Pod
               'Pods-SampleApp-macOS',
               'WatermelonLib-iOS',
               'WatermelonLib-iOS-App',
+              'WatermelonLib-iOS-UI-UITests',
               'WatermelonLib-iOS-Unit-SnapshotTests',
               'WatermelonLib-iOS-Unit-Tests',
               'WatermelonLib-iOS-WatermelonLibExampleAppResources',
               'WatermelonLib-iOS-WatermelonLibTestResources',
               'WatermelonLib-macOS',
               'WatermelonLib-macOS-App',
+              'WatermelonLib-macOS-UI-UITests',
               'WatermelonLib-macOS-Unit-SnapshotTests',
               'WatermelonLib-macOS-Unit-Tests',
               'WatermelonLib-macOS-WatermelonLibExampleAppResources',

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -877,9 +877,9 @@ module Pod
         end
 
         it 'returns correct whether a test spec uses Swift or not' do
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.base_name == 'Tests'}).should.be.true
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.base_name == 'UITests'}).should.be.false
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.base_name == 'SnapshotTests'}).should.be.false
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find { |t| t.base_name == 'Tests' }).should.be.true
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find { |t| t.base_name == 'UITests' }).should.be.false
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find { |t| t.base_name == 'SnapshotTests' }).should.be.false
         end
       end
     end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -841,6 +841,7 @@ module Pod
 
         it 'returns test label based on test type' do
           @test_pod_target.test_target_label(@test_pod_target.test_specs.first).should == 'WatermelonLib-Unit-Tests'
+          @test_pod_target.test_target_label(@test_pod_target.test_specs[1]).should == 'WatermelonLib-UI-SnapshotTests'
         end
 
         it 'returns the correct product type for test type' do

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -786,6 +786,7 @@ module Pod
           @watermelon_pod_target.resource_paths.should == {
             'WatermelonLib' => [],
             'WatermelonLib/Tests' => ['${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLibTestResources.bundle'],
+            'WatermelonLib/UITests' => [],
             'WatermelonLib/SnapshotTests' => [],
             'WatermelonLib/App' => ['${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLibExampleAppResources.bundle'],
           }
@@ -797,6 +798,7 @@ module Pod
             'WatermelonLib' => [],
             'WatermelonLib/Tests' => ['${PODS_ROOT}/../../spec/fixtures/watermelon-lib/App/resource.txt',
                                       '${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLibTestResources.bundle'],
+            'WatermelonLib/UITests' => [],
             'WatermelonLib/SnapshotTests' => [],
             'WatermelonLib/App' => ['${PODS_ROOT}/../../spec/fixtures/watermelon-lib/App/resource.txt',
                                     '${PODS_CONFIGURATION_BUILD_DIR}/WatermelonLib/WatermelonLibExampleAppResources.bundle'],
@@ -809,6 +811,7 @@ module Pod
               Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework'),
             ],
             'WatermelonLib/Tests' => [],
+            'WatermelonLib/UITests' => [],
             'WatermelonLib/SnapshotTests' => [],
             'WatermelonLib/App' => [
               Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework'),
@@ -874,9 +877,9 @@ module Pod
         end
 
         it 'returns correct whether a test spec uses Swift or not' do
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.name == 'Tests'}).should.be.true
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.name == 'UITests'}).should.be.false
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.name == 'SnapshotTests'}).should.be.false
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.base_name == 'Tests'}).should.be.true
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.base_name == 'UITests'}).should.be.false
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.base_name == 'SnapshotTests'}).should.be.false
         end
       end
     end

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -841,11 +841,15 @@ module Pod
 
         it 'returns test label based on test type' do
           @test_pod_target.test_target_label(@test_pod_target.test_specs.first).should == 'WatermelonLib-Unit-Tests'
-          @test_pod_target.test_target_label(@test_pod_target.test_specs[1]).should == 'WatermelonLib-UI-SnapshotTests'
+          @test_pod_target.test_target_label(@test_pod_target.test_specs[1]).should == 'WatermelonLib-UI-UITests'
         end
 
-        it 'returns the correct product type for test type' do
+        it 'returns the correct product type for unit test type' do
           @test_pod_target.product_type_for_test_type(:unit).should == :unit_test_bundle
+        end
+
+        it 'returns the correct product type for ui test type' do
+          @test_pod_target.product_type_for_test_type(:ui).should == :ui_test_bundle
         end
 
         it 'raises for unknown test type' do
@@ -870,8 +874,9 @@ module Pod
         end
 
         it 'returns correct whether a test spec uses Swift or not' do
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs[0]).should.be.true
-          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs[1]).should.be.false
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.name == 'Tests'}).should.be.true
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.name == 'UITests'}).should.be.false
+          @test_pod_target.uses_swift_for_spec?(@test_pod_target.test_specs.find{ |t| t.name == 'SnapshotTests'}).should.be.false
         end
       end
     end


### PR DESCRIPTION
requires: https://github.com/CocoaPods/Core/pull/562

This PR enables CP to generate a UI test bundle target when a test specification is defined as follows:

```ruby
s.test_spec 'UITests' |tests|
  # we have to set `test_type` to `:ui`, as `:unit` is the default value
  test.test_type = :ui
  test.requires_app_host = true
end
```

Resolves #9001.