### PR TITLE
Store relative project and file paths in the incremental cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9029](https://github.com/CocoaPods/CocoaPods/pull/9029)
 
+* Store relative project and file paths in the incremental cache.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9041](https://github.com/CocoaPods/CocoaPods/pull/9041)
+
 
 ## 1.7.5 (2019-07-19)
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -188,8 +188,8 @@ module Pod
                                                      analysis_result.all_user_build_configurations, object_version)
       else
         UI.message 'Analyzing Project Cache' do
-          @installation_cache = ProjectCache::ProjectInstallationCache.from_file(sandbox.project_installation_cache_path)
-          @metadata_cache = ProjectCache::ProjectMetadataCache.from_file(sandbox.project_metadata_cache_path)
+          @installation_cache = ProjectCache::ProjectInstallationCache.from_file(sandbox, sandbox.project_installation_cache_path)
+          @metadata_cache = ProjectCache::ProjectMetadataCache.from_file(sandbox, sandbox.project_metadata_cache_path)
           @project_cache_version = ProjectCache::ProjectCacheVersion.from_file(sandbox.project_version_cache_path)
 
           force_clean_install = clean_install || project_cache_version.version != Version.create(VersionMetadata.project_cache_version)

--- a/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
@@ -124,9 +124,10 @@ module Pod
             when PodTarget
               local = sandbox.local?(target.pod_name)
               checkout_options = sandbox.checkout_sources[target.pod_name]
-              [label, TargetCacheKey.from_pod_target(target, :is_local_pod => local, :checkout_options => checkout_options)]
+              [label, TargetCacheKey.from_pod_target(sandbox, target, :is_local_pod => local,
+                                                                      :checkout_options => checkout_options)]
             when AggregateTarget
-              [label, TargetCacheKey.from_aggregate_target(target)]
+              [label, TargetCacheKey.from_aggregate_target(sandbox, target)]
             else
               raise "[BUG] Unknown target type #{target}"
             end

--- a/lib/cocoapods/installer/project_cache/project_installation_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_installation_cache.rb
@@ -50,12 +50,12 @@ module Pod
           Sandbox.update_changed_file(path, YAMLHelper.convert(to_hash))
         end
 
-        def self.from_file(path)
+        def self.from_file(sandbox, path)
           return ProjectInstallationCache.new unless File.exist?(path)
           contents = YAMLHelper.load_file(path)
           cache_keys = contents.fetch('CACHE_KEYS', {})
           cache_key_by_target_label = Hash[cache_keys.map do |name, key_hash|
-            [name, TargetCacheKey.from_cache_hash(key_hash)]
+            [name, TargetCacheKey.from_cache_hash(sandbox, key_hash)]
           end]
           project_object_version = contents['OBJECT_VERSION']
           build_configurations = contents['BUILD_CONFIGURATIONS']

--- a/lib/cocoapods/installer/project_cache/project_metadata_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_metadata_cache.rb
@@ -6,6 +6,10 @@ module Pod
       class ProjectMetadataCache
         require 'cocoapods/installer/project_cache/target_metadata.rb'
 
+        # @return [Sandbox] The sandbox where the Pods should be installed.
+        #
+        attr_reader :sandbox
+
         # @return [Hash{String => TargetMetadata}]
         #         Hash of string by target metadata.
         #
@@ -13,9 +17,11 @@ module Pod
 
         # Initialize a new instance.
         #
+        # @param [Sandbox] sandbox see #sandbox
         # @param [Hash{String => TargetMetadata}] target_label_by_metadata @see #target_label_by_metadata
         #
-        def initialize(target_label_by_metadata = {})
+        def initialize(sandbox, target_label_by_metadata = {})
+          @sandbox = sandbox
           @target_label_by_metadata = target_label_by_metadata
         end
 
@@ -47,15 +53,15 @@ module Pod
           installation_results = pod_target_installation_results.values + aggregate_target_installation_results.values
           installation_results.each do |installation_result|
             native_target = installation_result.native_target
-            target_label_by_metadata[native_target.name] = TargetMetadata.from_native_target(native_target)
+            target_label_by_metadata[native_target.name] = TargetMetadata.from_native_target(sandbox, native_target)
           end
         end
 
