### PR TITLE
Add ruby 2.7.0 support to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - 2.6.2
+  - 2.7.0
 
 env:
   - COCOAPODS_CI_TASKS=SPECS


### PR DESCRIPTION
2.7.0 is stable now, and this was requested here https://github.com/CocoaPods/Core/pull/614#issuecomment-581570622