### PR TITLE
Allow Algolia search for CDNSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Allow Algolia search for CDNSource  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9015](https://github.com/CocoaPods/CocoaPods/issues/9015)
+  [#9046](https://github.com/CocoaPods/CocoaPods/pull/9046)
+  [Core#569](https://github.com/CocoaPods/Core/pull/569)
+
 * Using `repo push` now pushes to the current repo branch (`HEAD`) instead of `master`  
   [Jhonatan Avalos](https://github.com/baguio)
   [#8630](https://github.com/CocoaPods/CocoaPods/pull/8630)  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,12 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 0500e18fe1a4b849e917d2788b3ec154995ed9dc
+  revision: 5c62627fd1f5d64610b7a9a2bad27b986075a8c1
   branch: master
   specs:
     cocoapods-core (1.7.5)
       activesupport (>= 4.0.2, < 6)
+      algoliasearch (~> 1.0)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
 
@@ -140,6 +141,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    algoliasearch (1.26.0)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
     ast (2.2.0)
     atomos (0.1.3)
     awesome_print (1.6.1)
@@ -184,6 +188,7 @@ GEM
     gh_inspector (1.1.3)
     git (1.3.0)
     hashdiff (0.3.1)
+    httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     inch (0.8.0)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -141,10 +141,10 @@ module Pod
       #
       def update_repositories
         sources.each do |source|
-          if source.git?
+          if source.updateable?
             sources_manager.update(source.name, true)
           else
-            UI.message "Skipping `#{source.name}` update because the repository is not a git source repository."
+            UI.message "Skipping `#{source.name}` update because the repository is not an updateable repository."
           end
         end
         @specs_updated = true

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -107,9 +107,9 @@ module Pod
       #
       def update(source_name = nil, show_output = false)
         if source_name
-          sources = [git_source_named(source_name)]
+          sources = [updateable_source_named(source_name)]
         else
-          sources = git_sources
+          sources = updateable_sources
         end
 
         changed_spec_paths = {}

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -82,7 +82,7 @@ module Pod
         analyzer.update_repositories
       end
 
-      it 'does not update non-git repositories' do
+      it 'does not update non-updateable repositories' do
         tmp_directory = Pathname(Dir.tmpdir) + 'CocoaPods'
         FileUtils.mkdir_p(tmp_directory)
         FileUtils.cp_r(ROOT + 'spec/fixtures/spec-repos/test_repo/', tmp_directory)
@@ -103,7 +103,7 @@ module Pod
         analyzer.stubs(:sources).returns([source])
         analyzer.update_repositories
 
-        UI.output.should.match /Skipping `#{source.name}` update because the repository is not a git source repository./
+        UI.output.should.match /Skipping `#{source.name}` update because the repository is not an updateable repository./
 
         FileUtils.rm_rf(non_git_repo)
       end
@@ -117,7 +117,7 @@ module Pod
         end
 
         # Note that we are explicitly ignoring 'repo_1' since it isn't used.
-        source = mock('source', :name => 'repo_2', :git? => true)
+        source = mock('source', :name => 'repo_2', :updateable? => true)
         sources_manager = Source::Manager.new(config.repos_dir)
         sources_manager.expects(:find_or_create_source_with_url).with(repo_url).returns(source)
         sources_manager.expects(:update).once.with('repo_2', true)
@@ -167,7 +167,7 @@ module Pod
         plugin_source = Pod::Source.new(source_repo_dir)
         plugin_source.stubs(:all_specs).returns([spec])
         plugin_source.stubs(:url).returns('protocol://special-source.org/my-specs')
-        plugin_source.stubs(:git?).returns(false)
+        plugin_source.stubs(:updateable?).returns(false)
 
         sources_manager = Source::Manager.new(repo_dir)
         sources_manager.stubs(:cdn_url?).returns(false)


### PR DESCRIPTION
Fixes #9015. 

This PR addresses the fact that current full-text search capabilities of CocoaPods rely on having the full text of all podspecs offline. For a CDN source, such as the Trunk, this isn't possible.

Instead, `CDNSource` uses the same Algolia index API that cocoapods.org uses.  
The configuration (API key, etc) is retrieved from the CDN server, to decouple configuration from the code.

This PR requires to be merged together with:
* [Core#569](https://github.com/CocoaPods/Core/pull/569) - most of the code!
* [Specs#14422](https://github.com/CocoaPods/Specs/pull/14422) - for the config.

Note: there's a commit that points to a fork of Core, marked `[DNM]`. It should be removed after Core PR is merged. 