### PR TITLE
Move target build settings into the generated .xcconfig files

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -26,6 +26,10 @@ module Pod
           #
           attr_reader :target
 
+          # @return [Hash] The xcconfig hash for the target
+          #
+          attr_accessor :config_hash
+
           # Initialize a new instance
           #
           # @param [Sandbox] sandbox @see #sandbox
@@ -36,6 +40,7 @@ module Pod
             @sandbox = sandbox
             @project = project
             @target = target
+            @config_hash = {}
           end
 
           private
@@ -70,6 +75,8 @@ module Pod
               configuration.build_settings.merge!(custom_build_settings)
             end
 
+            @config_hash.merge! custom_xcconfig
+            @config_hash.merge! target.build_settings.generate.to_hash
             native_target
           end
 
@@ -98,6 +105,28 @@ module Pod
             end
 
             settings
+          end
+
+          # Returns the customized xcconfig values
+          #
+          # @return [Hash{String => String}]
+          #
+          def custom_xcconfig
+            {}
+          end
+
+          # Removes all keys in `xcconfig_overrides` from the targets build settings
+          #
+          # @param [Hash,#each_key] xcconfig_overrides
+          #
+          # @param @param [PBXNativeTarget] native_target
+          #
+          def remove_build_setting_overrides(xcconfig_overrides, native_target)
+            native_target.build_configurations.each do |configuration|
+              xcconfig_overrides.each_key do |setting|
+                configuration.build_settings.delete(setting)
+              end
+            end
           end
 
           # Creates the directory where to store the support files of the target.
@@ -149,12 +178,9 @@ module Pod
           # Creates the module map file which ensures that the umbrella header is
           # recognized with a customized path
           #
-          # @param  [PBXNativeTarget] native_target
-          #         the native target to link the module map file into.
-          #
           # @return [void]
           #
-          def create_module_map(native_target)
+          def create_module_map
             path = target.module_map_path_to_write
             UI.message "- Generating module map file at #{UI.path(path)}" do
               generator = Generator::ModuleMap.new(target)
@@ -168,11 +194,7 @@ module Pod
                 source = path.relative_path_from(linked_path.dirname)
                 FileUtils.ln_sf(source, linked_path)
               end
-
-              relative_path_string = target.module_map_path.relative_path_from(sandbox.root).to_s
-              native_target.build_configurations.each do |c|
-                c.build_settings['MODULEMAP_FILE'] = relative_path_string
-              end
+              config_hash['MODULEMAP_FILE'] = target.module_map_path.relative_path_from(sandbox.root).to_s
             end
           end
 

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -100,6 +100,8 @@ module Pod
       end
     end
 
+    # @return [Target::BuildSettings] the build settings for the provided configuration
+    #
     def build_settings(configuration_name = nil)
       if configuration_name
         @build_settings[configuration_name] ||

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -937,7 +937,7 @@ module Pod
         #-------------------------------------------------------------------------#
       end
 
-      # A subclass that generates build settings for a `PodTarget`
+      # A subclass that generates build settings for an `AggregateTarget`
       class AggregateTargetSettings < BuildSettings
         #-------------------------------------------------------------------------#
 

--- a/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/aggregate_target_installer_spec.rb
@@ -76,7 +76,7 @@ module Pod
 
             it "adds the user's build configurations to the target" do
               @installer.install!
-              @project.targets.first.build_configurations.map(&:name).sort.should == %w( AppStore Debug Release Test        )
+              @project.targets.first.build_configurations.map(&:name).sort.should == %w( AppStore Debug Release Test )
             end
 
             it 'it creates different hash instances for the build settings of various build configurations' do
@@ -86,26 +86,26 @@ module Pod
             end
 
             it 'does not enable the GCC_WARN_INHIBIT_ALL_WARNINGS flag by default' do
-              @installer.install!.native_target.build_configurations.each do |config|
-                config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'].should.be.nil
+              @installer.install!.native_target.resolved_build_setting('GCC_WARN_INHIBIT_ALL_WARNINGS', true).each_value do |value|
+                value.should.be.nil?
               end
             end
 
             it 'will be built as static library' do
-              @installer.install!.native_target.build_configurations.each do |config|
-                config.build_settings['MACH_O_TYPE'].should == 'staticlib'
+              @installer.install!.native_target.resolved_build_setting('MACH_O_TYPE', true).each_value do |value|
+                value.should == 'staticlib'
               end
             end
 
             it 'will be skipped when installing' do
