### PR TITLE
Fix iOS app spec code signing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix iOS app spec code signing.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9110](https://github.com/CocoaPods/CocoaPods/issues/9110)
+
 * Add Apple watch device family to resource bundles built for WatchOS  
   [Aaron McDaniel](https://github.com/Spilly)
   [#9075](https://github.com/CocoaPods/CocoaPods/issues/9075)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -445,6 +445,13 @@ module Pod
                 end
                 # For macOS we do not code sign the appbundle because we do not code sign the frameworks either.
                 configuration.build_settings['CODE_SIGN_IDENTITY'] = '' if target.platform == :osx
+                # For iOS, we delete the target_installer empty values that get set for libraries since CocoaPods will
+                # code sign the libraries manually but for apps this is not true.
+                if target.platform == :ios
+                  configuration.build_settings.delete('CODE_SIGN_IDENTITY[sdk=appletvos*]')
+                  configuration.build_settings.delete('CODE_SIGN_IDENTITY[sdk=iphoneos*]')
+                  configuration.build_settings.delete('CODE_SIGN_IDENTITY[sdk=watchos*]')
+                end
               end
 
               remove_pod_target_xcconfig_overrides_from_target(target.build_settings_for_spec(app_spec), app_native_target)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -213,6 +213,9 @@ module Pod
                   bc.build_settings['CODE_SIGNING_REQUIRED'].should == 'YES'
                   bc.build_settings['CODE_SIGNING_ALLOWED'].should == 'YES'
                   bc.build_settings['CODE_SIGN_IDENTITY'].should == 'iPhone Developer'
+                  bc.build_settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'].should.be.nil
+                  bc.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'].should.be.nil
+                  bc.build_settings['CODE_SIGN_IDENTITY[sdk=watchos*]'].should.be.nil
                   bc.build_settings['INFOPLIST_FILE'].should == 'App/WatermelonLib-App-Info.plist'
                   bc.build_settings['GCC_PREFIX_HEADER'].should == 'Target Support Files/WatermelonLib/WatermelonLib-App-prefix.pch'
                 end
@@ -1370,8 +1373,8 @@ module Pod
                 @banana_spec.resource_bundle = nil
                 @project.add_pod_group('BananaLib', fixture('banana-lib'))
 
-                @pod_target = fixture_pod_target(@banana_spec, false, 'Debug' => :debug, 'Release' => :release,
-                                                                      :build_type => Target::BuildType.dynamic_framework)
+                @pod_target = fixture_pod_target(@banana_spec, false, { 'Debug' => :debug, 'Release' => :release },
+                                                 :build_type => Target::BuildType.dynamic_framework)
                 target_installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
 
                 # Use a file references installer to add the files so that the correct ones are added.


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/9110

Today one cannot build an app spec for device due to code signing settings being broken.

I still ultimately want to re-do the target build settings but not for the 1.8.x beta.

cc @watt