### PR TITLE
Correctly set deployment target for non library specs even if the root spec does not specify one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Correctly set deployment target for non library specs even if the root spec does not specify one.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9153](https://github.com/CocoaPods/CocoaPods/pull/9153)
+
 * Make `APPLICATION_EXTENSION_API_ONLY` build setting not break when performing a cached incremental install.  
   [Igor Makarov](https://github.com/igor-makarov)
   [#8967](https://github.com/CocoaPods/CocoaPods/issues/8967)

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -415,12 +415,12 @@ module Pod
 
     # @param [Specification] spec The non library spec to calculate the deployment target for.
     #
-    # @return [String] The deployment target to use for the non library spec. If the spec provides one then that is the
-    #         one used otherwise the one for the whole target is used.
+    # @return [String] The deployment target to use for the non library spec. If the non library spec explicitly
+    #         specifies one then this is the one used otherwise the one that was determined by the analyzer is used.
     #
     def deployment_target_for_non_library_spec(spec)
       raise ArgumentError, 'Must be a non library spec.' unless spec.non_library_specification?
-      spec.deployment_target(platform.name)
+      spec.deployment_target(platform.name.to_s) || platform.deployment_target.to_s
     end
 
     # Returns the corresponding native product type to use given the test type.

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -753,6 +753,14 @@ module Pod
           @pod_target.deployment_target_for_non_library_spec(@watermelon_spec.test_specs.first).to_s.should == '8.0'
           @pod_target.deployment_target_for_non_library_spec(@watermelon_spec.app_specs.first).to_s.should == '8.0'
         end
+
+        it 'returns the determined deployment target even if the podspec does not explicitly specify one' do
+          # The coconut spec does not specify a deployment target at all. We expect the deployment target for the non
+          # library spec to be set with the one by the pod target itself instead.
+          coconut_spec = fixture_spec('coconut-lib/CoconutLib.podspec')
+          pod_target = fixture_pod_target(coconut_spec, false, {}, [], Platform.new(:ios, '4.3'))
+          pod_target.deployment_target_for_non_library_spec(coconut_spec.test_specs.first).to_s.should == '4.3'
+        end
       end
 
       describe 'script phases support' do


### PR DESCRIPTION
Deployment target for non library spec is explicitly used if one is specified, otherwise the code used to use the one from the parent spec. However, is it not guaranteed that the parent spec has a deployment target specified.

The `analyzer` sets a default deployment target if that is the case on the `PodTarget` itself. This PR ensures we use that if the deployment target for a non library spec is `nil`.

