### PR TITLE
Support Swift version variants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Support Swift version variants.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9230](https://github.com/CocoaPods/CocoaPods/pull/9230)
+
 * Include Podfile Plugin changes for incremental installation.  
   [Sebastian Shanus](https://github.com/sebastianv1)
   [#9147](https://github.com/CocoaPods/CocoaPods/pull/9147)

--- a/lib/cocoapods/installer/analyzer/pod_variant.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant.rb
@@ -23,11 +23,9 @@ module Pod
         #
         attr_reader :build_type
 
-        # @return [Specification] the root specification
+        # @return [String] the Swift version of the target.
         #
-        def root_spec
-          specs.first.root
-        end
+        attr_reader :swift_version
 
         # Initialize a new instance from its attributes.
         #
@@ -36,14 +34,23 @@ module Pod
         # @param [Array<Specification>] app_specs  @see #app_specs
         # @param [Platform] platform               @see #platform
         # @param [BuildType] build_type            @see #build_type
+        # @param [String] swift_version            @see #swift_version
         #
-        def initialize(specs, test_specs, app_specs, platform, build_type = BuildType.static_library)
+        def initialize(specs, test_specs, app_specs, platform, build_type = BuildType.static_library,
+                       swift_version = nil)
           @specs = specs
           @test_specs = test_specs
           @app_specs = app_specs
           @platform = platform
           @build_type = build_type
-          @hash = [specs, platform, build_type].hash
+          @swift_version = swift_version
+          @hash = [specs, platform, build_type, swift_version].hash
+        end
+
+        # @return [Specification] the root specification
+        #
+        def root_spec
+          specs.first.root
         end
 
         # @note Non library specs are intentionally not included as part of the equality for pod variants since a pod
@@ -54,6 +61,7 @@ module Pod
         def ==(other)
           self.class == other.class &&
           build_type == other.build_type &&
+            swift_version == other.swift_version &&
             platform == other.platform &&
             specs == other.specs
         end
@@ -65,6 +73,14 @@ module Pod
         #
         # @!visibility private
         attr_reader :hash
+
+        # @param [String] swift_version The swift version to use for this variant.
+        #
+        # @return [PodVariant] A copy of this pod variant with the specified Swift version.
+        #
+        def scoped_with_swift_version(swift_version)
+          PodVariant.new(specs, test_specs, app_specs, platform, build_type, swift_version)
+        end
       end
     end
   end

--- a/lib/cocoapods/installer/analyzer/pod_variant_set.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant_set.rb
@@ -98,7 +98,16 @@ module Pod
             # => Platform name + SDK version
             platform_name_proc = proc { |v| v.platform.to_s.tr(' ', '') }
           end
-          scope_if_necessary(grouped_variants.map(&:scope_without_suffix), &platform_name_proc)
+          scope_if_necessary(grouped_variants.map(&:scope_by_swift_version), &platform_name_proc)
+        end
+
+        # @private
+        # @return [Hash<PodVariant, String>]
+        #
+        def scope_by_swift_version
+          scope_if_necessary(group_by(&:swift_version).map(&:scope_without_suffix)) do |variant|
+            variant.swift_version ? "Swift#{variant.swift_version}" : ''
+          end
         end
 
         # @private
@@ -113,7 +122,7 @@ module Pod
                      root_spec.default_subspecs.map do |subspec_name|
                        root_spec.subspec_by_name("#{root_spec.name}/#{subspec_name}")
                      end
-          end
+                   end
           default_specs = Set.new(specs)
           grouped_variants = group_by(&:specs)
           all_spec_variants = grouped_variants.map { |set| set.variants.first.specs }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -118,20 +118,20 @@ end
 
 def fixture_pod_target(spec_or_name, build_type = Pod::BuildType.static_library, user_build_configurations = {},
                        archs = [], platform = Pod::Platform.new(:ios, '6.0'), target_definitions = [],
-                       scope_suffix = nil)
+                       scope_suffix = nil, swift_version = nil)
   spec = spec_or_name.is_a?(Pod::Specification) ? spec_or_name : fixture_spec(spec_or_name)
   fixture_pod_target_with_specs([spec], build_type, user_build_configurations, archs, platform, target_definitions,
-                                scope_suffix)
+                                scope_suffix, swift_version)
 end
 
 def fixture_pod_target_with_specs(specs, build_type = Pod::BuildType.static_library, user_build_configurations = {},
                                   archs = [], platform = Pod::Platform.new(:ios, '6.0'), target_definitions = [],
-                                  scope_suffix = nil)
+                                  scope_suffix = nil, swift_version = nil)
   target_definitions << fixture_target_definition if target_definitions.empty?
   target_definitions.each { |td| specs.each { |spec| td.store_pod(spec.name) } }
   file_accessors = specs.map { |spec| fixture_file_accessor(spec, platform) }
   Pod::PodTarget.new(config.sandbox, build_type, user_build_configurations, archs, platform, specs, target_definitions,
-                     file_accessors, scope_suffix)
+                     file_accessors, scope_suffix, swift_version)
 end
 
 def fixture_aggregate_target(pod_targets = [], build_type = Pod::BuildType.static_library,

--- a/spec/unit/installer/analyzer/pod_variant_set_spec.rb
+++ b/spec/unit/installer/analyzer/pod_variant_set_spec.rb
@@ -162,6 +162,17 @@ module Pod
           framework-static
         )
       end
