### PR TITLE
Fix a bug where an incremental install missed library resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#9458](https://github.com/CocoaPods/CocoaPods/issues/9458)
 
+* Fix a bug where an incremental install missed library resources.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9431](https://github.com/CocoaPods/CocoaPods/pull/9431)
 
 ## 1.9.0.beta.2 (2019-12-17)
 


### PR DESCRIPTION
I ran into an issue where having a (local) pod that has resources behaves incorrectly when performing an incremental install:

If a resource file (png, xib, storyboard etc.) is renamed/moved, the containing target gets regenerated. However, the aggregate target does not.

This leads to a state where the generated resource install script contains incorrect resource paths. The script fails silently, causing the build to complete and the app to crash at runtime.

This PR fixes this issue. I've added specs for the case I ran into.
