### PR TITLE
Hook up test spec test bundles to their respective app host's test action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#9332](https://github.com/CocoaPods/CocoaPods/issues/9332)
 
+* Fix an issue that prevented variables in test bundle scheme settings from expanding   
+  [Eric Amorde](https://github.com/amorde)
+  [#9539](https://github.com/CocoaPods/CocoaPods/pull/9539)
+
 ## 1.9.0.beta.3 (2020-02-04)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9518](https://github.com/CocoaPods/CocoaPods/pull/9518)  
 
+* Add support for running tests through the scheme of the app spec host of a test spec    
+  [Eric Amorde](https://github.com/amorde)
+  [#9332](https://github.com/CocoaPods/CocoaPods/issues/9332)
 
 ## 1.9.0.beta.3 (2020-02-04)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: 415cf26a26778fd417028de166930b0d0349066c
+  revision: 4772726f5878a910e5a72c473cfedefe35e377d6
   branch: master
   specs:
     xcodeproj (1.15.0)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -331,7 +331,7 @@ module Pod
         all_projects_by_pod_targets.merge!(pods_project_by_targets) if pods_project_by_targets
         all_projects_by_pod_targets.merge!(projects_by_pod_targets) if projects_by_pod_targets
         all_projects_by_pod_targets.each do |project, pod_targets|
-          generator.configure_schemes(project, pod_targets)
+          generator.configure_schemes(project, pod_targets, pod_project_generation_result)
         end
       end
     end

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -690,13 +690,13 @@ module Pod
             hash[app_spec.name] = Hash[app_dependencies_by_config.map { |k, v| [k, filter_dependencies(v, pod_targets_by_name, target)] }]
           end
 
-          target.test_app_hosts_by_spec_name = target.test_specs.each_with_object({}) do |test_spec, hash|
+          target.test_app_hosts_by_spec = target.test_specs.each_with_object({}) do |test_spec, hash|
             next unless app_host_name = test_spec.consumer(target.platform).app_host_name
             app_host_spec = pod_targets_by_name[Specification.root_name(app_host_name)].flat_map(&:app_specs).find do |pt|
               pt.name == app_host_name
             end
             app_host_dependencies = { app_host_spec.root => [app_host_spec] }
-            hash[test_spec.name] = [app_host_spec, filter_dependencies(app_host_dependencies, pod_targets_by_name, target).first]
+            hash[test_spec] = [app_host_spec, filter_dependencies(app_host_dependencies, pod_targets_by_name, target).first]
           end
         end
       end

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -271,6 +271,13 @@ module Pod
                 testable = Xcodeproj::XCScheme::TestAction::TestableReference.new(native_target)
                 scheme.test_action.add_testable(testable)
               end
+
+              if spec.test_specification?
+                # Default to using the test bundle to expand variables
+                native_target_for_expansion = generator_result.native_target_for_spec(spec)
+                macro_expansion = Xcodeproj::XCScheme::MacroExpansion.new(native_target_for_expansion)
+                scheme.launch_action.add_macro_expansion(macro_expansion)
+              end
               scheme.save!
             end
             Xcodeproj::XCScheme.share_scheme(project.path, scheme_name) if share_scheme

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -33,12 +33,12 @@ module Pod
           #
           attr_reader :test_resource_bundle_targets
 
-          # @return [Hash{Specification => PBXNativeTarget}] test_app_host_targets
+          # @return [Array<PBXNativeTarget>] test_app_host_targets
           #         The test app host native targets that were produced for this target. Can be empty.
           #
           attr_reader :test_app_host_targets
 
-          # @return [Array<PBXNativeTarget>] app_native_targets
+          # @return [Hash{Specification => PBXNativeTarget}] app_native_targets
           #         The app native targets that were produced for this target. Can be empty if there were no app
           #         native targets created (e.g. no app specs present).
           #

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installation_result.rb
@@ -33,7 +33,7 @@ module Pod
           #
           attr_reader :test_resource_bundle_targets
 
-          # @return [Array<PBXNativeTarget>] test_app_host_targets
+          # @return [Hash{Specification => PBXNativeTarget}] test_app_host_targets
           #         The test app host native targets that were produced for this target. Can be empty.
           #
           attr_reader :test_app_host_targets
@@ -58,12 +58,12 @@ module Pod
           # @param [Array<PBXNativeTarget>] test_native_targets @see #test_native_targets
           # @param [Hash{String=>Array<PBXNativeTarget>}] test_resource_bundle_targets @see #test_resource_bundle_targets
           # @param [Array<PBXNativeTarget>] test_app_host_targets @see #test_app_host_targets
-          # @param [Array<PBXNativeTarget>] app_native_targets @see #app_native_targets
+          # @param [Hash{Specification => PBXNativeTarget}] app_native_targets @see #app_native_targets
           # @param [Hash{String=>Array<PBXNativeTarget>}] app_resource_bundle_targets @see #app_resource_bundle_targets
           #
           def initialize(target, native_target, resource_bundle_targets = [], test_native_targets = [],
                          test_resource_bundle_targets = {}, test_app_host_targets = [],
-                         app_native_targets = [], app_resource_bundle_targets = {})
+                         app_native_targets = {}, app_resource_bundle_targets = {})
             @target = target
             @native_target = native_target
             @resource_bundle_targets = resource_bundle_targets
@@ -115,7 +115,7 @@ module Pod
           # @return [PBXNativeTarget] the app host target with the given target label.
           #
           def app_host_target_labelled(label)
-            app_native_targets.find do |app_native_target|
+            app_native_targets.values.find do |app_native_target|
               app_native_target.name == label
             end || test_app_host_targets.find do |app_native_target|
               app_native_target.name == label
@@ -131,9 +131,7 @@ module Pod
           end
 
           def app_native_target_from_spec(spec)
-            app_native_targets.find do |app_native_target|
-              app_native_target.name == target.app_target_label(spec)
-            end
+            app_native_targets[spec]
           end
         end
       end

--- a/lib/cocoapods/installer/xcode/pods_project_generator_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator_result.rb
@@ -33,6 +33,7 @@ module Pod
           #        A spec which was included in the generated project
           #
           # @return [Xcodeproj::PBXNativeTarget] the native target for the spec
+          #
           def native_target_for_spec(spec)
             installation_results_by_spec[spec.root].native_target_for_spec(spec)
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator_result.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator_result.rb
@@ -28,6 +28,24 @@ module Pod
             @projects_by_pod_targets = projects_by_pod_targets
             @target_installation_results = target_installation_results
           end
+
+          # @param [Pod::Specification] spec
+          #        A spec which was included in the generated project
+          #
+          # @return [Xcodeproj::PBXNativeTarget] the native target for the spec
+          def native_target_for_spec(spec)
+            installation_results_by_spec[spec.root].native_target_for_spec(spec)
+          end
+
+          private
+
+          def installation_results_by_spec
+            @target_installation_results_by_spec ||= begin
+              target_installation_results.pod_target_installation_results.values.each_with_object({}) do |installation_results, hash|
+                hash[installation_results.target.root_spec] = installation_results
+              end
+            end
+          end
         end
       end
     end

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -551,14 +551,14 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['a/Tests', ['a_testing']]]
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(a a_testing b base base_testing c e)
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'a_testing' }
             pod_target.dependent_targets.map(&:name).sort.should == %w(a base_testing)
             pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(a b base base_testing c e)
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'b' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -567,14 +567,14 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['b/Tests', []]]
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'base' }
             pod_target.dependent_targets.map(&:name).sort.should == []
             pod_target.recursive_dependent_targets.map(&:name).sort.should == []
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'c' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -583,7 +583,7 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['a_testing']]]
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(a a_testing b base base_testing c e)
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['app_host/App', 'app_host']]]
+            pod_target.test_app_hosts_by_spec.map { |k, v| [k.name, v.map(&:name)] }.should == [['c/Tests', ['app_host/App', 'app_host']]]
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'd' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -592,14 +592,14 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['d/Tests', ['b']]]
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(b base c e)
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'e' }
             pod_target.dependent_targets.map(&:name).sort.should == ['base']
             pod_target.recursive_dependent_targets.map(&:name).sort.should == ['base']
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'app_host' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -610,7 +610,7 @@ module Pod
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['app_host/App', ['d']]]
             pod_target.recursive_app_dependent_targets(app_spec).map(&:name).sort.should == %w(a b base c d e)