-        def self.from_file(path)
-          return ProjectMetadataCache.new unless File.exist?(path)
+        def self.from_file(sandbox, path)
+          return ProjectMetadataCache.new(sandbox) unless File.exist?(path)
           contents = YAMLHelper.load_file(path)
           target_by_label_metadata = Hash[contents.map { |target_label, hash| [target_label, TargetMetadata.from_hash(hash)] }]
-          ProjectMetadataCache.new(target_by_label_metadata)
+          ProjectMetadataCache.new(sandbox, target_by_label_metadata)
         end
       end
     end

--- a/lib/cocoapods/installer/project_cache/target_cache_key.rb
+++ b/lib/cocoapods/installer/project_cache/target_cache_key.rb
@@ -8,6 +8,10 @@ module Pod
         require 'cocoapods/target/aggregate_target.rb'
         require 'digest'
 
+        # @return [Sandbox] The sandbox where the Pods should be installed.
+        #
+        attr_reader :sandbox
+
         # @return [Symbol]
         #         The type of target. Either aggregate or pod target.
         #
@@ -20,10 +24,12 @@ module Pod
 
         # Initialize a new instance.
         #
+        # @param [Sandbox] sandbox see #sandbox
         # @param [Symbol] type @see #type
         # @param [Hash{String => Object}] key_hash @see #key_hash
         #
-        def initialize(type, key_hash)
+        def initialize(sandbox, type, key_hash)
+          @sandbox = sandbox
           @type = type
           @key_hash = key_hash
         end
@@ -74,12 +80,14 @@ module Pod
 
         # Creates a TargetCacheKey instance from the given hash.
         #
+        # @param [Sandbox] sandbox The sandbox to use to construct a TargetCacheKey object.
+        #
         # @param [Hash{String => Object}] key_hash
         #        The hash used to construct a TargetCacheKey object.
         #
         # @return [TargetCacheKey]
         #
-        def self.from_cache_hash(key_hash)
+        def self.from_cache_hash(sandbox, key_hash)
           cache_hash = key_hash.dup
           if files = cache_hash['FILES']
             cache_hash['FILES'] = files.sort_by(&:downcase)
@@ -88,10 +96,12 @@ module Pod
             cache_hash['SPECS'] = specs.sort_by(&:downcase)
           end
           type = cache_hash['CHECKSUM'] ? :pod_target : :aggregate
-          TargetCacheKey.new(type, cache_hash)
+          TargetCacheKey.new(sandbox, type, cache_hash)
         end
 
         # Constructs a TargetCacheKey instance from a PodTarget.
+        #
+        # @param [Sandbox] sandbox The sandbox to use to construct a TargetCacheKey object.
         #
         # @param [PodTarget] pod_target
         #        The pod target used to construct a TargetCacheKey object.
@@ -104,7 +114,7 @@ module Pod
         #
         # @return [TargetCacheKey]
         #
-        def self.from_pod_target(pod_target, is_local_pod: false, checkout_options: nil)
+        def self.from_pod_target(sandbox, pod_target, is_local_pod: false, checkout_options: nil)
           build_settings = {}
           build_settings[pod_target.label.to_s] = Digest::MD5.hexdigest(pod_target.build_settings.xcconfig.to_s)
           pod_target.test_spec_build_settings.each do |name, settings|
@@ -120,25 +130,30 @@ module Pod
             'BUILD_SETTINGS_CHECKSUM' => build_settings,
             'PROJECT_NAME' => pod_target.project_name,
           }
-          contents['FILES'] = pod_target.all_files.sort_by(&:downcase) if is_local_pod
+          if is_local_pod
+            relative_file_paths = pod_target.all_files.map { |f| Pathname.new(f).relative_path_from(sandbox.root).to_s }
+            contents['FILES'] = relative_file_paths.sort_by(&:downcase)
+          end
           contents['CHECKOUT_OPTIONS'] = checkout_options if checkout_options
-          TargetCacheKey.new(:pod_target, contents)
+          TargetCacheKey.new(sandbox, :pod_target, contents)
         end
 
         # Construct a TargetCacheKey instance from an AggregateTarget.
