### PR TITLE
Use the new Lockfile method option to warn about the old git spec repo

### DIFF
--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -205,7 +205,7 @@ module Pod
     # @return [Nil] If no Lockfile is available.
     #
     def lockfile
-      @lockfile ||= Lockfile.from_file(lockfile_path) if lockfile_path
+      @lockfile ||= Lockfile.from_file(lockfile_path, true) if lockfile_path
     end
 
     # Returns the path of the Podfile.


### PR DESCRIPTION
To be merged after https://github.com/CocoaPods/Core/pull/574 to unlock its function.