-            pod_target.test_app_hosts_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['app_host/Tests', ['app_host/App', 'app_host']]]
+            pod_target.test_app_hosts_by_spec.map { |k, v| [k.name, v.map(&:name)] }.should == [['app_host/Tests', ['app_host/App', 'app_host']]]
           end
 
           it 'correctly computes recursive dependent targets for scoped pod targets' do
@@ -717,14 +717,14 @@ module Pod
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['a/Tests', ['a_testing'].map { |n| n + scope }]]
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
               pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(a a_testing b base base_testing c e).map { |n| n + scope }
-              pod_target.test_app_hosts_by_spec_name.should == {}
+              pod_target.test_app_hosts_by_spec.should == {}
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'a_testing' + scope }
               pod_target.dependent_targets.map(&:name).sort.should == %w(a base_testing).map { |n| n + scope }
               pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(a b base base_testing c e).map { |n| n + scope }
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-              pod_target.test_app_hosts_by_spec_name.should == {}
+              pod_target.test_app_hosts_by_spec.should == {}
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'b' + scope }
               test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -733,14 +733,14 @@ module Pod
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['b/Tests', []]]
               pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == []
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-              pod_target.test_app_hosts_by_spec_name.should == {}
+              pod_target.test_app_hosts_by_spec.should == {}
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'base' + scope }
               pod_target.dependent_targets.map(&:name).sort.should == []
               pod_target.recursive_dependent_targets.map(&:name).sort.should == []
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-              pod_target.test_app_hosts_by_spec_name.should == {}
+              pod_target.test_app_hosts_by_spec.should == {}
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'c' + scope }
               test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -749,7 +749,7 @@ module Pod
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['a_testing'].map { |n| n + scope }]]
               pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(a a_testing b base base_testing c e).map { |n| n + scope }
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-              pod_target.test_app_hosts_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['app_host/App', 'app_host' + scope]]]
+              pod_target.test_app_hosts_by_spec.map { |k, v| [k.name, v.map(&:name)] }.should == [['c/Tests', ['app_host/App', 'app_host' + scope]]]
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'd' + scope }
               test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -758,14 +758,14 @@ module Pod
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['d/Tests', ['b'].map { |n| n + scope }]]
               pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(b base c e).map { |n| n + scope }
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-              pod_target.test_app_hosts_by_spec_name.should == {}
+              pod_target.test_app_hosts_by_spec.should == {}
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'e' + scope }
               pod_target.dependent_targets.map(&:name).sort.should == ['base'].map { |n| n + scope }
               pod_target.recursive_dependent_targets.map(&:name).sort.should == ['base'].map { |n| n + scope }
               pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-              pod_target.test_app_hosts_by_spec_name.should == {}
