### PR TITLE
Use correct deployment target for test specs and app specs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9041](https://github.com/CocoaPods/CocoaPods/pull/9041)
 
+* Use correct deployment target for test specs and app specs.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9040](https://github.com/CocoaPods/CocoaPods/pull/9040)
+
 
 ## 1.7.5 (2019-07-19)
 

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -108,10 +108,10 @@ module Pod
     #         The path to the root of the Pod.
     #
     # @param  [Bool] development
-    #         Wether the group should be added to the Development Pods group.
+    #         Whether the group should be added to the Development Pods group.
     #
     # @param  [Bool] absolute
-    #         Wether the path of the group should be set as absolute.
+    #         Whether the path of the group should be set as absolute.
     #
     # @return [PBXGroup] The new group.
     #

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -413,6 +413,16 @@ module Pod
       end
     end
 
+    # @param [Specification] spec The non library spec to calculate the deployment target for.
+    #
+    # @return [String] The deployment target to use for the non library spec. If the spec provides one then that is the
+    #         one used otherwise the one for the whole target is used.
+    #
+    def deployment_target_for_non_library_spec(spec)
+      raise ArgumentError, 'Must be a non library spec.' unless spec.non_library_specification?
+      spec.deployment_target(platform.name)
+    end
+
     # Returns the corresponding native product type to use given the test type.
     # This is primarily used when creating the native targets in order to produce the correct test bundle target
     # based on the type of tests included.

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -733,6 +733,28 @@ module Pod
         end
       end
 
+      describe 'Deployment target' do
+        before do
+          @watermelon_spec = fixture_spec('watermelon-lib/WatermelonLib.podspec')
+          @pod_target = fixture_pod_target(@watermelon_spec, false, {}, [], Platform.new(:ios, '9.0'))
+        end
+
+        it 'returns the correct deployment target it was initialized with' do
+          @pod_target.platform.deployment_target.to_s.should == '9.0'
+        end
+
+        it 'returns the correct non library spec deployment target that is inherited from parent' do
+          @pod_target.deployment_target_for_non_library_spec(@watermelon_spec.app_specs.first).to_s.should == '9.0'
+        end
+
+        it 'returns the overridden non library spec deployment target that is inherited from parent' do
+          @watermelon_spec.test_specs.first.ios.deployment_target = '8.0'
+          @watermelon_spec.app_specs.first.ios.deployment_target = '8.0'
+          @pod_target.deployment_target_for_non_library_spec(@watermelon_spec.test_specs.first).to_s.should == '8.0'
+          @pod_target.deployment_target_for_non_library_spec(@watermelon_spec.app_specs.first).to_s.should == '8.0'
+        end
+      end
+
       describe 'script phases support' do
         before do
           @pod_target = fixture_pod_target('coconut-lib/CoconutLib.podspec')


### PR DESCRIPTION
Even though subspecs _can_ define `deployment_target` we always pick the _max_ between library specs. That is because subspecs do not generate their own target in Xcode and are always merged into a single library target (framework or static library) so we need to pick something and we pick the _max_.

However, app specs and test specs _do_ generate an Xcode target for each (1-to-1), therefore we can honor the deployment target that is set for them. If it's not set then we pickup the one from the parent.

This PR does that.