### PR TITLE
Exclude the local spec-repos directory from Time Machine backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#9632](https://github.com/CocoaPods/CocoaPods/pull/9632)
 
+* Exclude the local spec-repos directory from Time Machine Backups.  
+  [Jakob Krigovsky](https://github.com/sonicdoe)
+  [#8308](https://github.com/CocoaPods/CocoaPods/issues/8308)
+
 ##### Bug Fixes
 
 * Re-implement `bcsymbolmap` copying to avoid duplicate outputs.  

--- a/lib/cocoapods/command/repo/update.rb
+++ b/lib/cocoapods/command/repo/update.rb
@@ -21,6 +21,17 @@ module Pod
         def run
           show_output = !config.silent?
           config.sources_manager.update(@name, show_output)
+          exclude_repos_dir_from_backup
+        end
+
+        private
+
+        # Excludes the repos directory from backups.
+        #
+        # @return [void]
+        #
+        def exclude_repos_dir_from_backup
+          config.exclude_from_backup(config.repos_dir)
         end
       end
     end

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -314,6 +314,18 @@ module Pod
       nil
     end
 
+    # Excludes the given dir from Time Machine backups.
+    #
+    # @param  [Pathname] dir
+    #         The directory to exclude from Time Machine backups.
+    #
+    # @return [void]
+    #
+    def exclude_from_backup(dir)
+      return if Gem.win_platform?
+      system('tmutil', 'addexclusion', dir.to_s, %i(out err) => File::NULL)
+    end
+
     public
 
     #-------------------------------------------------------------------------#

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -39,6 +39,16 @@ module Pod
       (repo2 + 'README').read.should.include 'Updated'
     end
 
+    # Conditionally skip the test if `tmutil` is not available.
+    has_tmutil = system('tmutil', 'version', :out => File::NULL)
+    cit = has_tmutil ? method(:it) : method(:xit)
+    cit.call 'excludes the spec-repo from Time Machine backups' do
+      repo_make('repo1')
+      repo_clone('repo1', 'repo2')
+      run_command('repo', 'update', 'repo2')
+      `tmutil isexcluded #{config.repos_dir + 'repo2'}`.chomp.should.start_with?('[Excluded]')
+    end
+
     it 'repo updates do not fail when executed in parallel' do
       repo1 = repo_make('repo1')
       repo_clone('repo1', 'repo2')

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -289,6 +289,26 @@ module Pod
         end
       end
 
+      describe '#exclude_from_backup' do
+        # Conditionally skip the test if `tmutil` is not available.
+        has_tmutil = system('tmutil', 'version', :out => File::NULL)
+        cit = has_tmutil ? method(:it) : method(:xit)
+        cit.call 'excludes the dir from Time Machine backups' do
+          dir = temporary_directory + 'no_backup'
+          FileUtils.mkdir(dir)
+          @config.send(:exclude_from_backup, dir)
+          `tmutil isexcluded #{dir}`.chomp.should.start_with?('[Excluded]')
+        end
+
+        it 'does not raise if the dir does not exist' do
+          dir = temporary_directory + 'no_backup'
+          FileUtils.remove_dir(dir, true)
+          should.not.raise do
+            @config.send(:exclude_from_backup, dir)
+          end
+        end
+      end
+
       #-----------------------------------------------------------------------#
     end
   end


### PR DESCRIPTION
Excludes the local spec-repos directory (`~/.cocoapods/repos`, by default) from Time Machine Backups using `tmutil addexclusion`. Resolves #8308.

Alternatively (and ideally), the local spec-repos directory could be placed under the `~/Library/Caches` directory (which is usually excluded by Time Machine as well as many other backup applications). However, that would arguably be a more drastic change.