### PR TITLE
Fix an issue when including XCFrameworks in macOS apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix an issue that caused a build failure with vendored XCFrameworks on macOS  
+  [Eric Amorde](https://github.com/amorde)
+  [#9574](https://github.com/CocoaPods/CocoaPods/pull/9574) 
 
 
 ## 1.9.0 (2020-02-25)

--- a/lib/cocoapods/generator/prepare_artifacts_script.rb
+++ b/lib/cocoapods/generator/prepare_artifacts_script.rb
@@ -148,7 +148,7 @@ module Pod
             if [[ "$PLATFORM_NAME" == *"simulator" ]]; then
               target_variant="simulator"
             fi
-            if [[ "$EFFECTIVE_PLATFORM_NAME" == *"maccatalyst" ]]; then
+            if [[ ! -z ${EFFECTIVE_PLATFORM_NAME+x} && "$EFFECTIVE_PLATFORM_NAME" == *"maccatalyst" ]]; then
               target_variant="maccatalyst"
             fi
             for i in ${!paths[@]}; do


### PR DESCRIPTION
${EFFECTIVE_PLATFORM_NAME} will only be set if applicable for the current platform.

Closes #9572