### PR TITLE
append file extension instead of substitute

### DIFF
--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -112,7 +112,7 @@ module Pod
       #
       def path_for_spec(request, slug_opts = {})
         path = root + 'Specs' + request.slug(slug_opts)
-        path.sub_ext('.podspec.json')
+        Pathname.new(path.to_path + '.podspec.json')
       end
 
       # @param  [Request] request


### PR DESCRIPTION
path.sub_ext:
0.0.3   => 0.0.podspec.json
2.7.0.1 => 2.7.0.podspec.json
1.0.12 => 1.0.podspec.json

which does not match `path_for_pod`

Pathname.new:
0.0.3   => 0.0.3.podspec.json
2.7.0.1 => 2.7.0.1.podspec.json
1.0.12 => 1.0.12.podspec.json

Thanks