### PR TITLE
Fix app spec frameworks script

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -704,9 +704,9 @@ module Pod
           #
           def create_app_target_copy_resources_script(app_spec)
             path = target.copy_resources_script_path_for_spec(app_spec)
-            resource_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
+            resource_paths_by_config = target.user_build_configurations.each_with_object({}) do |(config_name, config), resources_by_config|
               pod_targets = target.dependent_targets_for_app_spec(app_spec, :configuration => config)
-              resources_by_config[config] = pod_targets.flat_map do |pod_target|
+              resources_by_config[config_name] = pod_targets.flat_map do |pod_target|
                 spec_paths_to_include = pod_target.library_specs.map(&:name)
                 spec_paths_to_include << app_spec.name if pod_target == target
                 pod_target.resource_paths.values_at(*spec_paths_to_include).flatten.compact
@@ -728,9 +728,9 @@ module Pod
           #
           def create_app_target_embed_frameworks_script(app_spec)
             path = target.embed_frameworks_script_path_for_spec(app_spec)
-            framework_paths_by_config = target.user_build_configurations.keys.each_with_object({}) do |config, paths_by_config|
+            framework_paths_by_config = target.user_build_configurations.each_with_object({}) do |(config_name, config), paths_by_config|
               pod_targets = target.dependent_targets_for_app_spec(app_spec, :configuration => config)
-              paths_by_config[config] = pod_targets.flat_map do |pod_target|
+              paths_by_config[config_name] = pod_targets.flat_map do |pod_target|
                 spec_paths_to_include = pod_target.library_specs.map(&:name)
                 spec_paths_to_include << app_spec.name if pod_target == target
                 pod_target.framework_paths.values_at(*spec_paths_to_include).flatten.compact.uniq

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -712,7 +712,7 @@ module Pod
         hash[nil] = hash.each_value.reduce(Set.new, &:|).to_a
         hash
       end
-      @recursive_dependent_targets[configuration]
+      @recursive_dependent_targets.fetch(configuration) { raise ArgumentError, "No configuration #{configuration} for #{self}, known configurations are #{@recursive_dependent_targets.keys}" }
     end
 
     def _add_recursive_dependent_targets(set, configuration: nil)


### PR DESCRIPTION
The bug was that we were passing in the config name instead of the type to a method that was expecting the type, and because we were constructing arrays via splats instead of `concat`, it was silently coercing `nil` to `[]`. Integration specs change shows this is fixed, exception added in dep lookup will mean this cant silently start failing again.

Fixing a regression introduced on master, hence no CHANGELOG.