+
+      it 'returns scopes based on Swift version' do
+        variants = PodVariantSet.new([
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios, BuildType.dynamic_framework, '3.2'),
+          PodVariant.new([@root_spec, @default_subspec], [], [], Platform.ios, BuildType.dynamic_framework, '4.0'),
+        ])
+        variants.scope_suffixes.values.should == %w(
+          Swift3.2
+          Swift4.0
+        )
+      end
     end
   end
 end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -12,8 +12,9 @@ module Pod
               @project.add_pod_group('BananaLib', fixture('banana-lib'))
               platform = Platform.new(:ios, '4.3')
               @target_definition = fixture_target_definition('SampleProject', platform)
-              @pod_target = fixture_pod_target(@banana_spec, BuildType.static_library, { 'Debug' => :debug, 'Release' => :release }, [],
-                                               platform, [@target_definition])
+              @pod_target = fixture_pod_target(@banana_spec, BuildType.static_library,
+                                               { 'Debug' => :debug, 'Release' => :release }, [], platform,
+                                               [@target_definition])
               FileReferencesInstaller.new(config.sandbox, [@pod_target], @project).install!
               @installer = PodTargetInstaller.new(config.sandbox, @project, @pod_target)
             end
@@ -118,9 +119,12 @@ module Pod
                 end
               end
 
-              it 'sets the version to the one specified in the target definition' do
-                @target_definition.swift_version = '3.0'
-                @installer.install!
+              it 'sets the version to the one specified in by the pod target' do
+                pod_target = fixture_pod_target(@banana_spec, BuildType.static_library,
+                                                { 'Debug' => :debug, 'Release' => :release }, [], Platform.ios,
+                                                [@target_definition], nil, '3.0')
+                installer = PodTargetInstaller.new(config.sandbox, @project, pod_target)
+                installer.install!
                 @project.targets.first.build_configurations.each do |config|
                   config.build_settings['SWIFT_VERSION'].should == '3.0'
                 end

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -381,7 +381,9 @@ module Pod
             podfile.target_definition_list.find { |td| td.name == 'SampleProject' }.swift_version = '3.0'
             podfile.target_definition_list.find { |td| td.name == 'TestRunner' }.swift_version = '2.3'
             @validator.pod_targets.find { |pt| pt.name == 'OrangeFramework' }.stubs(:spec_swift_versions).returns(['4.0'])
+            @validator.pod_targets.find { |pt| pt.name == 'OrangeFramework' }.stubs(:swift_version).returns('4.0')
             @validator.pod_targets.find { |pt| pt.name == 'matryoshka' }.stubs(:spec_swift_versions).returns(['3.2'])
+            @validator.pod_targets.find { |pt| pt.name == 'matryoshka' }.stubs(:swift_version).returns('3.2')
             lambda { @validator.validate! }.should.not.raise
           end
 
