### PR TITLE
path list optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* PathList optimizations related to file system reads.  
+  [manuyavuz](https://github.com/manuyavuz)
+  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/4927)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -65,7 +65,10 @@ module Pod
           # @return [void]
           #
           def refresh_file_accessors
-            file_accessors.map(&:path_list).uniq.each(&:read_file_system)
+            file_accessors.reject do |file_accessor|
+              pod_name = file_accessor.spec.name
+              sandbox.local?(pod_name)
+            end.map(&:path_list).uniq.each(&:read_file_system)
           end
 
           # Prepares the main groups to which all files will be added for the respective target

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -54,7 +54,8 @@ module Pod
         dirs = []
         files = []
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
-        Dir.glob(root + '**/*', File::FNM_DOTMATCH).each do |f|
+        escaped_root = escape_path_for_glob(root)
+        Dir.glob(escaped_root + '**/*', File::FNM_DOTMATCH).each do |f|
           directory = File.directory?(f)
           # Ignore `.` and `..` directories
           next if directory && f =~ /\.\.?$/
@@ -214,6 +215,25 @@ module Pod
           end
           patterns
         end
+      end
+
+      # Escapes the glob metacharacters from a given path so it can used in
+      # Dir#glob and similar methods.
+      #
+      # @note   See CocoaPods/CocoaPods#862.
+      #
+      # @param  [String, Pathname] path
+      #         The path to escape.
+      #
+      # @return [Pathname] The escaped path.
+      #
+      def escape_path_for_glob(path)
+        result = path.to_s
+        characters_to_escape = ['[', ']', '{', '}', '?', '*']
+        characters_to_escape.each do |character|
+          result.gsub!(character, "\\#{character}")
+        end
+        Pathname.new(result)
       end
 
       #-----------------------------------------------------------------------#

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -51,12 +51,14 @@ module Pod
         unless root.exist?
           raise Informative, "Attempt to read non existent folder `#{root}`."
         end
-
         dirs = []
         files = []
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
-        Find.find(root.to_s) do |f|
+        Dir.glob(root + '**/*', File::FNM_DOTMATCH).each do |f|
           directory = File.directory?(f)
+          # Ignore `.` and `..` directories
+          next if directory && f =~ /\.\.?$/
+
           f = f.slice(root_length, f.length - root_length)
           next if f.nil?
 


### PR DESCRIPTION
- Uses Dir.glob instead of Find.find for faster content fetch
- Does not recalculate file system content for local pods during installation as they won't be changed by cocoapods itself anytime.


## Improvements
### Previous
```
bundle exec pod install --clean-install  10.97s user 7.97s system 96% cpu 19.628 total
bundle exec pod install  4.91s user 4.41s system 95% cpu 9.772 total
```

### This branch
```
bundle exec pod install --clean-install  6.62s user 4.12s system 86% cpu 12.453 total
bundle exec pod install  3.99s user 3.60s system 88% cpu 8.587 total
```