### PR TITLE
Fix an issue that caused stale framework artifacts when archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Paul Beusterien](https://github.com/paulb777)
   [#9465](https://github.com/CocoaPods/CocoaPods/pull/9465)
 
+* Fix an issue that caused iOS archives to be invalid when including a vendored XCFramework  
+  [Eric Amorde](https://github.com/amorde)
+  [#9458](https://github.com/CocoaPods/CocoaPods/issues/9458)
+
 
 ## 1.9.0.beta.2 (2019-12-17)
 

--- a/lib/cocoapods/generator/prepare_artifacts_script.rb
+++ b/lib/cocoapods/generator/prepare_artifacts_script.rb
@@ -117,7 +117,7 @@ module Pod
             fi
 
             local record_artifact=${2:-true}
-            local destination="${TARGET_BUILD_DIR}"
+            local destination="${CONFIGURATION_BUILD_DIR}"
 
             if [ -L "${source}" ]; then
               echo "Symlinked..."


### PR DESCRIPTION
Closes #9458 

Requires https://github.com/CocoaPods/cocoapods-integration-specs/pull/264

When archiving, the `.framework` slice that was placed in `Prepare Artifacts` was left in the `Products/Applications` directory of the archive because that is what `${TARGET_BUILD_DIR}` is set to when archiving. During a non-install build, the value matches that of `${CONFIGURATION_BUILD_DIR}`