### PR TITLE
Fix crash when running on mounted filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix crash when running on mounted filesystems  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#9200](https://github.com/CocoaPods/CocoaPods/pull/9200)
 
 
 ## 1.8.1 (2019-09-27)

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -307,7 +307,7 @@ module Pod
     def podfile_path_in_dir(dir)
       PODFILE_NAMES.each do |filename|
         candidate = dir + filename
-        if candidate.exist?
+        if candidate.file?
           return candidate
         end
       end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -136,6 +136,16 @@ module Pod
         end
       end
 
+      it 'should not return the working directory as the installation root if found Podfile is a directory' do
+        Dir.chdir(temporary_directory) do
+          path = temporary_directory + 'Podfile'
+          path.mkpath
+          Dir.chdir(path) do
+            @config.installation_root.should == path
+          end
+        end
+      end
+
       it 'returns the parent directory which contains the Podfile if it can be found' do
         Dir.chdir(temporary_directory) do
           File.open('Podfile', 'w') {}


### PR DESCRIPTION
For performance reasons, mounted filesystems may make the assumption that all directories exist at the filesystem root.

This change checks to make sure that the Podfile really is a file and not a directory and prevents the subsequent crash.