### PR TITLE
[Analyzer] Set BUILD_LIBRARY_FOR_DISTRIBUTION for all dependencies if it's set in the user target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Add a post_integrate_hook API  
   [lucasmpaim](https://github.com/lucasmpaim)
   [#7432](https://github.com/CocoaPods/CocoaPods/issues/7432)
+* Set the `BUILD_LIBRARY_FOR_DISTRIBUTION` build setting if integrating with a target that has the setting set to `YES` (directly or in an .xcconfig).  
+  [Juanjo López](https://github.com/juanjonol)
+  [#9232](https://github.com/CocoaPods/CocoaPods/issues/9232)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Add a post_integrate_hook API  
   [lucasmpaim](https://github.com/lucasmpaim)
   [#7432](https://github.com/CocoaPods/CocoaPods/issues/7432)
-* Set the `BUILD_LIBRARY_FOR_DISTRIBUTION` build setting if integrating with a target that has the setting set to `YES` (directly or in an .xcconfig).  
+
+* Set the `BUILD_LIBRARY_FOR_DISTRIBUTION` build setting if integrating with
+  a target that has the setting set to `YES` (directly or in an .xcconfig).  
   [Juanjo López](https://github.com/juanjonol)
   [#9232](https://github.com/CocoaPods/CocoaPods/issues/9232)
 
@@ -57,6 +59,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Set `Missing Localizability` setting to `'YES'` to prevent warnings in Xcode 11  
   [Eric Amorde](https://github.com/amorde)
   [#9612](https://github.com/CocoaPods/CocoaPods/pull/9612)
+
 
 ## 1.9.1 (2020-03-09)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -446,22 +446,18 @@ module Pod
           is_app_extension ||= aggregate_target.user_targets.any? do |user_target|
             user_target.common_resolved_build_setting('APPLICATION_EXTENSION_API_ONLY', :resolve_against_xcconfig => true) == 'YES'
           end
+          if is_app_extension
+            aggregate_target.mark_application_extension_api_only
+            aggregate_target.pod_targets.each(&:mark_application_extension_api_only)
+          end
 
-          next unless is_app_extension
-
-          aggregate_target.mark_application_extension_api_only
-          aggregate_target.pod_targets.each(&:mark_application_extension_api_only)
-        end
-
-        aggregate_targets.each do |aggregate_target|
           build_library_for_distribution = aggregate_target.user_targets.any? do |user_target|
             user_target.common_resolved_build_setting('BUILD_LIBRARY_FOR_DISTRIBUTION', :resolve_against_xcconfig => true) == 'YES'
           end
-
-          next unless build_library_for_distribution
-
-          aggregate_target.mark_build_library_for_distribution
-          aggregate_target.pod_targets.each(&:mark_build_library_for_distribution)
+          if build_library_for_distribution
+            aggregate_target.mark_build_library_for_distribution
+            aggregate_target.pod_targets.each(&:mark_build_library_for_distribution)
+          end
         end
 
         if installation_options.integrate_targets?

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -453,6 +453,17 @@ module Pod
           aggregate_target.pod_targets.each(&:mark_application_extension_api_only)
         end
 
+        aggregate_targets.each do |aggregate_target|
+          build_library_for_distribution = aggregate_target.user_targets.any? do |user_target|
+            user_target.common_resolved_build_setting('BUILD_LIBRARY_FOR_DISTRIBUTION', :resolve_against_xcconfig => true) == 'YES'
+          end
+
+          next unless build_library_for_distribution
+
+          aggregate_target.mark_build_library_for_distribution
+          aggregate_target.pod_targets.each(&:mark_build_library_for_distribution)
+        end
+
         if installation_options.integrate_targets?
           # Copy embedded target pods that cannot have their pods embedded as frameworks to
           # their host targets, and ensure we properly link library pods to their host targets

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -304,16 +304,16 @@ module Pod
       support_files_dir + "#{label}-dummy.m"
     end
 
-    # mark the target as extension-only,
-    # translates to APPLICATION_EXTENSION_API_ONLY = YES in the build settings
+    # Mark the target as extension-only.
+    # Translates to APPLICATION_EXTENSION_API_ONLY = YES in the build settings.
     #
     def mark_application_extension_api_only
       @application_extension_api_only = true
     end
 
-    # compiles the target with Swift's library evolution support,
-    # necessary to build XCFrameworks
-    # translates to BUILD_LIBRARY_FOR_DISTRIBUTION = YES in the build settings
+    # Compiles the target with Swift's library evolution support, necessary to
+    # build XCFrameworks.
+    # Translates to BUILD_LIBRARY_FOR_DISTRIBUTION = YES in the build settings.
     #
     def mark_build_library_for_distribution
       @build_library_for_distribution = true

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -43,6 +43,11 @@ module Pod
     #
     attr_reader :application_extension_api_only
 
+    # @return [Boolean] whether the target must be compiled with Swift's library
+    # evolution support, necessary for XCFrameworks.
+    #
+    attr_reader :build_library_for_distribution
+
     # Initialize a new target
     #
     # @param [Sandbox] sandbox @see #sandbox
@@ -59,6 +64,7 @@ module Pod
       @build_type = build_type
 
       @application_extension_api_only = false
+      @build_library_for_distribution = false
       @build_settings = create_build_settings
     end
 
@@ -303,6 +309,14 @@ module Pod
     #
     def mark_application_extension_api_only
       @application_extension_api_only = true
+    end
+
+    # compiles the target with Swift's library evolution support,
+    # necessary to build XCFrameworks
+    # translates to BUILD_LIBRARY_FOR_DISTRIBUTION = YES in the build settings
+    #
+    def mark_build_library_for_distribution
+      @build_library_for_distribution = true
     end
 
     # @return [Pathname] The absolute path of the prepare artifacts script.

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -98,6 +98,7 @@ module Pod
                           target_definition, client_root, user_project, user_target_uuids, merged).tap do |aggregate_target|
         aggregate_target.search_paths_aggregate_targets.concat(search_paths_aggregate_targets).freeze
         aggregate_target.mark_application_extension_api_only if application_extension_api_only
+        aggregate_target.mark_build_library_for_distribution if build_library_for_distribution
       end
     end
 

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -911,6 +911,11 @@ module Pod
         define_build_settings_method :application_extension_api_only, :build_setting => true, :memoized => true do
           target.application_extension_api_only ? 'YES' : nil
         end
+        
+        # @return [String]
+        define_build_settings_method :build_library_for_distribution, :build_setting => true, :memoized => true do
+          target.build_library_for_distribution ? 'YES' : nil
+        end
 
         #-------------------------------------------------------------------------#
 

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -911,7 +911,7 @@ module Pod
         define_build_settings_method :application_extension_api_only, :build_setting => true, :memoized => true do
           target.application_extension_api_only ? 'YES' : nil
         end
-        
+
         # @return [String]
         define_build_settings_method :build_library_for_distribution, :build_setting => true, :memoized => true do
           target.build_library_for_distribution ? 'YES' : nil

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -2317,27 +2317,26 @@ module Pod
               source SpecHelper.test_repo_url
               platform :ios, '8.0'
               project project_path
-  
+
               target 'Sample Extensions Project' do
                 pod 'JSONKit', '1.4'
               end
-  
+
               target 'Today Extension' do
                 use_frameworks!
                 pod 'monkey'
               end
             end
-  
+
             @podfile.use_frameworks!
             analyzer = Pod::Installer::Analyzer.new(config.sandbox, @podfile)
             result = analyzer.analyze
-  
+
             result.targets.map { |t| [t.name, t.build_library_for_distribution] }.
               should == [['Pods-Sample Extensions Project', true], ['Pods-Today Extension', true]]
             result.pod_targets.map { |t| [t.name, t.build_library_for_distribution] }.
               should == [['JSONKit', true], ['monkey', true]]
           end
-
         end
       end
 

--- a/spec/unit/installer/analyzer_spec.rb
+++ b/spec/unit/installer/analyzer_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 module Pod
   describe Installer::Analyzer do # rubocop:disable Metrics/BlockLength
-    describe 'Analysis' do
+    describe 'Analysis' do # rubocop:disable Metrics/BlockLength
       before do
         repos = [Source.new(fixture('spec-repos/test_repo')), TrunkSource.new(fixture('spec-repos/trunk'))]
         aggregate = Pod::Source::Aggregate.new(repos)


### PR DESCRIPTION
As discussed in #9232, this PR checks if the `BUILD_LIBRARY_FOR_DISTRIBUTION` Build Setting evaluates to `YES` in an user target, and in that case it applies this setting to all the dependencies of this target. This is needed to avoid issues with XCFrameworks.

This also checks if `BUILD_LIBRARY_FOR_DISTRIBUTION` is set in a .xcconfig, as proposed for `APPLICATION_EXTENSION_API_ONLY` in #9233.
 
This is both my first PR and my first time working with Ruby, so I heavily based this PR in the previous work with the `APPLICATION_EXTENSION_API_ONLY` Build Setting. I hope I didn't miss anything critical.

BTW, thank you for your amazing work in CocoaPods!