+        #
+        # @param [Sandbox] sandbox The sandbox to use to construct a TargetCacheKey object.
         #
         # @param [AggregateTarget] aggregate_target
         #        The aggregate target used to construct a TargetCacheKey object.
         #
         # @return [TargetCacheKey]
         #
-        def self.from_aggregate_target(aggregate_target)
+        def self.from_aggregate_target(sandbox, aggregate_target)
           build_settings = {}
           aggregate_target.user_build_configurations.keys.each do |configuration|
             build_settings[configuration] = Digest::MD5.hexdigest(aggregate_target.build_settings(configuration).xcconfig.to_s)
           end
 
-          TargetCacheKey.new(:aggregate, 'BUILD_SETTINGS_CHECKSUM' => build_settings)
+          TargetCacheKey.new(sandbox, :aggregate, 'BUILD_SETTINGS_CHECKSUM' => build_settings)
         end
       end
     end

--- a/lib/cocoapods/installer/project_cache/target_metadata.rb
+++ b/lib/cocoapods/installer/project_cache/target_metadata.rb
@@ -56,13 +56,17 @@ module Pod
 
         # Constructs a TargetMetadata instance from a native target.
         #
+        # @param [Sandbox] sandbox
+        #        The sandbox used for this installation.
+        #
         # @param [PBXNativeTarget] native_target
         #        The native target used to construct a TargetMetadata instance.
         #
         # @return [TargetMetadata]
         #
-        def self.from_native_target(native_target)
-          TargetMetadata.new(native_target.name, native_target.uuid, native_target.project.path.to_s)
+        def self.from_native_target(sandbox, native_target)
+          TargetMetadata.new(native_target.name, native_target.uuid,
+                             native_target.project.path.relative_path_from(sandbox.root).to_s)
         end
       end
     end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_dependency_installer.rb
@@ -59,8 +59,8 @@ module Pod
                 # Hit the cache
                 is_local = sandbox.local?(pod_target.pod_name)
                 cached_dependency = metadata_cache.target_label_by_metadata[pod_target.label]
-                project.add_cached_pod_subproject(cached_dependency, is_local)
-                Project.add_cached_dependency(aggregate_native_target, cached_dependency)
+                project.add_cached_pod_subproject(sandbox, cached_dependency, is_local)
+                Project.add_cached_dependency(sandbox, aggregate_native_target, cached_dependency)
               end
             end
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -6,6 +6,10 @@ module Pod
       class PodTargetDependencyInstaller
         require 'cocoapods/native_target_extension.rb'
 
+        # @return [Sandbox] The sandbox used for this installation.
+        #
+        attr_reader :sandbox
+
         # @return [TargetInstallationResults] The target installation results for pod targets.
         #
         attr_reader :pod_target_installation_results
@@ -13,10 +17,6 @@ module Pod
         # @return [ProjectMetadataCache] The metadata cache for targets.
         #
         attr_reader :metadata_cache
-
-        # @return [Sandbox] The sandbox used for this installation.
-        #
-        attr_reader :sandbox
 
         # Initialize a new instance.
         #
@@ -85,8 +85,8 @@ module Pod
             else
               # Hit the cache
               cached_dependency = metadata_cache.target_label_by_metadata[dependent_target.label]
-              project.add_cached_pod_subproject(cached_dependency, is_local)
-              Project.add_cached_dependency(native_target, cached_dependency)
+              project.add_cached_pod_subproject(sandbox, cached_dependency, is_local)
+              Project.add_cached_dependency(sandbox, native_target, cached_dependency)
             end
           end
         end
@@ -111,8 +111,8 @@ module Pod
               else
                 # Hit the cache
                 cached_dependency = metadata_cache.target_label_by_metadata[test_dependent_target.label]
-                project.add_cached_pod_subproject(cached_dependency, is_local)
-                Project.add_cached_dependency(test_native_target, cached_dependency)
+                project.add_cached_pod_subproject(sandbox, cached_dependency, is_local)
+                Project.add_cached_dependency(sandbox, test_native_target, cached_dependency)
               end
             end
 
@@ -155,8 +155,8 @@ module Pod
           else
             # Hit the cache
             cached_dependency = metadata_cache.target_label_by_metadata[app_host_target_label]
