### PR TITLE
Make CDNSource show up in `pod repo env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Make CDNSource show up in `pod repo env`  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9016](https://github.com/CocoaPods/CocoaPods/pull/9016)
+
 * Fix regenerating aggregate targets for incremental installation.  
   [Sebastian Shanus](https://github.com/sebastianv1)
   [#9009](https://github.com/CocoaPods/CocoaPods/pull/9009)

--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -171,12 +171,16 @@ EOS
 
         def repo_information
           Config.instance.sources_manager.all.map do |source|
-            next unless source.type == 'file system'
             repo = source.repo
-            Dir.chdir(repo) do
-              url = `git config --get remote.origin.url 2>&1`.strip
-              sha = `git rev-parse HEAD 2>&1`.strip
-              "#{repo.basename} - #{url} @ #{sha}"
+            if source.is_a?(Pod::CDNSource)
+              "#{repo.basename} - CDN - #{source.url}"
+            elsif source.git?
+              Dir.chdir(repo) do
+                sha = `git rev-parse HEAD 2>&1`.strip
+                "#{repo.basename} - git - #{source.url} @ #{sha}"
+              end
+            else
+              "#{repo.basename} - #{source.type}"
             end
           end
         end


### PR DESCRIPTION
When users submit issues, they are requested to run `pod repo env`.  
`CDNSource` should show up on that list.