@@ -444,6 +446,7 @@ module Pod
 
             @validator = create_validator(config.sandbox, podfile, lockfile)
             @validator.pod_targets.find { |pt| pt.name == 'OrangeFramework' }.stubs(:spec_swift_versions).returns(['4.0'])
+            @validator.pod_targets.find { |pt| pt.name == 'OrangeFramework' }.stubs(:swift_version).returns('4.0')
             e = lambda { @validator.validate! }.should.raise Informative
             e.message.should.include <<-EOS.strip_heredoc.strip
               [!] The following Swift pods cannot yet be integrated as static libraries:

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -184,55 +184,6 @@ module Pod
       end
     end
 
-    describe 'swift version' do
-      it 'returns the swift version with the given requirements from the target definition' do
-        @target_definition.store_swift_version_requirements('>= 4.0')
-        @pod_target.root_spec.stubs(:swift_versions).returns([Version.new('3.0'), Version.new('4.0')])
-        @pod_target.swift_version.should == '4.0'
-      end
-
-      it 'returns the swift version with the given requirements from all target definitions' do
-        target_definition_one = fixture_target_definition('App1')
-        target_definition_one.store_swift_version_requirements('>= 4.0')
-        target_definition_two = fixture_target_definition('App2')
-        target_definition_two.store_swift_version_requirements('= 4.2')
-        pod_target = PodTarget.new(config.sandbox, BuildType.static_library, {}, [], Platform.ios, [@banana_spec],
-                                   [target_definition_one, target_definition_two])
-        @pod_target.root_spec.stubs(:swift_versions).returns([Version.new('3.0'), Version.new('4.0'),
-                                                              Version.new('4.2')])
-        pod_target.swift_version.should == '4.2'
-      end
-
-      it 'returns an empty swift version if none of the requirements match' do
-        target_definition_one = fixture_target_definition('App1')
-        target_definition_one.store_swift_version_requirements('>= 4.0')
-        target_definition_two = fixture_target_definition('App2')
-        target_definition_two.store_swift_version_requirements('= 4.2')
-        pod_target = PodTarget.new(config.sandbox, BuildType.static_library, {}, [], Platform.ios, [@banana_spec],
-                                   [target_definition_one, target_definition_two])
-        @pod_target.root_spec.stubs(:swift_versions).returns([Version.new('3.0'), Version.new('4.0')])
-        pod_target.swift_version.should == ''
-      end
-
-      it 'uses the swift version defined in the specification' do
-        @pod_target.root_spec.stubs(:swift_versions).returns([Version.new('3.0')])
-        @target_definition.stubs(:swift_version).returns('2.3')
-        @pod_target.swift_version.should == '3.0'
-      end
-
-      it 'uses the max swift version defined in the specification' do
-        @pod_target.root_spec.stubs(:swift_versions).returns([Version.new('3.0'), Version.new('4.0')])
-        @target_definition.stubs(:swift_version).returns('2.3')
-        @pod_target.swift_version.should == '4.0'
-      end
-
-      it 'uses the swift version defined by the target definitions if no swift version is specified in the spec' do
-        @pod_target.root_spec.stubs(:swift_versions).returns([])
-        @target_definition.stubs(:swift_version).returns('2.3')
-        @pod_target.swift_version.should == '2.3'
-      end
-    end
-
     describe 'Inhibit warnings' do
       it 'should inhibit warnings for pods that are part of the target definition and require it' do
         target_definition = fixture_target_definition('App1')


### PR DESCRIPTION
Given:
```ruby
Pod::Spec.new do |s|
  s.name         = 'CannonPodder'
  s.version      = '1.0.0'
  # ...
  s.swift_versions = ['4.0', '5.0']
end
```
and:
```ruby
target 'SampleApp' do
  supports_swift_version '< 5.0'
  pod 'CannonPodder'
end

target 'SecondApp' do
  supports_swift_version '>= 5.0'
  pod 'CannonPodder'
end
```

CocoaPods will now correctly install the above and create two different targets for each app target and its corresponding Swift version.

![image](https://user-images.githubusercontent.com/310370/66451466-90c70980-ea2a-11e9-9cb6-23ffd86f5eef.png)
