### PR TITLE
Add --strict flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [lucasmpaim](https://github.com/lucasmpaim)
   [#7432](https://github.com/CocoaPods/CocoaPods/issues/7432)
 
+* Add `--strict` flag
+  [ileitch](https://github.com/ileitch)
+  [#9640](https://github.com/CocoaPods/CocoaPods/issues/9640)
+
 ##### Bug Fixes
 
 * When preserving pod paths, preserve ALL the paths  

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -40,10 +40,13 @@ module Pod
     def self.options
       [
         ['--silent', 'Show nothing'],
+        ['--strict', 'Return a non-zero exit status if any warnings are emitted'],
       ].concat(super)
     end
 
     def self.run(argv)
+      strict = !argv.delete('--strict').nil?
+
       help! 'You cannot run CocoaPods as root.' if Process.uid == 0 && !Gem.win_platform?
 
       verify_minimum_git_version!
@@ -52,6 +55,7 @@ module Pod
       super(argv)
     ensure
       UI.print_warnings
+      exit 1 if strict && UI.has_warnings?
     end
 
     def self.report_error(exception)

--- a/lib/cocoapods/command.rb
+++ b/lib/cocoapods/command.rb
@@ -55,7 +55,7 @@ module Pod
       super(argv)
     ensure
       UI.print_warnings
-      exit 1 if strict && UI.has_warnings?
+      exit 1 if strict && UI.warnings?
     end
 
     def self.report_error(exception)

--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -296,6 +296,13 @@ module Pod
         end
       end
 
+      # Signifies if there are any stored warnings.
+      #
+      # @return [Bool] whether there are any stored warnings.
+      def has_warnings?
+        !warnings.empty?
+      end
+
       # Presents a choice among the elements of an array to the user.
       #
       # @param  [Array<#to_s>] array

--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -299,7 +299,7 @@ module Pod
       # Signifies if there are any stored warnings.
       #
       # @return [Bool] whether there are any stored warnings.
-      def has_warnings?
+      def warnings?
         !warnings.empty?
       end
 


### PR DESCRIPTION
From time to time our project accumulates warnings, typically from a bad rebase. We'd like to catch these warnings before they're merged into our master branch by catching them in CI when we test a pull-request.

This change adds a `--strict` flag that'll cause a non-zero exit status if any warnings are emitted.

I've had to side-step CLAide as we don't have access to the parsed options yet. Any ideas how to improve this?