### PR TITLE
Print project name when a target cannot be found.

### DIFF
--- a/lib/cocoapods/installer/analyzer/target_inspector.rb
+++ b/lib/cocoapods/installer/analyzer/target_inspector.rb
@@ -105,7 +105,7 @@ module Pod
           target = native_targets.find { |t| t.name == target_definition.name.to_s }
           unless target
             found = native_targets.map { |t| "`#{t.name}`" }.to_sentence
-            raise Informative, "Unable to find a target named `#{target_definition.name}`, did find #{found}."
+            raise Informative, "Unable to find a target named `#{target_definition.name}` in project `#{Pathname(user_project.path).basename}`, did find #{found}."
           end
           [target]
         end

--- a/spec/unit/installer/analyzer/target_inspector_spec.rb
+++ b/spec/unit/installer/analyzer/target_inspector_spec.rb
@@ -59,7 +59,7 @@ module Pod
     describe '#compute_targets' do
       it 'returns the targets specified in the target definition' do
         target_definition = Podfile::TargetDefinition.new('UserTarget', nil)
-        user_project = Xcodeproj::Project.new('path')
+        user_project = Xcodeproj::Project.new('UserProject.xcodeproj')
         user_project.new_target(:application, 'FirstTarget', :ios)
         user_project.new_target(:application, 'UserTarget', :ios)
 
@@ -70,11 +70,11 @@ module Pod
 
       it 'raises if it is unable to find the targets specified by the target definition' do
         target_definition = Podfile::TargetDefinition.new('UserTarget', nil)
-        user_project = Xcodeproj::Project.new('path')
+        user_project = Xcodeproj::Project.new('UserProject.xcodeproj')
 
         target_inspector = TargetInspector.new(target_definition, config.installation_root)
         e = lambda { target_inspector.send(:compute_targets, user_project) }.should.raise Informative
-        e.message.should.match /Unable to find a target named `UserTarget`/
+        e.message.should.match /Unable to find a target named `UserTarget` in project `UserProject.xcodeproj`/
       end
 
       it 'suggests project native target names if the target cannot be found' do


### PR DESCRIPTION
This was inspired by https://github.com/CocoaPods/CocoaPods/issues/9057 and helps consumers diagnose their problem easier.