-            project.add_cached_subproject_reference(cached_dependency, project.dependencies_group)
-            Project.add_cached_dependency(test_native_target, cached_dependency)
+            project.add_cached_subproject_reference(sandbox, cached_dependency, project.dependencies_group)
+            Project.add_cached_dependency(sandbox, test_native_target, cached_dependency)
           end
         end
 
@@ -186,8 +186,8 @@ module Pod
               else
                 # Hit the cache
                 cached_dependency = metadata_cache.target_label_by_metadata[app_dependent_target.label]
-                project.add_cached_pod_subproject(cached_dependency, is_local)
-                Project.add_cached_dependency(native_target, cached_dependency)
+                project.add_cached_pod_subproject(sandbox, cached_dependency, is_local)
+                Project.add_cached_dependency(sandbox, native_target, cached_dependency)
               end
             end
           end

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -150,6 +150,9 @@ module Pod
     # Creates a new subproject reference for the given cached metadata and configures its
     # group location.
     #
+    # @param [Sandbox] sandbox
+    #        The sandbox used for installation.
+    #
     # @param [TargetMetadata] metadata
     #        The project metadata to be added.
     #
@@ -159,9 +162,9 @@ module Pod
     #
     # @return [PBXFileReference] The new file reference.
     #
-    def add_cached_pod_subproject(metadata, development = false)
+    def add_cached_pod_subproject(sandbox, metadata, development = false)
       parent_group = group_for_subproject_reference(development)
-      add_cached_subproject_reference(metadata, parent_group)
+      add_cached_subproject_reference(sandbox, metadata, parent_group)
     end
 
     # @return [Array<PBXGroup>] Returns all the group of the Pods.
@@ -291,6 +294,9 @@ module Pod
 
     # Adds a file reference for a cached project as a child of the given group.
     #
+    # @param  [Sandbox] sandbox
+    #         The sandbox used for installation.
+    #
     # @param  [MetadataCache] metadata
     #         The metadata holding the required properties to create a subproject reference.
     #
@@ -299,8 +305,8 @@ module Pod
     #
     # @return [PBXFileReference] The new file reference.
     #
-    def add_cached_subproject_reference(metadata, group)
-      new_subproject_file_reference(metadata.container_project_path, group)
+    def add_cached_subproject_reference(sandbox, metadata, group)
+      new_subproject_file_reference(sandbox.root + metadata.container_project_path, group)
     end
 
     # Returns the file reference for the given absolute path.

--- a/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
+++ b/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
@@ -14,7 +14,10 @@ module Pod
           @pod_targets = [@banana_lib, @orange_lib, @monkey_lib]
           @main_aggregate_target = fixture_aggregate_target(@pod_targets)
           secondary_target_definition = fixture_target_definition('Pods2')
-          @secondary_aggregate_target = fixture_aggregate_target([@banana_lib, @monkey_lib], false, Pod::Target::DEFAULT_BUILD_CONFIGURATIONS, [], Pod::Platform.new(:ios, '6.0'), secondary_target_definition)
+          @secondary_aggregate_target = fixture_aggregate_target([@banana_lib, @monkey_lib], false,
+                                                                 Pod::Target::DEFAULT_BUILD_CONFIGURATIONS, [],
+                                                                 Pod::Platform.new(:ios, '6.0'),
+                                                                 secondary_target_definition)
           @sandbox.project_path.mkpath
           @main_aggregate_target.support_files_dir.mkpath
           @secondary_aggregate_target.support_files_dir.mkpath
@@ -34,8 +37,8 @@ module Pod
           end
 
           it 'returns an empty result if no targets have changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, @pod_targets, [@main_aggregate_target])
@@ -45,8 +48,8 @@ module Pod
           end
 
           it 'returns the list of pod targets that have changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             @banana_lib.root_spec.stubs(:checksum).returns('Blah')
@@ -57,8 +60,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if the build configurations have changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations.merge('Production' => :release), @project_object_version, @pod_targets, [@main_aggregate_target])
@@ -68,8 +71,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if the project object version configurations has changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, 2, @pod_targets, [@main_aggregate_target])
@@ -79,8 +82,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if a project name has changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             @banana_lib.stubs(:project_name).returns('SomeProject')
@@ -91,10 +94,10 @@ module Pod
           end
 
           it 'returns all aggregate targets if one has changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache_key_by_aggregate_target_labels = {
