### PR TITLE
Revert "Check CDN repo URL procedure changed with common one"

### DIFF
--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -69,7 +69,7 @@ module Pod
       #
       def cdn_url?(url)
         url =~ %r{^https?:\/\/} &&
-          Pod::HTTP.validate_url(url + '/all_pods.txt', nil).ok?
+          REST.head(url + '/all_pods.txt').ok?
       rescue => e
         raise Informative, "Couldn't determine repo type for URL: `#{url}`: #{e}"
       end


### PR DESCRIPTION
This reverts commit 115187f0188f37157f4dd9c89415e9bc716ae32b.

Only affects 1.9.x (current `master`)

See discussion on why for the revert in https://github.com/CocoaPods/CocoaPods/pull/9164#issuecomment-536747408

cc @igor-makarov @igorudovika 