### PR TITLE
When pod target is a static framework, save time by copying compiled resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [cltnschlosser](https://github.com/cltnschlosser)
   [#9865](https://github.com/CocoaPods/CocoaPods/issues/9865)
 
+* When pod target is a static framework, save time by copying compiled resources  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9441](https://github.com/CocoaPods/CocoaPods/pull/9441)
+
 * Re-implement `bcsymbolmap` copying to avoid duplicate outputs.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [mplorentz](https://github.com/mplorentz)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -368,27 +368,6 @@ module Pod
             end
           end
 
-          # Returns an extension in the target that corresponds to the
-          # resource's input extension.
-          #
-          # @param [String] input_extension
-          #        The input extension to map to.
-          #
-          # @return [String] The output extension.
-          #
-          def output_extension_for_resource(input_extension)
-            case input_extension
-            when '.storyboard'        then '.storyboardc'
-            when '.xib'               then '.nib'
-            when '.framework'         then '.framework'
-            when '.xcdatamodel'       then '.mom'
-            when '.xcdatamodeld'      then '.momd'
-            when '.xcmappingmodel'    then '.cdm'
-            when '.xcassets'          then '.car'
-            else                      input_extension
-            end
-          end
-
           # Returns the resource output paths for all given input paths.
           #
           # @param [Array<String>] resource_input_paths
@@ -401,7 +380,7 @@ module Pod
               base_path = '${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}'
               extname = File.extname(resource_input_path)
               basename = extname == '.xcassets' ? 'Assets' : File.basename(resource_input_path)
-              output_extension = TargetIntegrator.output_extension_for_resource(extname)
+              output_extension = Target.output_extension_for_resource(extname)
               File.join(base_path, File.basename(basename, extname) + output_extension)
             end.uniq
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -354,6 +354,11 @@ module Pod
 
               filter_resource_file_references(file_accessor.resources.flatten) do |compile_phase_refs, resource_phase_refs|
                 native_target.add_file_references(compile_phase_refs, nil)
+
+                if target.build_as_static_framework?
+                  resource_phase_refs = resource_phase_refs.select { |ref| Target.resource_extension_compilable?(File.extname(ref.path)) }
+                end
+
                 native_target.add_resources(resource_phase_refs)
               end
             end

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -329,6 +329,30 @@ module Pod
       support_files_dir + "#{label}-artifacts.sh"
     end
 
+    # Returns an extension in the target that corresponds to the
+    # resource's input extension.
+    #
+    # @param [String] input_extension
+    #        The input extension to map to.
+    #
+    # @return [String] The output extension.
+    #
+    def self.output_extension_for_resource(input_extension)
+      case input_extension
+      when '.storyboard'        then '.storyboardc'
+      when '.xib'               then '.nib'
+      when '.xcdatamodel'       then '.mom'
+      when '.xcdatamodeld'      then '.momd'
+      when '.xcmappingmodel'    then '.cdm'
+      when '.xcassets'          then '.car'
+      else                      input_extension
+      end
+    end
+
+    def self.resource_extension_compilable?(input_extension)
+      output_extension_for_resource(input_extension) != input_extension
+    end
+
     #-------------------------------------------------------------------------#
 
     private

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -4,8 +4,8 @@ module Pod
   class Installer
     class Xcode
       class PodsProjectGenerator
-        describe PodTargetInstaller do
-          describe 'In General' do
+        describe PodTargetInstaller do # rubocop:disable Metrics/BlockLength
+          describe 'In General' do # rubocop:disable Metrics/BlockLength
             before do
               @banana_spec = fixture_spec('banana-lib/BananaLib.podspec')
               @project = Pod::Project.new(config.sandbox.project_path)

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -739,16 +739,25 @@ module Pod
               resource.should.be.not.nil
             end
 
-            it 'adds framework resources to the static framework target' do
+            it 'adds compilable framework resources to the static framework target' do
+              @pod_target.stubs(:build_type => BuildType.static_framework)
+              @installer.install!
+              resources = @project.targets.first.resources_build_phase.files
+              resources.count.should > 0
+              resource = resources.find { |res| res.file_ref.path.include?('Migration.xcmappingmodel') }
+              resource.should.be.not.nil
+            end
+
+            it 'doesn\'t add non-compilable framework resources to the static framework target' do
               @pod_target.stubs(:build_type => BuildType.static_framework)
               @installer.install!
               resources = @project.targets.first.resources_build_phase.files
               resources.count.should > 0
               resource = resources.find { |res| res.file_ref.path.include?('logo-sidebar.png') }
-              resource.should.be.not.nil
+              resource.should.be.nil
 
               resource = resources.find { |res| res.file_ref.path.include?('en.lproj') }
-              resource.should.be.not.nil
+              resource.should.be.nil
             end
 
             it 'includes spec info_plist entries for dynamic frameworks' do

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -187,6 +187,18 @@ module Pod
           resource_paths_by_config['Release'].should == ['MyResources.bundle']
         end
 
+        it 'checks resource paths for compilable are converted for static frameworks' do
+          @pod_target.stubs(:should_build?).returns(true)
+          @pod_target.stubs(:build_type => BuildType.static_framework)
+          convertible_files = %w[.storyboard .xib .xcdatamodel .xcdatamodeld .xcmappingmodel].map { |ext| "Filename#{ext}" }
+          @pod_target.stubs(:resource_paths).returns('BananaLib' => convertible_files)
+          @target.stubs(:bridge_support_file).returns(nil)
+          resource_paths_by_config = @target.resource_paths_by_config
+          expected_files = %w[.storyboardc .nib .mom .momd .cdm].map { |ext| "${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework/Filename#{ext}" }
+          resource_paths_by_config['Debug'].should == expected_files
+          resource_paths_by_config['Release'].should == expected_files
+        end
+
         it 'returns non vendored frameworks by config with different release and debug targets' do
           @pod_target_release.stubs(:should_build?).returns(true)
           @pod_target_release.stubs(:build_type => BuildType.dynamic_framework)


### PR DESCRIPTION
I've investigated an issue with pods as static frameworks and discovered the following problem:  

Because the pod target is of framework type, the `Copy Bundle Resources` phase actually gets executed (as opposed to static library). This means that processed resources (XIBs, storyboards etc.) are processed using the appropriate tool. Additionally, Xcode does this processing in parallel.

However, when the integration phase `[CP] Copy Pods Resources` runs, its inputs are the original resource files, like in the case of a static library. This results in the resource processing tools running again, this time serially.  
This results in duplicate work and performance penalty.

This PR solves this by converting the `[CP] Copy Pods Resources` input paths to be the framework output files (`.nib`, `.storyboardc` etc.). These get handled by plain `rsync` and run blazingly fast.