+              pod_target.test_app_hosts_by_spec.should == {}
 
               pod_target = result.pod_targets.find { |pt| pt.name == 'app_host' + scope }
               test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -776,7 +776,7 @@ module Pod
               pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == []
               pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['app_host/App', ['d'].map { |n| n + scope }]]
               pod_target.recursive_app_dependent_targets(app_spec).map(&:name).sort.should == %w(a b base c d e).map { |n| n + scope }
-              pod_target.test_app_hosts_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['app_host/Tests', ['app_host/App', 'app_host' + scope]]]
+              pod_target.test_app_hosts_by_spec.map { |k, v| [k.name, v.map(&:name)] }.should == [['app_host/Tests', ['app_host/App', 'app_host' + scope]]]
             end
           end
 
@@ -1001,14 +1001,14 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['a/Tests', ['a_testing'].map { |n| n + '-Pods-SampleProject' }]]
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(a a_testing b base base_testing c e).map { |n| n + '-Pods-SampleProject' }
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'a_testing-Pods-SampleProject' }
             pod_target.dependent_targets.map(&:name).sort.should == %w(a base_testing).map { |n| n + '-Pods-SampleProject' }
             pod_target.recursive_dependent_targets.map(&:name).sort.should == %w(a b base base_testing c e).map { |n| n + '-Pods-SampleProject' }
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'b-Pods-SampleProject' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -1017,14 +1017,14 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['b/Tests', []]]
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'base-Pods-SampleProject' }
             pod_target.dependent_targets.map(&:name).sort.should == []
             pod_target.recursive_dependent_targets.map(&:name).sort.should == []
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'c-Pods-SampleProject' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -1033,7 +1033,7 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['a_testing'].map { |n| n + '-Pods-SampleProject' }]]
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(a a_testing b base base_testing c e).map { |n| n + '-Pods-SampleProject' }
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['c/Tests', ['app_host/App', 'app_host-Pods-SampleProject']]]
+            pod_target.test_app_hosts_by_spec.map { |k, v| [k.name, v.map(&:name)] }.should == [['c/Tests', ['app_host/App', 'app_host-Pods-SampleProject']]]
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'd-Pods-SampleProject' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -1042,14 +1042,14 @@ module Pod
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['d/Tests', ['b'].map { |n| n + '-Pods-SampleProject' }]]
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == %w(b base c e).map { |n| n + '-Pods-SampleProject' }
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'e-Pods-SampleProject' }
             pod_target.dependent_targets.map(&:name).sort.should == ['base'].map { |n| n + '-Pods-SampleProject' }
             pod_target.recursive_dependent_targets.map(&:name).sort.should == ['base'].map { |n| n + '-Pods-SampleProject' }
             pod_target.test_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == []
