### PR TITLE
Move run_podfile_post_install_hooks call to execute right before projects are saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Move `run_podfile_post_install_hooks` call to execute right before projects are saved.  
+  [Yusuf Sobh](https://github.com/yusufoos)
+  [#9379](https://github.com/CocoaPods/CocoaPods/issues/9379)
+
 * Do not apply header mapping copy if the spec does not provide a header mappings dir.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9308](https://github.com/CocoaPods/CocoaPods/issues/9308)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -319,11 +319,11 @@ module Pod
         predictabilize_uuids(generated_projects) if installation_options.deterministic_uuids?
         stabilize_target_uuids(generated_projects)
 
-        run_podfile_post_install_hooks
-
         projects_writer = Xcode::PodsProjectWriter.new(sandbox, generated_projects,
                                                        target_installation_results.pod_target_installation_results, installation_options)
-        projects_writer.write!
+        projects_writer.write! do
+          run_podfile_post_install_hooks
+        end
 
         pods_project_pod_targets = pod_targets_to_generate - projects_by_pod_targets.values.flatten
         all_projects_by_pod_targets = {}

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pods_project_writer.rb
@@ -35,27 +35,32 @@ module Pod
           @installation_options = installation_options
         end
 
+        # Writes projects to disk.
+        #
+        # @yield If provided, this block will execute right before writing the projects to disk.
+        #
         def write!
           cleanup_projects(projects)
 
           projects.each do |project|
-            UI.message "- Writing Xcode project file to #{UI.path project.path}" do
-              library_product_types = [:framework, :dynamic_library, :static_library]
-              results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
-                [result.native_target, result]
-              end]
-              project.recreate_user_schemes(false) do |scheme, target|
-                next unless target.respond_to?(:symbol_type)
-                next unless library_product_types.include? target.symbol_type
-                installation_result = results_by_native_target[target]
-                next unless installation_result
-                installation_result.test_native_targets.each do |test_native_target|
-                  scheme.add_test_target(test_native_target)
-                end
+            library_product_types = [:framework, :dynamic_library, :static_library]
+            results_by_native_target = Hash[pod_target_installation_results.map do |_, result|
+              [result.native_target, result]
+            end]
+            project.recreate_user_schemes(false) do |scheme, target|
+              next unless target.respond_to?(:symbol_type)
+              next unless library_product_types.include? target.symbol_type
+              installation_result = results_by_native_target[target]
+              next unless installation_result
+              installation_result.test_native_targets.each do |test_native_target|
+                scheme.add_test_target(test_native_target)
               end
-              project.save
             end
           end
+
+          yield if block_given?
+
+          save_projects(projects)
         end
 
         private
@@ -66,7 +71,17 @@ module Pod
           projects.each do |project|
             [project.pods, project.support_files_group,
              project.development_pods, project.dependencies_group].each { |group| group.remove_from_project if group.empty? }
+          end
+        end
+
+        # Sorts and then saves projects which writes them to disk.
+        #
+        def save_projects(projects)
+          projects.each do |project|
             project.sort(:groups_position => :below)
+            UI.message "- Writing Xcode project file to #{UI.path project.path}" do
+              project.save
+            end
           end
         end
       end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -111,10 +111,11 @@ module Pod
         generator_result = Installer::Xcode::PodsProjectGenerator::PodsProjectGeneratorResult.new(nil, {}, target_installation_results)
         generator.stubs(:generate!).returns(generator_result)
         generator.stubs(:configure_schemes)
+        Installer::Xcode::PodsProjectWriter.any_instance.unstub(:write!)
 
         hooks = sequence('hooks')
         @installer.expects(:run_podfile_post_install_hooks).once.in_sequence(hooks)
-        Installer::Xcode::PodsProjectWriter.any_instance.expects(:write!).once.in_sequence(hooks)
+        Installer::Xcode::PodsProjectWriter.any_instance.expects(:save_projects).once.in_sequence(hooks)
 
         @installer.install!
       end


### PR DESCRIPTION
This will allow us to make changes to the project and schema without it getting overwritten by the pods_project_writer. #9379 