-              @installer.install!.native_target.build_configurations.each do |config|
-                config.build_settings['SKIP_INSTALL'].should == 'YES'
+              @installer.install!.native_target.resolved_build_setting('SKIP_INSTALL', true).each_value do |value|
+                value.should == 'YES'
               end
             end
 
             it 'has a PRODUCT_BUNDLE_IDENTIFIER set' do
-              @installer.install!.native_target.build_configurations.each do |config|
-                config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+              @installer.install!.native_target.resolved_build_setting('PRODUCT_BUNDLE_IDENTIFIER', true).each_value do |value|
+                value.should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
               end
             end
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -66,9 +66,9 @@ module Pod
             it 'sets an empty codesigning identity for iOS/tvOS/watchOS' do
               @installer.install!
               @project.targets.first.build_configurations.each do |config|
-                config.build_settings['CODE_SIGN_IDENTITY[sdk=appletvos*]'].should == ''
-                config.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'].should == ''
-                config.build_settings['CODE_SIGN_IDENTITY[sdk=watchos*]'].should == ''
+                config.resolve_build_setting('CODE_SIGN_IDENTITY[sdk=appletvos*]').should == ''
+                config.resolve_build_setting('CODE_SIGN_IDENTITY[sdk=iphoneos*]').should == ''
+                config.resolve_build_setting('CODE_SIGN_IDENTITY[sdk=watchos*]').should == ''
               end
             end
 
@@ -94,16 +94,16 @@ module Pod
                 @pod_target.stubs(:build_type => BuildType.dynamic_framework)
                 @installer.install!
                 @project.targets.first.build_configurations.each do |config|
-                  config.build_settings['PUBLIC_HEADERS_FOLDER_PATH'].should.be.nil
-                  config.build_settings['PRIVATE_HEADERS_FOLDER_PATH'].should.be.nil
+                  config.resolve_build_setting('PUBLIC_HEADERS_FOLDER_PATH').should.be.nil
+                  config.resolve_build_setting('PRIVATE_HEADERS_FOLDER_PATH').should.be.nil
                 end
               end
 
               it 'empties them for non-framework targets' do
                 @installer.install!
                 @project.targets.first.build_configurations.each do |config|
-                  config.build_settings['PUBLIC_HEADERS_FOLDER_PATH'].should.be.empty
-                  config.build_settings['PRIVATE_HEADERS_FOLDER_PATH'].should.be.empty
+                  config.resolve_build_setting('PUBLIC_HEADERS_FOLDER_PATH').should.be.empty
+                  config.resolve_build_setting('PRIVATE_HEADERS_FOLDER_PATH').should.be.empty
                 end
               end
             end
@@ -113,6 +113,7 @@ module Pod
             describe 'setting the SWIFT_VERSION' do
               it 'does not set the version if not included by the target definition' do
                 @installer.install!
+                @installer.config_hash.should.not.include?('SWIFT_VERSION')
                 @project.targets.first.build_configurations.each do |config|
                   config.build_settings.should.not.include?('SWIFT_VERSION')
                 end
@@ -122,7 +123,7 @@ module Pod
                 @target_definition.swift_version = '3.0'
                 @installer.install!
                 @project.targets.first.build_configurations.each do |config|
-                  config.build_settings['SWIFT_VERSION'].should == '3.0'
+                  config.resolve_build_setting('SWIFT_VERSION').should == '3.0'
                 end
               end
             end
@@ -1042,8 +1043,7 @@ module Pod
                 Pathname.any_instance.stubs(:mkpath)
 
                 FileUtils.expects(:ln_sf).with(relative_path, target_module_path)
-                native_target = mock(:build_configurations => [])
-                @installer.send(:create_module_map, native_target)
+                @installer.send(:create_module_map)
               end
             end
 

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -74,8 +74,7 @@ module Pod
               Pathname.any_instance.stubs(:mkpath)
 
               FileUtils.expects(:ln_sf).with(relative_path, target_module_path)
-              native_target = mock(:build_configurations => [])
-              @installer.send(:create_module_map, native_target)
+              @installer.send(:create_module_map)
             end
           end
 


### PR DESCRIPTION
This moves most of the custom build settings applied during installation into the target's `.xcconfig` files.

Reasons to do this:

1. Consistency - we already put customized build settings in `.xcconfig`s
2. Troublshooting - it's much easier for issue authors to provide the contents of a pod target's `.xcconfig` (and to diff between two versions) than to pull build settings from a project file
3. Duplication - there were a couple settings that were being placed in both `.xcconfig` and `.pbxproj` files