### PR TITLE
Always generate a lockfile even if project integration is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Always generate a lockfile even if project integration is disabled.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9288](https://github.com/CocoaPods/CocoaPods/issues/9288)
+
 * Fix incremental installation with plugins that include arguments with different ordering.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9170](https://github.com/CocoaPods/CocoaPods/pull/9170)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -161,6 +161,7 @@ module Pod
       else
         integrate
       end
+      write_lockfiles
       perform_post_install_actions
     end
 
@@ -296,7 +297,6 @@ module Pod
       SandboxDirCleaner.new(sandbox, pod_targets, aggregate_targets).clean!
 
       update_project_cache(cache_analysis_result, target_installation_results)
-      write_lockfiles
     end
 
     def create_and_save_projects(pod_targets_to_generate, aggregate_targets_to_generate, build_configurations, project_object_version)


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/9288

Integration specs https://github.com/CocoaPods/cocoapods-integration-specs/pull/255