### PR TITLE
Fix last framework not being removed from the script

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb
@@ -30,7 +30,7 @@ module Pod
               # cause an App Store rejection because frameworks cannot be
               # embedded in embedded targets.
               #
-              create_embed_frameworks_script if target.includes_frameworks? && !target.requires_host_target?
+              create_embed_frameworks_script if !target.requires_host_target?
               create_bridge_support_file(native_target)
               create_copy_resources_script if target.includes_resources?
               create_acknowledgements


### PR DESCRIPTION
Removing the last pod dependency that vendors a framework and running
`pod install` caused the `install_framework "${PODS_ROOT}/*.framework"`
lines not to get removed from the CocoaPods generated
`Pods-*-frameworks.sh` script.