### PR TITLE
Lazy require Typhoeus because its load takes 300ms

### DIFF
--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -2,7 +2,6 @@ require 'cocoapods-core/source'
 require 'netrc'
 require 'set'
 require 'rest'
-require 'typhoeus'
 require 'yaml'
 
 module Pod
@@ -72,6 +71,8 @@ module Pod
       #
       def cdn_url?(url)
         if url =~ %r{^https?:\/\/}
+          require 'typhoeus'
+
           response = Typhoeus.get(url + '/CocoaPods-version.yml', :netrc_file => Netrc.default_path, :netrc => :optional)
           response.code == 200 && begin
             response_hash = YAML.load(response.body) # rubocop:disable Security/YAMLLoad


### PR DESCRIPTION
Split from https://github.com/CocoaPods/CocoaPods/pull/9435 by @dnkoutso's request.

Also https://github.com/CocoaPods/Core/pull/610