-            pod_target.test_app_hosts_by_spec_name.should == {}
+            pod_target.test_app_hosts_by_spec.should == {}
 
             pod_target = result.pod_targets.find { |pt| pt.name == 'app_host-Pods-SampleProject' }
             test_spec = pod_target.test_specs.find { |ts| ts.name == "#{pod_target.pod_name}/Tests" }
@@ -1060,7 +1060,7 @@ module Pod
             pod_target.recursive_test_dependent_targets(test_spec).map(&:name).sort.should == []
             pod_target.app_dependent_targets_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['app_host/App', ['d'].map { |n| n + '-Pods-SampleProject' }]]
             pod_target.recursive_app_dependent_targets(app_spec).map(&:name).sort.should == %w(a b base c d e).map { |n| n + '-Pods-SampleProject' }
-            pod_target.test_app_hosts_by_spec_name.map { |k, v| [k, v.map(&:name)] }.should == [['app_host/Tests', ['app_host/App', 'app_host-Pods-SampleProject']]]
+            pod_target.test_app_hosts_by_spec.map { |k, v| [k.name, v.map(&:name)] }.should == [['app_host/Tests', ['app_host/App', 'app_host-Pods-SampleProject']]]
           end
 
           it 'picks the right variants up when there are multiple' do

--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -740,6 +740,7 @@ module Pod
                 { :key => 'Key1', :value => 'Val1', :enabled => true },
               ]
               test_scheme.test_action.code_coverage_enabled?.should.be.true
+              test_scheme.launch_action.macro_expansions.empty?.should.be.false
             end
 
             it 'adds the test bundle to the test action of the app host when using app specs' do

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
@@ -217,9 +217,9 @@ module Pod
 
                   @app_host_spec = @pineapple_pod_target.app_specs.find { |t| t.base_name == 'App' }
 
-                  @pineapple_pod_target.test_app_hosts_by_spec_name = {
-                    'PineappleLib/Tests' => [@app_host_spec, @pineapple_pod_target],
-                    'PineappleLib/UI' => [@app_host_spec, @pineapple_pod_target],
+                  @pineapple_pod_target.test_app_hosts_by_spec = {
+                    @pineapple_spec.subspec_by_name('PineappleLib/Tests', true, true) => [@app_host_spec, @pineapple_pod_target],
+                    @pineapple_spec.subspec_by_name('PineappleLib/UI', true, true) => [@app_host_spec, @pineapple_pod_target],
                   }
                 end
 

--- a/spec/unit/installer/xcode/pods_project_generator/target_installation_result_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installation_result_spec.rb
@@ -19,7 +19,7 @@ module Pod
               result.test_native_targets.should == []
               result.test_resource_bundle_targets.should == {}
               result.test_app_host_targets.should == []
-              result.app_native_targets.should == []
+              result.app_native_targets.should == {}
               result.app_resource_bundle_targets.should == {}
             end
 

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -550,6 +550,7 @@ module Pod
                   map { |test_spec| pod_generator_result.native_target_for_spec(test_spec).uuid }.
                   sort
               host_scheme.test_action.testables.flat_map { |t| t.buildable_references.map(&:target_uuid) }.sort.should == native_target_uuids
+              test_scheme.launch_action.macro_expansions.empty?.should.be.false
             end
 
             it 'allows opting out' do

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -72,8 +72,20 @@ module Pod
                                                                         [@ios_target_definition], 'iOS')
             @grapefruits_ios_pod_target.app_dependent_targets_by_spec_name = { @grapefruits_app_spec.name => [@banana_ios_pod_target] }
 