-              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target),
-              @secondary_aggregate_target.label => TargetCacheKey.from_cache_hash('BUILD_SETTINGS_CHECKSUM' => 'Blah'),
+              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target),
+              @secondary_aggregate_target.label => TargetCacheKey.from_cache_hash(@sandbox, 'BUILD_SETTINGS_CHECKSUM' => 'Blah'),
             }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
@@ -106,10 +109,10 @@ module Pod
           end
 
           it 'returns all aggregate targets if one has been removed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache_key_by_aggregate_target_labels = {
-              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target),
-              @secondary_aggregate_target.label => TargetCacheKey.from_aggregate_target(@secondary_aggregate_target),
+              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target),
+              @secondary_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @secondary_aggregate_target),
             }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
@@ -121,7 +124,7 @@ module Pod
           end
 
           it 'returns all aggregate targets if one has been added' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache_key_by_aggregate_target_labels = {}
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
@@ -142,7 +145,7 @@ module Pod
 
           it 'returns a pod if its target support dir is dirty' do
             FileUtils.rm_rf @orange_lib.support_files_dir
-            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
+            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, @pod_targets, [])
             result = analyzer.analyze
@@ -152,7 +155,7 @@ module Pod
 
           it 'returns a pod if its project file is dirty' do
             FileUtils.rm_rf @sandbox.pod_target_project_path(@orange_lib.pod_name)
-            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
+            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, @pod_targets, [])
             result = analyzer.analyze
@@ -164,8 +167,8 @@ module Pod
             cache_pod_targets = [@banana_lib, @orange_lib]
             FileUtils.rm_rf @sandbox.pod_target_project_path(@monkey_lib.pod_name)
 
-            cache_key_by_pod_target_labels = Hash[cache_pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[cache_pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
 
@@ -187,8 +190,8 @@ module Pod
             end
 
             cache_key_by_aggregate_target_labels = {
-              subspec_target_1.label => TargetCacheKey.from_pod_target(subspec_target_1),
-              subspec_target_2.label => TargetCacheKey.from_cache_hash('BUILD_SETTINGS_CHECKSUM' => 'Blah'),
+              subspec_target_1.label => TargetCacheKey.from_pod_target(@sandbox, subspec_target_1),
+              subspec_target_2.label => TargetCacheKey.from_cache_hash(@sandbox, 'BUILD_SETTINGS_CHECKSUM' => 'Blah'),
             }
             cache = ProjectInstallationCache.new(cache_key_by_aggregate_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, subspec_pods, [])
@@ -211,7 +214,7 @@ module Pod
             end
 
             cache_key_by_aggregate_target_labels = {
-              subspec_target_1.label => TargetCacheKey.from_pod_target(original_subspec),
+              subspec_target_1.label => TargetCacheKey.from_pod_target(@sandbox, original_subspec),
             }
 
             cache = ProjectInstallationCache.new(cache_key_by_aggregate_target_labels, @build_configurations, @project_object_version)

--- a/spec/unit/installer/project_cache/target_cache_key_spec.rb
+++ b/spec/unit/installer/project_cache/target_cache_key_spec.rb
@@ -6,10 +6,11 @@ module Pod
     module ProjectCache
       describe TargetCacheKey do
         before do
-          @banana_pod_target = fixture_pod_target('banana-lib/BananaLib.podspec')
-          @banana_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target)
+          @banana_spec = fixture_spec('banana-lib/BananaLib.podspec')
+          @banana_pod_target = fixture_pod_target(@banana_spec)
+          @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target)
           @aggregate_target = fixture_aggregate_target
-          @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(@aggregate_target)
+          @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, @aggregate_target)
         end
 
         describe 'cache key structure' do
@@ -19,7 +20,7 @@ module Pod
             subspec2 = Pod::Specification.new(root_spec, 'Module')
 
             pod_target = fixture_pod_target_with_specs([root_spec, subspec1, subspec2], true)
