### PR TITLE
[PathList] Add symlink follow support

### DIFF
--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -55,7 +55,7 @@ module Pod
         files = []
         root_length = root.cleanpath.to_s.length + File::SEPARATOR.length
         escaped_root = escape_path_for_glob(root)
-        Dir.glob(escaped_root + '**/*', File::FNM_DOTMATCH).each do |f|
+        Dir.glob(escaped_root + '**{,/[^.]*/**}/*', File::FNM_DOTMATCH).each do |f|
           directory = File.directory?(f)
           # Ignore `.` and `..` directories
           next if directory && f =~ /\.\.?$/
@@ -66,8 +66,8 @@ module Pod
           (directory ? dirs : files) << f
         end
 
-        dirs.sort_by!(&:upcase)
-        files.sort_by!(&:upcase)
+        dirs.sort_by!(&:upcase).uniq!
+        files.sort_by!(&:upcase).uniq!
 
         @dirs = dirs
         @files = files

--- a/spec/unit/sandbox/path_list_spec.rb
+++ b/spec/unit/sandbox/path_list_spec.rb
@@ -14,8 +14,12 @@ module Pod
         end
         expected = %w(
           Banana.modulemap
+          BananaFramework.framework/Headers/BananaFramework.h
+          BananaFramework.framework/Headers/SubDir/SubBananaFramework.h
           BananaFramework.framework/Versions/A/Headers/BananaFramework.h
           BananaFramework.framework/Versions/A/Headers/SubDir/SubBananaFramework.h
+          BananaFramework.framework/Versions/Current/Headers/BananaFramework.h
+          BananaFramework.framework/Versions/Current/Headers/SubDir/SubBananaFramework.h
           BananaLib.podspec
           Classes/Banana.h
           Classes/Banana.m
@@ -56,11 +60,14 @@ module Pod
         dirs.sort.should == %w(
           BananaFramework.framework
           BananaFramework.framework/Headers
+          BananaFramework.framework/Headers/SubDir
           BananaFramework.framework/Versions
           BananaFramework.framework/Versions/A
           BananaFramework.framework/Versions/A/Headers
           BananaFramework.framework/Versions/A/Headers/SubDir
           BananaFramework.framework/Versions/Current
+          BananaFramework.framework/Versions/Current/Headers
+          BananaFramework.framework/Versions/Current/Headers/SubDir
           Classes
           Resources
           Resources/Base.lproj
@@ -336,12 +343,12 @@ module Pod
         @path_list.dirs.map(&:to_s).should.include?('Classes/symlinked')
       end
 
-      it 'doesn\'t include file in symlinked dir' do
+      it 'includes file in symlinked dir' do
         @path_list.instance_variable_set(:@files, nil)
         @path_list.instance_variable_set(:@dirs, nil)
         File.symlink(@tmpdir, @symlink_dir)
 
-        @path_list.files.map(&:to_s).should.not.include?('Classes/symlinked/someheader.h')
+        @path_list.files.map(&:to_s).should.include?('Classes/symlinked/someheader.h')
       end
     end
 


### PR DESCRIPTION
Adds support to follow symlink folders under `PathList` root once.

This might also fix #6603, #7761, #7795.

I needed this change because currently I can't put a file which exists under a symlink folder as a resource to my pod. The main reason is that `**/*` glob pattern does not follow symlinks in Ruby for Dir.glob. Result is the same with `Find.find` module, it does not traverse symlinks.

There is a discussion in a ruby forum with a workaround:
http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/206308

It basically suggests to use `**/*/**/*` to follow symlinks for once. Even though I don't know the exact technical detail why that works, I assume that when ruby glob resolver sees `**` after `*`, it tries to glob recursively again from files matching with first `*`.

This expands symbolic links, but misses immediate children for the root folder. To fix this, I applied `**{,/*/**}/*` to collect matches for both `**/*` and ``**/*/**/*`. This solves missing immediate children problem, but may result in duplicate records, so a `uniq!` is required.

One problem is that, `**/*/**/*` pattern also expands `.` that exists in root folder. Therefore, we get duplicate records for top level files, such as `foo.h` and `./foo.h`. To drop latter ones, a used to final glob pattern as follows:

`**{,/[^.]*/**}/*`

This seems to work for various cases that I tried. I also fixed tests as we now support symlink following, and tests were trying to assure that we are not following symlinks.

What's your feeling about this change? I think this solves a big chunk of symlink following problem. 

However, it's not a complete solution as it only follows symlinks once. So for a directory tree like this:
```
.
├── a
│   ├── b
│   ├── d
│   │   └── e
│   └── f -> d
├── b -> a/b
└── c -> a
```
I get following output:
```
irb(main):019:0> Dir.glob('**{,/*/**}/*').uniq!
=> ["a", "a/f", "a/d", "a/d/e", "a/b", "c", "x", "b", "a/f/e", "c/f", "c/d", "c/d/e", "c/b"]
```

Here `c/d/e` is resolved, but `c/f/e` is not because it didn't follow `f` symlink in folder `a`.

One very dirty solution would be to add `{,/*/**}` part multiple times into glob pattern. Each addition would add an extra level of symlink following.

Another solution would be to traverse all found files from `**/*` and try to follow the path if it's a link and directory, and do this recursively. Even though this would be a solution, this complicates the implementation and possible performance.


A completely different solution would be to give full control to podspec developer, and run glob patterns provided by them directly on the file system, rather than trying to match them in a pre generated list of files and directories which is collected with `**` which does not have a notion to follow symlinks by default. I think this can be a great solution if we don't observe performance penalties. This would make us to completely get rid of PathList possibly.