### PR TITLE
Fix deduplicate_targets and Swift crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix deduplicate_targets and Swift crash  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#9688](https://github.com/CocoaPods/CocoaPods/pull/9688)
+
 * Honor prefix_header_file=false for subspecs  
   [Paul Beusterien](https://github.com/paulb777)
   [#9687](https://github.com/CocoaPods/CocoaPods/pull/9687)

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -115,7 +115,7 @@ module Pod
                 target_errors = swift_target_definitions.map(&error_message_for_target_definition).to_sentence
                 "- `#{swift_pod_target.name}` is integrated by multiple targets that use a different Swift version: #{target_errors}."
               end
-            elsif swift_pod_target.swift_version.empty?
+            elsif !swift_pod_target.swift_version.nil? && swift_pod_target.swift_version.empty?
               "- `#{swift_pod_target.name}` does not specify a Swift version (#{swift_pod_target.spec_swift_versions.map { |v| "`#{v}`" }.to_sentence}) " \
                 "that is satisfied by any of targets (#{swift_pod_target.target_definitions.map { |td| "`#{td.name}`" }.to_sentence}) integrating it."
             end

--- a/spec/unit/installer/xcode/target_validator_spec.rb
+++ b/spec/unit/installer/xcode/target_validator_spec.rb
@@ -410,6 +410,30 @@ module Pod
               'any of targets (`SampleProject` and `TestRunner`) integrating it.'
           end
 
+          it 'does not crash on swift version check with deduplicate_targets' do
+            fixture_path = ROOT + 'spec/fixtures'
+            config.repos_dir = fixture_path + 'spec-repos'
+            podfile = Podfile.new do
+              project(fixture_path + 'SampleProject/SampleProject').to_s
+              platform :ios, '10.0'
+              install! 'cocoapods', :integrate_targets => false, :deduplicate_targets => false
+              pod 'MultiSwift', :path => (fixture_path + 'multi-swift').to_s
+              supports_swift_versions '< 3.0'
+              target 'SampleProject'
+              target 'TestRunner'
+            end
+            lockfile = generate_lockfile
+
+            @validator = create_validator(config.sandbox, podfile, lockfile)
+            # @todo Fix swift version handling with deduplicate_targets to uncomment the rest.
+            # e = should.raise Informative do
+            @validator.validate!
+            # end
+            # e.message.should.match /Unable to determine Swift version for the following pods:/
+            # e.message.should.include 'MultiSwift` does not specify a Swift version (`3.2` and `4.0`) that is satisfied by ' \
+            #  'any of targets (`SampleProject` and `TestRunner`) integrating it.'
+          end
+
           it 'does not raise an error if a pods swift versions are satisfied by the targets requirements' do
             fixture_path = ROOT + 'spec/fixtures'
             config.repos_dir = fixture_path + 'spec-repos'


### PR DESCRIPTION
Prevent a crash. There seems to be something more fundamental with the pod target not being properly initialized with the swift version when `deduplicate_targets` is set in the Podfile, but I wasn't able to figure that out. This might be an incremental improvement.

To reproduce add the following to a Podfile with a Swift pod (I used this [one](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorageSwift.podspec))

```
install! 'cocoapods',
          :deduplicate_targets => false
```

```
$ pod install
Analyzing dependencies
Downloading dependencies

――― MARKDOWN TEMPLATE ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

### Command

```
/Users/paulbeusterien/.rbenv/versions/2.6.5/bin/pod install
```

### Report

* What did you do?

* What did you expect to happen?

* What happened instead?


### Stack

```
   CocoaPods : 1.9.1
        Ruby : ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin18]
    RubyGems : 3.0.3
        Host : Mac OS X 10.15.2 (19C57)
       Xcode : 11.3.1 (11C505)
         Git : git version 2.24.0.525.g8f36a354ae-goog
Ruby lib dir : /Users/paulbeusterien/.rbenv/versions/2.6.5/lib
Repositories : cpdc-eap-spec - git - sso://cpdc-eap/spec @ 5ea80f78a3981fd5527e3361a4b74debadc3a819

               cpdc-internal-firebase - git - sso://cpdc-internal/firebase @ eb12c904fbfa33e5d87f9f84808336e6ab319bca

               cpdc-test-mlkit - git - sso://cpdc-test/mlkit @ 2b3d6463b0c1bc3df1aa0a2d9433cccf8ac4a6ca

               firebase - git - https://github.com/firebase/SpecsStaging.git @ c40ca90b1e31514aa1c401cf5bf0e24c68f06bbf

               master - git - https://github.com/CocoaPods/Specs.git @ 766a557b9e9e60587136ca4d549d3940ac9f7ec4

               PrivateSpecRepo - git - https://github.com/tripleCC/PrivateSpecRepo.git @ 1389676849943e81066525ea090043647660089d

               staging - git - git@github.com:firebase/SpecsStaging.git @ c40ca90b1e31514aa1c401cf5bf0e24c68f06bbf

               trunk - CDN - https://cdn.cocoapods.org/
```

### Plugins

```
claide-plugins                        : 0.9.2
cocoapods-deintegrate                 : 1.0.4
cocoapods-dependencies                : 1.3.0
cocoapods-disable-podfile-validations : 0.1.1
cocoapods-generate                    : 1.6.0
cocoapods-plugins                     : 1.0.0
cocoapods-search                      : 1.0.0
cocoapods-stats                       : 1.1.0
cocoapods-trunk                       : 1.4.1
cocoapods-try                         : 1.1.0
cocoapods_debug                       : 0.1.0
```

### Podfile

```ruby
# StorageExample

use_frameworks!
platform :ios, '8.0'

install! 'cocoapods',
          :deduplicate_targets => false

#pod 'Firebase/Analytics'
#pod 'Firebase/Auth'
#pod 'Firebase/Storage'
pod 'FirebaseStorageSwift',  :path => '/Users/paulbeusterien/gh4/firebase-ios-sdk'

target 'StorageExample' do
end
target 'StorageExampleSwift' do
end
target 'StorageExampleTests' do
end
```

### Error

```
NoMethodError - undefined method `empty?' for nil:NilClass
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/installer/xcode/target_validator.rb:118:in `block in verify_swift_pods_swift_version'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/installer/xcode/target_validator.rb:102:in `map'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/installer/xcode/target_validator.rb:102:in `verify_swift_pods_swift_version'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/installer/xcode/target_validator.rb:39:in `validate!'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/installer.rb:590:in `validate_targets'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/installer.rb:158:in `install!'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/command/install.rb:52:in `run'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/lib/cocoapods/command.rb:52:in `run'
/Users/paulbeusterien/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/cocoapods-1.9.1/bin/pod:55:in `<top (required)>'
/Users/paulbeusterien/.rbenv/versions/2.6.5/bin/pod:23:in `load'
/Users/paulbeusterien/.rbenv/versions/2.6.5/bin/pod:23:in `<main>'
```

――― TEMPLATE END ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

[!] Oh no, an error occurred.

Search for existing GitHub issues similar to yours:
https://github.com/CocoaPods/CocoaPods/search?q=undefined+method+%60empty%3F%27+for+nil%3ANilClass&type=Issues

If none exists, create a ticket, with the template displayed above, on:
https://github.com/CocoaPods/CocoaPods/issues/new

Be sure to first read the contributing guide for details on how to properly submit a ticket:
https://github.com/CocoaPods/CocoaPods/blob/master/CONTRIBUTING.md

Don't forget to anonymize any private data!

Looking for related issues on cocoapods/cocoapods...
 - NoMethodError - undefined method `recursive_predecessors' for nil:NilClass in Flutter App
   https://github.com/CocoaPods/CocoaPods/issues/9286 [closed] [5 comments]
   4 weeks ago

 - Unable to see XCode/SwiftUI Previews within CocoaPods frameworks
   https://github.com/CocoaPods/CocoaPods/issues/9275 [open] [39 comments]
   2 weeks ago

 - CocoaPods 1.5.2 crashes with rome plugin
   https://github.com/CocoaPods/CocoaPods/issues/7757 [open] [9 comments]
   22 May 2018

and 30 more at:
https://github.com/cocoapods/cocoapods/search?q=undefined%20method%20%60empty%3F%27%20for%20nil&type=Issues&utf8=✓
```