+            @pineapple_spec = fixture_spec('pineapple-lib/PineappleLib.podspec')
+            @pineapple_app_spec = @pineapple_spec.app_specs.first
+            @pineapple_test_spec = @pineapple_spec.test_specs.first
+            @pineapple_ios_pod_target = fixture_pod_target_with_specs([@pineapple_spec, *@pineapple_spec.recursive_subspecs],
+                                                                      BuildType.dynamic_framework,
+                                                                      user_build_configurations, [], Platform.new(:ios, '13.0'),
+                                                                      [@ios_target_definition], 'iOS')
+            @pineapple_ios_pod_target.app_dependent_targets_by_spec_name = { @pineapple_app_spec.name => [@pineapple_ios_pod_target] }
+            @pineapple_ios_pod_target.test_app_hosts_by_spec = @pineapple_spec.test_specs.each_with_object({}) do |test_spec, hash|
+              hash[test_spec] = [@pineapple_app_spec, @pineapple_ios_pod_target]
+            end
+
             ios_pod_targets = [@banana_ios_pod_target, @monkey_ios_pod_target, @coconut_ios_pod_target,
-                               @orangeframework_pod_target, @watermelon_ios_pod_target, @grapefruits_ios_pod_target]
+                               @orangeframework_pod_target, @watermelon_ios_pod_target, @grapefruits_ios_pod_target, @pineapple_ios_pod_target]
             osx_pod_targets = [@banana_osx_pod_target, @monkey_osx_pod_target, @coconut_osx_pod_target, @watermelon_osx_pod_target]
             pod_targets = ios_pod_targets + osx_pod_targets
 
@@ -178,6 +190,10 @@ module Pod
               'GrapefruitsLib-iOS',
               'GrapefruitsLib-iOS-App',
               'OrangeFramework',
+              'PineappleLib-iOS',
+              'PineappleLib-iOS-App',
+              'PineappleLib-iOS-UI-UI',
+              'PineappleLib-iOS-Unit-Tests',
               'Pods-SampleApp-iOS',
               'Pods-SampleApp-macOS',
               'WatermelonLib-iOS',
@@ -209,20 +225,21 @@ module Pod
             pod_generator_result.project.targets.find { |t| t.name == 'CoconutLib-iOS' }.dependencies.map(&:name).sort.should == [
               'OrangeFramework',
             ]
-            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.dependencies.map(&:name).sort.should == [
-              'BananaLib-iOS',
-              'CoconutLib-iOS',
-              'GrapefruitsLib-iOS',
-              'OrangeFramework',
-              'WatermelonLib-iOS',
-              'monkey-iOS',
-            ]
-            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-macOS' }.dependencies.map(&:name).sort.should == [
-              'BananaLib-macOS',
-              'CoconutLib-macOS',
-              'WatermelonLib-macOS',
-              'monkey-macOS',
-            ]
+            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-iOS' }.dependencies.map(&:name).sort.should == %w(
+              BananaLib-iOS
+              CoconutLib-iOS
+              GrapefruitsLib-iOS
+              OrangeFramework
+              PineappleLib-iOS
+              WatermelonLib-iOS
+              monkey-iOS
+            )
+            pod_generator_result.project.targets.find { |t| t.name == 'Pods-SampleApp-macOS' }.dependencies.map(&:name).sort.should == %w(
+              BananaLib-macOS
+              CoconutLib-macOS
+              WatermelonLib-macOS
+              monkey-macOS
+            )
           end
 
           it 'adds no system frameworks to static targets' do
