### PR TITLE
Fix regenerating all aggregate targets if one is removed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix regenerating aggregate targets for incremental installation.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#9009](https://github.com/CocoaPods/CocoaPods/pull/9009)
+
 * Fix heuristic for determining whether the source URL to be added is CDN  
   [Igor Makarov](https://github.com/igor-makarov)
   [#9000](https://github.com/CocoaPods/CocoaPods/issues/9000)


### PR DESCRIPTION
This fixes a bug during incremental installation where if an aggregate target is removed, we will not generate `Pods.xcodeproj` since the `AggregateTarget` instance doesn't exist and thus will produce a nil value in an array thereby making it empty. A result of this getting shipped was because the aggregate target test fixtures weren't setup correctly and shared the same target definition in the cache. Verified that the fixed test fails with the old code.