### PR TITLE
Honor prefix_header_file=false for subspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Honor prefix_header_file=false for subspecs  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#9687](https://github.com/CocoaPods/CocoaPods/pull/9687)
+
 * Do not clean user projects from sandbox.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9683](https://github.com/CocoaPods/CocoaPods/pull/9683)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -179,7 +179,7 @@ module Pod
           # @return [Boolean] Whether the target should build a pch file.
           #
           def skip_pch?(specs)
-            specs.any? { |spec| spec.prefix_header_file.is_a?(FalseClass) }
+            specs.any? { |spec| spec.root.prefix_header_file.is_a?(FalseClass) }
           end
 
           # True if info.plist generation should be skipped


### PR DESCRIPTION
I noticed that GoogleUtilities installations included a pch even though its [podspec](https://github.com/CocoaPods/Specs/blob/master/Specs/0/8/4/GoogleUtilities/6.5.2/GoogleUtilities.podspec.json#L23) includes  `"prefix_header_file": false`

The fix is to check prefix_header_file on the root podspec. Subspecs do not have separate pch files.