@@ -297,7 +314,7 @@ module Pod
           it 'sets the app host app spec dependency for the tests that need it' do
             @coconut_test_spec.ios.requires_app_host = true
             @coconut_test_spec.ios.app_host_name = @grapefruits_app_spec.name
-            @coconut_ios_pod_target.test_app_hosts_by_spec_name = { @coconut_test_spec.name => [@grapefruits_app_spec, @grapefruits_ios_pod_target] }
+            @coconut_ios_pod_target.test_app_hosts_by_spec = { @coconut_test_spec => [@grapefruits_app_spec, @grapefruits_ios_pod_target] }
             pod_generator_result = @generator.generate!
             coconut_project = pod_generator_result.project
             coconut_project.should.not.be.nil
@@ -416,8 +433,11 @@ module Pod
 
           describe '#share_development_pod_schemes' do
             it 'does not share by default' do
+              pod_generator_result = @generator.generate!
+              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              @generator.configure_schemes(nil, [])
+              targets = @generator.pod_targets.select { |target| target.root_spec.name == 'BananaLib' }
+              @generator.configure_schemes(pod_generator_result.project, targets, pod_generator_result)
             end
 
             it 'can share all schemes' do
@@ -436,7 +456,8 @@ module Pod
                 pod_generator_result.project.path,
                 'BananaLib-macOS')
 
-              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets)
+              targets = @generator.pod_targets.select { |target| target.root_spec.name == 'BananaLib' }
+              @generator.configure_schemes(pod_generator_result.project, targets, pod_generator_result)
             end
 
             it 'shares test schemes' do
@@ -463,7 +484,8 @@ module Pod
                 pod_generator_result.project.path,
                 'CoconutLib-macOS-Unit-Tests')
 
-              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets)
+              targets = @generator.pod_targets.select { |target| target.root_spec.name == 'CoconutLib' }
+              @generator.configure_schemes(pod_generator_result.project, targets, pod_generator_result)
             end
 
             it 'correctly configures schemes for all specs' do
@@ -482,7 +504,7 @@ module Pod
                                            pod_generator_result.target_installation_results.pod_target_installation_results,
                                            @generator.installation_options).write!
 
-              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets)
+              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets, pod_generator_result)
 
               scheme_path = Xcodeproj::XCScheme.shared_data_dir(pod_generator_result.project.path) + 'CoconutLib-iOS.xcscheme'
               scheme = Xcodeproj::XCScheme.new(scheme_path)
@@ -500,20 +522,59 @@ module Pod
               test_scheme.test_action.code_coverage_enabled?.should.be.true
             end
 
+            it 'adds the test bundle to the test action of the app host when using app specs' do
+              @generator.installation_options.
+                  stubs(:share_schemes_for_development_pods).
+                  returns(true)
+              @generator.sandbox.stubs(:development_pods).returns('PineappleLib' => fixture('pineapple-lib'))
+
+              pod_generator_result = @generator.generate!
+
+              project = pod_generator_result.project
+
+              Xcode::PodsProjectWriter.new(config.sandbox, [project],
+                                           pod_generator_result.target_installation_results.pod_target_installation_results,
+                                           @generator.installation_options).write!
+
+              @generator.configure_schemes(project, @generator.pod_targets, pod_generator_result)
+
+              scheme_path = Xcodeproj::XCScheme.shared_data_dir(project.path) + 'PineappleLib-iOS.xcscheme'
+              scheme_path.should.exist?
+              test_scheme_path = Xcodeproj::XCScheme.shared_data_dir(project.path) + 'PineappleLib-iOS-Unit-Tests.xcscheme'
+              test_scheme = Xcodeproj::XCScheme.new(test_scheme_path)
+              test_scheme.launch_action.macro_expansions.should.not.be.empty?
+
+              host_scheme_path = Xcodeproj::XCScheme.shared_data_dir(project.path) + 'PineappleLib-iOS-App.xcscheme'
+              host_scheme = Xcodeproj::XCScheme.new(host_scheme_path)
+              native_target_uuids = @pineapple_spec.test_specs.
+                  map { |test_spec| pod_generator_result.native_target_for_spec(test_spec).uuid }.
+                  sort
+              host_scheme.test_action.testables.flat_map { |t| t.buildable_references.map(&:target_uuid) }.sort.should == native_target_uuids
+            end
+
             it 'allows opting out' do
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
                   returns(false)
 
