### PR TITLE
Fix resource bundle warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Add Apple watch device family to resource bundles built for WatchOS
+  [Aaron McDaniel](https://github.com/Spilly)
+  [#9075](https://github.com/CocoaPods/CocoaPods/issues/9075)
 
 ## 1.8.0.beta.1 (2019-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Add Apple watch device family to resource bundles built for WatchOS
+* Add Apple watch device family to resource bundles built for WatchOS  
   [Aaron McDaniel](https://github.com/Spilly)
   [#9075](https://github.com/CocoaPods/CocoaPods/issues/9075)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -533,7 +533,7 @@ module Pod
                   device_family_by_platform = {
                     :ios => '1,2',
                     :tvos => '3',
-                    :watchos => '1,2' # The device family for watchOS is 4, but Xcode creates watchkit-compatible bundles as 1,2
+                    :watchos => '1,2,4'
                   }
 
                   if (family = device_family_by_platform[target.platform.name])

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -533,7 +533,7 @@ module Pod
                   device_family_by_platform = {
                     :ios => '1,2',
                     :tvos => '3',
-                    :watchos => '1,2,4'
+                    :watchos => '1,2,4',
                   }
 
                   if (family = device_family_by_platform[target.platform.name])


### PR DESCRIPTION
Fix warning generated by xcode when using a resource bundle generated by CocoaPods for a WatchOS target.

Fixes:
#9075