### PR TITLE
Apply correct `SYSTEM_FRAMEWORK_SEARCH_PATHS` for `XCTUnwrap` fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Apply correct `SYSTEM_FRAMEWORK_SEARCH_PATHS` for `XCTUnwrap` fix.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9579](https://github.com/CocoaPods/CocoaPods/pull/9579)
+
 * Fix an issue that caused a build failure with vendored XCFrameworks on macOS  
   [Eric Amorde](https://github.com/amorde)
   [#9572](https://github.com/CocoaPods/CocoaPods/issues/9572)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -691,7 +691,7 @@ module Pod
 
         # @return [Array<String>]
         define_build_settings_method :system_framework_search_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
-          return ['$(PLATFORM_DIR)/Developer/usr/lib'] if should_apply_xctunwrap_fix?
+          return ['$(PLATFORM_DIR)/Developer/Library/Frameworks'] if should_apply_xctunwrap_fix?
           []
         end
 

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -189,7 +189,7 @@ module Pod
             @pod_target.stubs(:platform).returns(Platform.new(:ios, '12.1'))
             generator = PodTargetSettings.new(@pod_target, nil, :configuration => :debug)
             hash = generator.generate.to_hash
-            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
+            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/Library/Frameworks"'
             hash['LIBRARY_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
             hash['SWIFT_INCLUDE_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
           end
@@ -199,7 +199,7 @@ module Pod
             @pod_target.stubs(:platform).returns(Platform.new(:ios, '12.1'))
             generator = PodTargetSettings.new(@pod_target, nil, :configuration => :debug)
             hash = generator.generate.to_hash
-            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
+            hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/Library/Frameworks"'
             hash['LIBRARY_SEARCH_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
             hash['SWIFT_INCLUDE_PATHS'].should.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
           end


### PR DESCRIPTION
🤦‍♂ 

Integration specs: https://github.com/CocoaPods/cocoapods-integration-specs/pull/276

From Apple:

```
SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks"
LIBRARY_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"
SWIFT_INCLUDE_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/usr/lib"
```