### PR TITLE
Fix XCTUnwrap workaround search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * None.  
 
 
+* Fix Xcode 11 `XCTUnwrap` workaround paths that prevented linting of podspecs dependent on XCTest  
+  [Steven Grosmark](https://github.com/g-mark)
+  [#9571](https://github.com/CocoaPods/CocoaPods/pull/9571)
+
 ## 1.9.0 (2020-02-25)
 
 ##### Enhancements

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -691,7 +691,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :system_framework_search_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
-          return ['$(PLATFORM_DIR)/Developer/usr/lib'] if should_apply_xctunwrap_fix?
+          return ['$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks'] if should_apply_xctunwrap_fix?
           []
         end
 
@@ -749,7 +749,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :library_search_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
-          library_search_paths = should_apply_xctunwrap_fix? ? ['$(PLATFORM_DIR)/Developer/usr/lib'] : []
+          library_search_paths = should_apply_xctunwrap_fix? ? ['$(inherited) $(PLATFORM_DIR)/Developer/usr/lib'] : []
           return library_search_paths if library_xcconfig? && target.build_as_static?
 
           library_search_paths.concat library_search_paths_to_import.dup
@@ -851,7 +851,7 @@ module Pod
         define_build_settings_method :swift_include_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
           paths = dependent_targets.flat_map { |pt| pt.build_settings[@configuration].swift_include_paths_to_import }
           paths.concat swift_include_paths_to_import if non_library_xcconfig?
-          paths.concat ['$(PLATFORM_DIR)/Developer/usr/lib'] if should_apply_xctunwrap_fix?
+          paths.concat ['$(inherited) $(PLATFORM_DIR)/Developer/usr/lib'] if should_apply_xctunwrap_fix?
           paths
         end
 

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -189,9 +189,10 @@ module Pod
             @pod_target.stubs(:platform).returns(Platform.new(:ios, '12.1'))
             generator = PodTargetSettings.new(@pod_target, nil, :configuration => :debug)
             hash = generator.generate.to_hash
-            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
-            hash['LIBRARY_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
-            hash['SWIFT_INCLUDE_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
+            puts hash
+            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks"'
+            hash['LIBRARY_SEARCH_PATHS'].should.include '"$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"'
+            hash['SWIFT_INCLUDE_PATHS'].should.include '"$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"'
           end
 
           it 'includes xctunwrap fix for a pod target with deployment target < 12.2 and weakly links XCTest' do
@@ -199,9 +200,9 @@ module Pod
             @pod_target.stubs(:platform).returns(Platform.new(:ios, '12.1'))
             generator = PodTargetSettings.new(@pod_target, nil, :configuration => :debug)
             hash = generator.generate.to_hash
-            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
-            hash['LIBRARY_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
-            hash['SWIFT_INCLUDE_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
+            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks"'
+            hash['LIBRARY_SEARCH_PATHS'].should.include '"$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"'
+            hash['SWIFT_INCLUDE_PATHS'].should.include '"$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"'
           end
 
           it 'does not include xctunwrap fix for a pod target with higher than 12.1 deployment target' do
@@ -210,7 +211,7 @@ module Pod
             generator = PodTargetSettings.new(@pod_target, nil, :configuration => :debug)
             hash = generator.generate.to_hash
             hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.be.nil
-            hash['LIBRARY_SEARCH_PATHS'].should.not.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
+            hash['LIBRARY_SEARCH_PATHS'].should.not.include '"$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"'
             hash['SWIFT_INCLUDE_PATHS'].should.be.nil
           end
 


### PR DESCRIPTION
Fix for Issue https://github.com/CocoaPods/CocoaPods/issues/9570

Fixes the search paths used when applying Apple's recommended workaround for XCTUnwrap support.  See: https://developer.apple.com/documentation/xcode_release_notes/xcode_11_release_notes


> The XCTUnwrap API is only available in primary test bundle targets and not in other libraries or frameworks. (51117167)

> Workaround: Move any library code that makes use of XCTUnwrap to your primary test bundle target or manually modify the following build settings in affected targets:

```
SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks"
LIBRARY_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"
SWIFT_INCLUDE_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"
```