### PR TITLE
Move custom `Copy Headers` script phase for header mappings before `Compile Sources`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Move custom `Copy Headers` script phase for header mappings before `Compile Sources`.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9131](https://github.com/CocoaPods/CocoaPods/pull/9131)
 
 
 ## 1.8.0.beta.2 (2019-08-27)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -934,10 +934,14 @@ module Pod
                               else
                                 file_ref.real_path.relative_path_from(file_accessor.path_list.root)
                               end
+              compile_build_phase_index = native_target.build_phases.index do |bp|
+                bp.is_a?(Xcodeproj::Project::Object::PBXSourcesBuildPhase)
+              end
               sub_dir = relative_path.dirname
               copy_phase_name = "Copy #{sub_dir} #{acl} Headers"
               copy_phase = native_target.copy_files_build_phases.find { |bp| bp.name == copy_phase_name } ||
                 native_target.new_copy_files_build_phase(copy_phase_name)
+              native_target.build_phases.move(copy_phase, compile_build_phase_index - 1) unless compile_build_phase_index.nil?
               copy_phase.symbol_dst_subfolder_spec = :products_directory
               copy_phase.dst_path = "$(#{acl.upcase}_HEADERS_FOLDER_PATH)/#{sub_dir}"
               copy_phase.add_file_reference(file_ref, true)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -1075,13 +1075,17 @@ module Pod
                   snake-umbrella.h
                 )
 
-                copy_files_build_phases = target.copy_files_build_phases.sort_by(&:name)
-                copy_files_build_phases.map(&:name).should == [
-                  'Copy . Public Headers',
+                target.build_phases.map(&:display_name).should == [
+                  'Headers',
                   'Copy A Public Headers',
+                  'Copy . Public Headers',
                   'Copy B Private Headers',
+                  'Sources',
+                  'Frameworks',
+                  'Resources',
                 ]
 
+                copy_files_build_phases = target.copy_files_build_phases.sort_by(&:name)
                 copy_files_build_phases.map(&:symbol_dst_subfolder_spec).should == Array.new(3, :products_directory)
 
                 copy_files_build_phases.map(&:dst_path).should == [


### PR DESCRIPTION
The custom "Copy Headers" phase added to preserve header mappings within a `.framework` are executed _after_ `Compile Sources`. This is generally fine but there is a case in which it can fail if the module itself imports its own header at an expected location. The header would not be copied by then causing a build failure.

This change moves these custom script phases to _always_ execute before `Compile Sources` so all headers are in the right spot before compilation.

- [x] add tests