+              pod_generator_result = @generator.generate!
+              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
+
+              targets =@generator.pod_targets.select { |target| target.root_spec.name == 'BananaLib' }
+
+              Xcode::PodsProjectWriter.new(config.sandbox, [pod_generator_result.project],
+                                           pod_generator_result.target_installation_results.pod_target_installation_results,
+                                           @generator.installation_options).write!
+
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              @generator.configure_schemes(nil, [])
+              @generator.configure_schemes(pod_generator_result.project, targets, pod_generator_result)
 
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
                   returns(nil)
 
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              @generator.configure_schemes(nil, [])
+              @generator.configure_schemes(pod_generator_result.project, targets, pod_generator_result)
             end
 
             it 'allows specifying strings of pods to share' do
@@ -522,7 +583,11 @@ module Pod
                   returns(%w(BananaLib))
 
               pod_generator_result = @generator.generate!
-              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
+              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'), 'PineappleLib' => fixture('pineapple-lib'))
+
+              Xcode::PodsProjectWriter.new(config.sandbox, [pod_generator_result.project],
+                                           pod_generator_result.target_installation_results.pod_target_installation_results,
+                                           @generator.installation_options).write!
 
               Xcodeproj::XCScheme.expects(:share_scheme).with(
                 pod_generator_result.project.path,
@@ -532,23 +597,27 @@ module Pod
                 pod_generator_result.project.path,
                 'BananaLib-macOS')
 
-              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets)
+              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets, pod_generator_result)
 
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
                   returns(%w(orange-framework))
 
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets)
+              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets, pod_generator_result)
             end
 
             it 'allows specifying regular expressions of pods to share' do
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
-                  returns([/bAnaNalIb/i, /B*/])
+                  returns([/bAnaNalIb/i, /Ban*/])
 
               pod_generator_result = @generator.generate!
-              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
+              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'), 'PineappleLib' => fixture_spec('pineapple-lib/PineappleLib.podspec'))
+
+              Xcode::PodsProjectWriter.new(config.sandbox, [pod_generator_result.project],
+                                           pod_generator_result.target_installation_results.pod_target_installation_results,
+                                           @generator.installation_options).write!
 
               Xcodeproj::XCScheme.expects(:share_scheme).with(
                 pod_generator_result.project.path,
@@ -558,14 +627,14 @@ module Pod
                 pod_generator_result.project.path,
                 'BananaLib-macOS')
 
-              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets)
+              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets, pod_generator_result)
 
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
                   returns([/banana$/, /[^\A]BananaLib/])
 
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              @generator.configure_schemes(nil, [])
+              @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets, pod_generator_result)
             end
 
             it 'raises when an invalid type is set' do
@@ -574,9 +643,9 @@ module Pod
                   returns(Pathname('foo'))
 
               pod_generator_result = @generator.generate!
-              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
+              @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'), 'PineappleLib' => fixture_spec('pineapple-lib/PineappleLib.podspec'))
               Xcodeproj::XCScheme.expects(:share_scheme).never
-              e = should.raise(Informative) { @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets) }
+              e = should.raise(Informative) { @generator.configure_schemes(pod_generator_result.project, @generator.pod_targets, pod_generator_result) }
               e.message.should.match /share_schemes_for_development_pods.*set it to true, false, or an array of pods to share schemes for/
             end
           end

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -561,7 +561,7 @@ module Pod
               pod_generator_result = @generator.generate!
               @generator.sandbox.stubs(:development_pods).returns('BananaLib' => fixture('BananaLib'))
 
