### PR TITLE
Support plugins for incremental installation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Include Podfile Plugin changes for incremental installation.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#9147](https://github.com/CocoaPods/CocoaPods/pull/9147)
+
 * Integrate `use_frameworks!` linkage DSL.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9099](https://github.com/CocoaPods/CocoaPods/issues/9099)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -194,7 +194,7 @@ module Pod
 
           force_clean_install = clean_install || project_cache_version.version != Version.create(VersionMetadata.project_cache_version)
           cache_result = ProjectCache::ProjectCacheAnalyzer.new(sandbox, installation_cache, analysis_result.all_user_build_configurations,
-                                                                object_version, pod_targets, aggregate_targets, :clean_install => force_clean_install).analyze
+                                                                object_version, plugins, pod_targets, aggregate_targets, :clean_install => force_clean_install).analyze
           aggregate_targets_to_generate = cache_result.aggregate_targets_to_generate || []
           pod_targets_to_generate = cache_result.pod_targets_to_generate
           (aggregate_targets_to_generate + pod_targets_to_generate).each do |target|
@@ -775,6 +775,7 @@ module Pod
       installation_cache.update_cache_key_by_target_label!(cache_analysis_result.cache_key_by_target_label)
       installation_cache.update_project_object_version!(cache_analysis_result.project_object_version)
       installation_cache.update_build_configurations!(cache_analysis_result.build_configurations)
+      installation_cache.update_podfile_plugins!(plugins)
       installation_cache.save_as(sandbox.project_installation_cache_path)
 
       metadata_cache.update_metadata!(target_installation_results.pod_target_installation_results || {},

--- a/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
@@ -22,6 +22,10 @@ module Pod
         #
         attr_reader :project_object_version
 
+        # @return [Hash<String, Hash>] The podfile plugins to be run for the installation.
+        #
+        attr_reader :podfile_plugins
+
         # @return [Array<PodTarget>] The list of pod targets.
         #
         attr_reader :pod_targets
@@ -40,15 +44,17 @@ module Pod
         # @param [ProjectInstallationCache] cache @see #cache
         # @param [Hash{String => Symbol}] build_configurations @see #build_configurations
         # @param [Integer] project_object_version @see #project_object_version
+        # @param [Hash<String, Hash>] podfile_plugins @see #podfile_plugins
         # @param [Array<PodTarget>] pod_targets @see #pod_targets
         # @param [Array<AggregateTarget>] aggregate_targets @see #aggregate_targets
         # @param [Bool] clean_install @see #clean_install
         #
-        def initialize(sandbox, cache, build_configurations, project_object_version, pod_targets, aggregate_targets,
+        def initialize(sandbox, cache, build_configurations, project_object_version, podfile_plugins, pod_targets, aggregate_targets,
                        clean_install: false)
           @sandbox = sandbox
           @cache = cache
           @build_configurations = build_configurations
+          @podfile_plugins = podfile_plugins
           @pod_targets = pod_targets
           @aggregate_targets = aggregate_targets
           @project_object_version = project_object_version
@@ -70,7 +76,9 @@ module Pod
           end
 
           # Bail out early since these properties affect all targets and their associate projects.
-          if cache.build_configurations != build_configurations || cache.project_object_version != project_object_version
+          if cache.build_configurations != build_configurations ||
+              cache.project_object_version != project_object_version ||
+              cache.podfile_plugins != podfile_plugins
             UI.message 'Ignoring project cache due to project configuration changes.'
             return full_install_results
           end

--- a/lib/cocoapods/installer/project_cache/project_installation_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_installation_cache.rb
@@ -21,16 +21,23 @@ module Pod
         #
         attr_reader :project_object_version
 
+        # @return [Hash<String, Hash>]
+        #         Podfile plugins used with a particular install.
+        #
+        attr_reader :podfile_plugins
+
         # Initializes a new instance.
         #
         # @param [Hash{String => TargetCacheKey}] cache_key_by_target_label @see #cache_key_by_target_label
         # @param [Hash{String => Symbol}] build_configurations @see #build_configurations
         # @param [Integer] project_object_version @see #project_object_version
+        # @param [Hash<String, Hash>] podfile_plugins @see #podfile_plugins
         #
-        def initialize(cache_key_by_target_label = {}, build_configurations = nil, project_object_version = nil)
+        def initialize(cache_key_by_target_label = {}, build_configurations = nil, project_object_version = nil, podfile_plugins = {})
           @cache_key_by_target_label = cache_key_by_target_label
           @build_configurations = build_configurations
           @project_object_version = project_object_version
+          @podfile_plugins = podfile_plugins
         end
 
         def update_cache_key_by_target_label!(cache_key_by_target_label)
@@ -43,6 +50,10 @@ module Pod
 
         def update_project_object_version!(project_object_version)
           @project_object_version = project_object_version
+        end
+
+        def update_podfile_plugins!(podfile_plugins)
+          @podfile_plugins = podfile_plugins
         end
 
         def save_as(path)
@@ -59,7 +70,8 @@ module Pod
           end]
           project_object_version = contents['OBJECT_VERSION']
           build_configurations = contents['BUILD_CONFIGURATIONS']
-          ProjectInstallationCache.new(cache_key_by_target_label, build_configurations, project_object_version)
+          podfile_plugins = contents['PLUGINS']
+          ProjectInstallationCache.new(cache_key_by_target_label, build_configurations, project_object_version, podfile_plugins)
         end
 
         def to_hash
@@ -69,6 +81,7 @@ module Pod
           contents = { 'CACHE_KEYS' => cache_key_contents }
           contents['BUILD_CONFIGURATIONS'] = build_configurations if build_configurations
           contents['OBJECT_VERSION'] = project_object_version if project_object_version
+          contents['PLUGINS'] = podfile_plugins if podfile_plugins
           contents
         end
       end


### PR DESCRIPTION
Plugins can possibly dirty a target during installation without the core cocoapods logic knowing. If the podfile list of plugins and its inputs change, we will regenerate all pod targets.