### PR TITLE
Gate target UUID stabilizing behind incremental installation option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Only stabilize target UUIDs if incremental installation is enabled.  
+  [Sebastian Shanus](https://github.com/sebastianv1/)
+  [Xcodeproj #681](https://github.com/CocoaPods/Xcodeproj/issues/681)
+
 * Fix issue where workspace was missing user project references during incremental installation.  
   [Sebastian Shanus](https://github.com/sebastianv1)
   [#9237](https://github.com/CocoaPods/CocoaPods/issues/9237)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -317,7 +317,7 @@ module Pod
         projects_by_pod_targets = pod_project_generation_result.projects_by_pod_targets
 
         predictabilize_uuids(generated_projects) if installation_options.deterministic_uuids?
-        stabilize_target_uuids(generated_projects)
+        stabilize_target_uuids(generated_projects) if installation_options.incremental_installation?
 
         run_podfile_post_install_hooks
 

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -203,8 +203,15 @@ module Pod
           @installer.install!
         end
 
-        it 'stabilizes target UUIDs' do
+        it 'does not stabilize target UUIDs if incremental installation is disabled' do
           @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new)
+          @installer.expects(:stabilize_target_uuids).with([fixture('Pods.xcodeproj')]).never
+
+          @installer.install!
+        end
+
+        it 'does stabilize target UUIDs if incremental installation is enabled' do
+          @installer.stubs(:installation_options).returns(Pod::Installer::InstallationOptions.new(:incremental_installation => true))
           @installer.expects(:stabilize_target_uuids).with([fixture('Pods.xcodeproj')]).once
 
           @installer.install!


### PR DESCRIPTION
* Target UUID stabilizing is only important for incremental installation. Running this code path otherwise slows down pod install unnecessarily.