-            cache_key = TargetCacheKey.from_pod_target(pod_target)
+            cache_key = TargetCacheKey.from_pod_target(config.sandbox, pod_target)
             cache_key.to_h['SPECS'].should.equal(['BananaLib (1.0)', 'BananaLib/Module (1.0)', 'BananaLib/MUS (1.0)'])
           end
         end
@@ -32,7 +33,7 @@ module Pod
           it 'should return inequality for different checksums' do
             diff_banana_checksum = fixture_pod_target('banana-lib/BananaLib.podspec')
             diff_banana_checksum.root_spec.stubs(:checksum).returns('blah')
-            diff_banana_cache_key = TargetCacheKey.from_pod_target(diff_banana_checksum)
+            diff_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, diff_banana_checksum)
             difference = @banana_cache_key.key_difference(diff_banana_cache_key)
             inverse_difference = diff_banana_cache_key.key_difference(@banana_cache_key)
             difference.should.equal(:project)
@@ -41,7 +42,7 @@ module Pod
 
           it 'should return inequality for external pod turned local' do
             local_banana = fixture_pod_target('banana-lib/BananaLib.podspec')
-            local_banana_cache_key = TargetCacheKey.from_pod_target(local_banana, :is_local_pod => true)
+            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, local_banana, :is_local_pod => true)
             difference = @banana_cache_key.key_difference(local_banana_cache_key)
             inverse_difference = local_banana_cache_key.key_difference(@banana_cache_key)
             difference.should.equal(:project)
@@ -63,7 +64,8 @@ module Pod
             added_dependency_aggregate_target = AggregateTarget.new(config.sandbox, false, { 'Debug' => :debug }, [], Platform.ios,
                                                                     fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
                                                                     nil, 'Debug' => [@banana_pod_target])
-            added_dependency_cache_key = TargetCacheKey.from_aggregate_target(added_dependency_aggregate_target)
+            added_dependency_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox,
+                                                                              added_dependency_aggregate_target)
             diff = @aggregate_target_cache_key.key_difference(added_dependency_cache_key)
             inverse_diff = added_dependency_cache_key.key_difference(@aggregate_target_cache_key)
             diff.should.equal(:project)
@@ -74,24 +76,28 @@ module Pod
             old_checkout_options = { 'BananaLib' => { :git => 'https://git.com', :sha => '1' } }
             new_checkout_options = { 'BananaLib' => { :git => 'https://git.com', :sha => '2' } }
 
-            banana_sha1_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target, :checkout_options => old_checkout_options)
-            banana_sha2_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target, :checkout_options => new_checkout_options)
+            banana_sha1_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+                                                                   :checkout_options => old_checkout_options)
+            banana_sha2_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+                                                                   :checkout_options => new_checkout_options)
 
             banana_sha1_cache_key.key_difference(banana_sha2_cache_key).should.equal(:project)
 
-            banana_no_checkout_options = TargetCacheKey.from_pod_target(@banana_pod_target)
+            banana_no_checkout_options = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target)
             banana_no_checkout_options.key_difference(banana_sha1_cache_key).should.equal(:project)
             banana_sha1_cache_key.key_difference(banana_no_checkout_options).should.equal(:project)
           end
 
           it 'should return inequality if the list of tracked files has changed' do
             added_banana_files_target = fixture_pod_target('banana-lib/BananaLib.podspec')
-            @banana_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target, :is_local_pod => true)
-            new_file = ['CoolFile.h']
+            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+                                                               :is_local_pod => true)
+            new_file = [(Pod::Sandbox::PathList.new(@banana_spec.defined_in_file.dirname).root + 'CoolFile.h').to_s]
             added_files_list = new_file + @banana_pod_target.all_files
             added_banana_files_target.stubs(:all_files).returns(added_files_list)
 
-            added_banana_cache_key = TargetCacheKey.from_pod_target(added_banana_files_target, :is_local_pod => true)
+            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, added_banana_files_target,
+                                                                    :is_local_pod => true)
             diff = added_banana_cache_key.key_difference(@banana_cache_key)
             inverse_diff = @banana_cache_key.key_difference(added_banana_cache_key)
             diff.should.equal(:project)
@@ -105,17 +111,18 @@ module Pod
               'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"',
             }
             changed_build_settings_target.build_settings.stubs(:xcconfig).returns(Xcodeproj::Config.new(changed_build_settings))
