### PR TITLE
Add user projects to workspace during incremental install.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix issue where workspace was missing user project references during incremental installation.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#9237](https://github.com/CocoaPods/CocoaPods/issues/9237)
+
 * Search in users xcconfig's for figuring out when to set `APPLICATION_EXTENSION_API_ONLY`.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9233](https://github.com/CocoaPods/CocoaPods/issues/9233)

--- a/lib/cocoapods/installer/user_project_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator.rb
@@ -92,7 +92,7 @@ module Pod
       # @return [void]
       #
       def create_workspace
-        all_projects = user_project_paths_to_integrate.sort.push(sandbox.project_path).uniq
+        all_projects = user_project_paths.sort.push(sandbox.project_path).uniq
         file_references = all_projects.map do |path|
           relative_path = path.relative_path_from(workspace_path.dirname).to_s
           Xcodeproj::Workspace::FileReference.new(relative_path, 'group')
@@ -219,15 +219,6 @@ module Pod
             "workspace. Specify one in your Podfile like so:\n\n"       \
             "    workspace 'path/to/Workspace.xcworkspace'\n"
         end
-      end
-
-      # @return [Array<Pathname>] the paths of all the user projects referenced
-      #         by the targets that require integration.
-      #
-      # @note   Empty target definitions are ignored.
-      #
-      def user_project_paths_to_integrate
-        targets_to_integrate.map(&:user_project_path).compact.uniq
       end
 
       # @return [Array<Xcodeproj::Project>] the projects of all the targets that require integration.

--- a/spec/unit/installer/user_project_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator_spec.rb
@@ -187,6 +187,19 @@ module Pod
             'SampleProject/SampleProject.xcodeproj',
           ]
         end
+
+        it 'add user projects to workspace during incremental installation' do
+          targets = [@target, @empty_library]
+          @integrator = UserProjectIntegrator.new(@podfile, config.sandbox, temporary_directory, targets, nil)
+          @integrator.send(:create_workspace)
+
+          workspace_path = @integrator.send(:workspace_path)
+          saved = Xcodeproj::Workspace.new_from_xcworkspace(workspace_path)
+          saved.file_references.map(&:path).should == [
+            'SampleProject/SampleProject.xcodeproj',
+            'Pods/Pods.xcodeproj',
+          ]
+        end
       end
 
       #-----------------------------------------------------------------------#
@@ -211,7 +224,7 @@ module Pod
         end
 
         it 'returns the paths of the user projects' do
-          @integrator.send(:user_project_paths_to_integrate).should == [@sample_project_path]
+          @integrator.send(:user_project_paths).should == [@sample_project_path]
         end
 
         it 'does not skip libraries with empty target definitions' do


### PR DESCRIPTION
closes #9237

During incremental installation, if the set of `targets_to_generate` was empty and the workspace was missing, we wouldn't add the user projects to the workspace and be missing.

This changes `user_project_paths_to_integrate` to map over `targets` instead of the subset `targets_to_generate` to ensure all user projects will be added. There is existing logic to make sure that duplicate file references to user projects are removed.