### PR TITLE
Allow overriding custom xcconfig entries set for compiling a library when specifying an app or test spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9029](https://github.com/CocoaPods/CocoaPods/pull/9029)
 
+* Allow overriding custom xcconfig entries set for compiling a library when
+  specifying an app or test spec.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 1.7.5 (2019-07-19)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: e9967503122ace79f43dd22defa5634374e95bb0
+  revision: 0500e18fe1a4b849e917d2788b3ec154995ed9dc
   branch: master
   specs:
     cocoapods-core (1.7.5)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -417,8 +417,10 @@ module Pod
             end
           elsif PLURAL_SETTINGS.include? key
             # Plural build settings
-            overridden = xcconfig[key]
-            uniq_values.prepend(overridden) if overridden
+            if xcconfig.key?(key)
+              overridden = xcconfig[key]
+              uniq_values.prepend(overridden)
+            end
             xcconfig[key] = uniq_values.uniq.join(' ')
           elsif uniq_values.count > 1
             # Singular build settings

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -243,12 +243,24 @@ module Pod
           end
 
           it 'does not merge pod target xcconfig of test specifications for a non test xcconfig' do
-            @coconut_spec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'NON_TEST_FLAG=1', 'PODS_ROOT' => 'OVERRIDDEN' }
-            @coconut_test_spec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'TEST_ONLY=1', 'PODS_ROOT' => 'OVERRIDDEN2' }
+            @coconut_spec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'NON_TEST_FLAG=1', 'PODS_ROOT' => 'OVERRIDDEN', 'GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED' => 'YES', 'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES' }
+            @coconut_test_spec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'TEST_ONLY=1', 'PODS_ROOT' => 'OVERRIDDEN2', 'GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED' => 'YES', 'GCC_TREAT_WARNINGS_AS_ERRORS' => 'NO' }
+
             generator = PodTargetSettings.new(@coconut_pod_target)
             xcconfig = generator.generate
             xcconfig.to_hash['GCC_PREPROCESSOR_DEFINITIONS'].should == '$(inherited) COCOAPODS=1 NON_TEST_FLAG=1'
             xcconfig.to_hash['PODS_ROOT'].should == 'OVERRIDDEN'
+            xcconfig.to_hash['GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED'].should == 'YES'
+            xcconfig.to_hash['GCC_TREAT_WARNINGS_AS_ERRORS'].should == 'YES'
+
+            generator = PodTargetSettings.new(@coconut_pod_target, @coconut_test_spec)
+            xcconfig = generator.generate
+            xcconfig.to_hash['GCC_PREPROCESSOR_DEFINITIONS'].should == '$(inherited) COCOAPODS=1 NON_TEST_FLAG=1 TEST_ONLY=1'
+            xcconfig.to_hash['PODS_ROOT'].should == 'OVERRIDDEN2'
+            xcconfig.to_hash['GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED'].should == 'YES'
+            xcconfig.to_hash['GCC_TREAT_WARNINGS_AS_ERRORS'].should == 'NO'
+
+            UI.warnings.should.be.empty
           end
 
           it 'merges pod target xcconfig settings from subspecs' do


### PR DESCRIPTION
Depends on https://github.com/CocoaPods/Core/pull/568