### PR TITLE
Do not clean user projects from sandbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not clean user projects from sandbox.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9683](https://github.com/CocoaPods/CocoaPods/pull/9683)
+
 * Fix mapping of resource paths for app specs.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9676](https://github.com/CocoaPods/CocoaPods/pull/9676)

--- a/lib/cocoapods/installer/sandbox_dir_cleaner.rb
+++ b/lib/cocoapods/installer/sandbox_dir_cleaner.rb
@@ -67,8 +67,9 @@ module Pod
             sandbox.pod_target_project_path(pod_target.project_name)
           end
           project_dir_names = sandbox_project_dir_names - [sandbox.project_path]
+          user_project_dir_names = aggregate_targets.map(&:user_project_path).uniq
 
-          removed_project_dir_names = project_dir_names - project_dir_names_to_install
+          removed_project_dir_names = project_dir_names - user_project_dir_names - project_dir_names_to_install
           removed_project_dir_names.each { |dir| remove_dir(dir) }
         end
       end


### PR DESCRIPTION
This does not happen in the very normal use cases of CocoaPods. It _can_ happen for 3rd party tools like cocoapods-generate that install the user project inside the sandbox directory and it is being picked up and cleaned.

This is good to have anyway as we want to be extra careful of not deleting/cleaning the user projects.