-              targets =@generator.pod_targets.select { |target| target.root_spec.name == 'BananaLib' }
+              targets = @generator.pod_targets.select { |target| target.root_spec.name == 'BananaLib' }
 
               Xcode::PodsProjectWriter.new(config.sandbox, [pod_generator_result.project],
                                            pod_generator_result.target_installation_results.pod_target_installation_results,

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -667,8 +667,9 @@ module Pod
           @pod_target.dependent_targets = [@orangeframework_pod_target]
           @pod_target.test_dependent_targets_by_spec_name = { @orangeframework_pod_target.name => [@matryoshka_pod_target] }
           @pod_target.app_dependent_targets_by_spec_name = { @orangeframework_pod_target.name => [@monkey_pod_target] }
-          @pod_target.test_app_hosts_by_spec_name = { @orangeframework_pod_target.name => [@matryoshka_pod_target.specs.first,
-                                                                                           @matryoshka_pod_target] }
+          @pod_target.test_app_hosts_by_spec = {
+              fixture_spec('orange-framework/OrangeFramework.podspec') => [@matryoshka_pod_target.specs.first, @matryoshka_pod_target]
+          }
         end
 
         it 'resolves simple dependencies' do
@@ -686,10 +687,10 @@ module Pod
         end
 
         it 'scopes test app host dependencies' do
-          scoped_pod_target = @pod_target.scoped
-          scoped_pod_target.first.test_app_hosts_by_spec_name.count.should == 1
-          scoped_pod_target.first.test_app_hosts_by_spec_name['OrangeFramework'].first.should == @matryoshka_pod_target.specs.first
-          scoped_pod_target.first.test_app_hosts_by_spec_name['OrangeFramework'].last.name.should == 'matryoshka-Pods'
+          scoped_pod_target = @pod_target.scoped.first
+          scoped_pod_target.test_app_hosts_by_spec.count.should == 1
+          scoped_pod_target.test_app_hosts_by_spec[@orangeframework_pod_target.root_spec].first.should == @matryoshka_pod_target.specs.first
+          scoped_pod_target.test_app_hosts_by_spec[@orangeframework_pod_target.root_spec].last.name.should == 'matryoshka-Pods'
         end
 
         describe 'With cyclic dependencies' do
@@ -935,7 +936,7 @@ module Pod
                                                                [target_definition])
           app_host_spec = pineapple_pod_target.app_specs.find { |t| t.base_name == 'App' }
           test_spec = pineapple_pod_target.test_specs.find { |t| t.base_name == 'Tests' }
-          pineapple_pod_target.test_app_hosts_by_spec_name = { 'PineappleLib/Tests' => [app_host_spec, pineapple_pod_target] }
+          pineapple_pod_target.test_app_hosts_by_spec = { pineapple_spec.subspec_by_name('PineappleLib/Tests', true, true) => [app_host_spec, pineapple_pod_target] }
           pineapple_pod_target.app_host_dependent_targets_for_spec(test_spec).map(&:name).should == ['PineappleLib']
         end
 
@@ -947,7 +948,7 @@ module Pod
                                                                [target_definition])
           app_host_spec = pineapple_pod_target.app_specs.find { |t| t.base_name == 'App' }
           test_spec = pineapple_pod_target.test_specs.find { |t| t.base_name == 'UI' }
-          pineapple_pod_target.test_app_hosts_by_spec_name = { 'PineappleLib/UI' => [app_host_spec, pineapple_pod_target] }
+          pineapple_pod_target.test_app_hosts_by_spec = { pineapple_spec.subspec_by_name('PineappleLib/UI', true, true) => [app_host_spec, pineapple_pod_target] }
           pineapple_pod_target.app_host_dependent_targets_for_spec(test_spec).map(&:name).should == []
         end
 

--- a/spec/unit/target/pod_target_spec.rb
+++ b/spec/unit/target/pod_target_spec.rb
@@ -668,7 +668,7 @@ module Pod
           @pod_target.test_dependent_targets_by_spec_name = { @orangeframework_pod_target.name => [@matryoshka_pod_target] }
           @pod_target.app_dependent_targets_by_spec_name = { @orangeframework_pod_target.name => [@monkey_pod_target] }
           @pod_target.test_app_hosts_by_spec = {
-              fixture_spec('orange-framework/OrangeFramework.podspec') => [@matryoshka_pod_target.specs.first, @matryoshka_pod_target]
+            fixture_spec('orange-framework/OrangeFramework.podspec') => [@matryoshka_pod_target.specs.first, @matryoshka_pod_target],
           }
         end
 


### PR DESCRIPTION
Also resolves an issue that prevented macros from expanding when included in test bundle's scheme settings (ex. using `$PODS_ROOT` within a test spec's `scheme[:environment]`)

Closes #9332 