### PR TITLE
Fix resource bundle warning on WatchOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Add Apple watch device family to resource bundles built for WatchOS
+  [Aaron McDaniel](https://github.com/Spilly)
+  [#9075](https://github.com/CocoaPods/CocoaPods/issues/9075)
 
 ## 1.8.0.beta.1 (2019-08-05)
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7
 
 group :development do
   cp_gem 'claide',                'CLAide'
-  cp_gem 'cocoapods-core',        'Core', '1-8-stable'
+  cp_gem 'cocoapods-core',        'Core'
   cp_gem 'cocoapods-deintegrate', 'cocoapods-deintegrate'
   cp_gem 'cocoapods-downloader',  'cocoapods-downloader'
   cp_gem 'cocoapods-plugins',     'cocoapods-plugins'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: e77cd1cbf20f97562d58f6db6b65cedc943aa4df
-  branch: 1-8-stable
+  revision: 137cfe17c33646542fb8ed9231c52cd4e4754b2e
+  branch: master
   specs:
     cocoapods-core (1.8.0.beta.1)
       activesupport (>= 4.0.2, < 6)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -533,7 +533,7 @@ module Pod
                   device_family_by_platform = {
                     :ios => '1,2',
                     :tvos => '3',
-                    :watchos => '1,2,4' # The device family for watchOS is 4, but Xcode creates watchkit-compatible bundles as 1,2. Adding wathOS device family to resolve warning.
+                    :watchos => '1,2,4'
                   }
 
                   if (family = device_family_by_platform[target.platform.name])

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -533,7 +533,7 @@ module Pod
                   device_family_by_platform = {
                     :ios => '1,2',
                     :tvos => '3',
-                    :watchos => '1,2' # The device family for watchOS is 4, but Xcode creates watchkit-compatible bundles as 1,2
+                    :watchos => '1,2,4' # The device family for watchOS is 4, but Xcode creates watchkit-compatible bundles as 1,2. Adding wathOS device family to resolve warning.
                   }
 
                   if (family = device_family_by_platform[target.platform.name])


### PR DESCRIPTION
Fix warning generated by xcode when using a resource bundle generated by CocoaPods for a WatchOS target.

Fixes:
#9075 