-            changed_build_settings_cache_key = TargetCacheKey.from_pod_target(changed_build_settings_target)
+            changed_build_settings_cache_key = TargetCacheKey.from_pod_target(config.sandbox,
+                                                                              changed_build_settings_target)
             @banana_cache_key.key_difference(changed_build_settings_cache_key).should.equal(:project)
             changed_build_settings_cache_key.key_difference(@banana_cache_key).should.equal(:project)
           end
 
           it 'should return inequality if the project name changed' do
             banana_project_target = fixture_pod_target('banana-lib/BananaLib.podspec')
-            @banana_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target)
+            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target)
             banana_project_target.stubs(:project_name).returns('SomeProject')
 
-            added_banana_cache_key = TargetCacheKey.from_pod_target(banana_project_target)
+            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, banana_project_target)
             diff = added_banana_cache_key.key_difference(@banana_cache_key)
             inverse_diff = @banana_cache_key.key_difference(added_banana_cache_key)
             diff.should.equal(:project)
@@ -125,23 +132,25 @@ module Pod
 
         describe 'key_difference with hash objects' do
           it 'should return equality for same pod target and hash' do
-            hash_cache_key = TargetCacheKey.from_cache_hash(@banana_cache_key.to_h)
+            hash_cache_key = TargetCacheKey.from_cache_hash(config.sandbox, @banana_cache_key.to_h)
             @banana_cache_key.key_difference(hash_cache_key).should.equal(:none)
             hash_cache_key.key_difference(@banana_cache_key).should.equal(:none)
           end
 
           it 'should return equality for same local pod target and hash' do
-            local_banana_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target, :is_local_pod => true)
-            hash_cache_key = TargetCacheKey.from_cache_hash(local_banana_cache_key.to_h)
+            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+                                                                    :is_local_pod => true)
+            hash_cache_key = TargetCacheKey.from_cache_hash(config.sandbox, local_banana_cache_key.to_h)
             local_banana_cache_key.key_difference(hash_cache_key).should.equal(:none)
             hash_cache_key.key_difference(local_banana_cache_key).should.equal(:none)
           end
 
           it 'should return inequality for modified pod target' do
-            local_banana_cache_key = TargetCacheKey.from_pod_target(@banana_pod_target, :is_local_pod => true)
+            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+                                                                    :is_local_pod => true)
             cache_hash = local_banana_cache_key.to_h.dup
             cache_hash['FILES'] = cache_hash['FILES'].dup << 'Blah.h'
-            hash_cache_key = TargetCacheKey.from_cache_hash(cache_hash)
+            hash_cache_key = TargetCacheKey.from_cache_hash(config.sandbox, cache_hash)
             local_banana_cache_key.key_difference(hash_cache_key).should.equal(:project)
             hash_cache_key.key_difference(local_banana_cache_key).should.equal(:project)
           end

--- a/spec/unit/native_target_extension_spec.rb
+++ b/spec/unit/native_target_extension_spec.rb
@@ -12,7 +12,7 @@ module Pod
     end
 
     it 'adds a cached dependency correctly' do
-      Project.add_cached_dependency(@native_target, @metadata)
+      Project.add_cached_dependency(config.sandbox, @native_target, @metadata)
       @native_target.dependencies.count.should.be.equal 1
       @native_target.dependencies.first.name.should.equal 'Bubba'
     end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -119,7 +119,7 @@ module Pod
           subproject_path = config.sandbox.pod_target_project_path('SubprojA')
           subproject_path.mkpath
           metadata = Installer::ProjectCache::TargetMetadata.new('LabelA', '0000', subproject_path)
-          ref = @project.add_cached_pod_subproject(metadata)
+          ref = @project.add_cached_pod_subproject(config.sandbox, metadata)
           @project.main_group['Pods'].children.should.equal([ref])
         end
       end


### PR DESCRIPTION
All paths stored for the cache are now relative to the `sandbox.root`.

This way if a project is generated with incremental installation and is shared to someone else it will continue to work and the cache won't change.

See https://github.com/CocoaPods/CocoaPods/issues/8319#issuecomment-513093481