### PR TITLE
When preserving pod paths, preserve ALL the paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* When preserving pod paths, preserve ALL the paths  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9483](https://github.com/CocoaPods/CocoaPods/pull/9483)
+
 * Re-implement `dSYM` copying and stripping to avoid duplicate outputs.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9185](https://github.com/CocoaPods/CocoaPods/issues/9185)  

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -218,7 +218,8 @@ module Pod
               pod_name = file_accessor.spec.name
               preserve_pod_file_structure_flag = (sandbox.local?(pod_name) || preserve_pod_file_structure) && reflect_file_system_structure
               base_path = preserve_pod_file_structure_flag ? common_path(paths) : nil
-              group = pods_project.group_for_spec(pod_name, group_key)
+              actual_group_key = preserve_pod_file_structure_flag ? nil : group_key
+              group = pods_project.group_for_spec(pod_name, actual_group_key)
               paths.each do |path|
                 pods_project.add_file_reference(path, group, preserve_pod_file_structure_flag, base_path)
               end

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -295,6 +295,12 @@ module Pod
           end
 
           #-------------------------------------------------------------------------#
+
+          it 'preserves all the paths of the Pod' do
+            @installer = FileReferencesInstaller.new(config.sandbox, [@pod_target], @project, true)
+            @installer.install!
+            @project.group_for_spec('BananaLib').recursive_children.map(&:name).compact.should.not.include? 'Resources'
+          end
         end
       end
     end


### PR DESCRIPTION
This PR addresses an issue happening when a pod is set to preserve local paths, e.g. a local pod.

The issue is that some file references weren't actually being preserved. Interface Builder files are a good example, these were getting put into a `Resources` group and this was very inconvenient as it placed them away from the corresponding source file. 

This PR fixes this issue by preserving ALL paths when a pod is set to preserve local paths.

Integration specs - https://github.com/CocoaPods/cocoapods-integration-specs/pull/265