### PR TITLE
Only return library itself as a framework path for library specs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   xcconfig files are missing.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Only return library itself as a framework path for library specs.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9029](https://github.com/CocoaPods/CocoaPods/pull/9029)
+
 
 ## 1.7.5 (2019-07-19)
 

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -383,7 +383,7 @@ module Pod
                                 end
             FrameworkPaths.new(framework_source, dsym_source, bcsymbolmap_paths)
           end
-          if !file_accessor.spec.test_specification? && should_build? && build_as_dynamic_framework?
+          if file_accessor.spec.library_specification? && should_build? && build_as_dynamic_framework?
             frameworks << FrameworkPaths.new(build_product_path('${BUILT_PRODUCTS_DIR}'))
           end
           hash[file_accessor.spec.name] = frameworks

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -822,9 +822,7 @@ module Pod
             'WatermelonLib/Tests' => [],
             'WatermelonLib/UITests' => [],
             'WatermelonLib/SnapshotTests' => [],
-            'WatermelonLib/App' => [
-              Target::FrameworkPaths.new('${BUILT_PRODUCTS_DIR}/WatermelonLib/WatermelonLib.framework'),
-            ],
+            'WatermelonLib/App' => [],
           }
         end
 


### PR DESCRIPTION
This was a bug when `app_specs` were introduced.