### PR TITLE
Don't crash on non UTF-8 error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#9612](https://github.com/CocoaPods/CocoaPods/pull/9612)
 
+* Don't crash on non UTF-8 error message
+  [Kenji KATO](https://github.com/katoken-0215)
+  [#9706](https://github.com/CocoaPods/CocoaPods/pull/9706)
 
 ## 1.9.1 (2020-03-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#9612](https://github.com/CocoaPods/CocoaPods/pull/9612)
 
-* Don't crash on non UTF-8 error message
+* Don't crash on non UTF-8 error message  
   [Kenji KATO](https://github.com/katoken-0215)
   [#9706](https://github.com/CocoaPods/CocoaPods/pull/9706)
 

--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -31,7 +31,7 @@ module Pod
 ### Error
 
 ```
-#{exception.class} - #{exception.message.force_encoding("UTF-8")}
+#{exception.class} - #{exception.message.force_encoding('UTF-8')}
 #{exception.backtrace.join("\n") if exception.backtrace}
 ```
 

--- a/lib/cocoapods/user_interface/error_report.rb
+++ b/lib/cocoapods/user_interface/error_report.rb
@@ -31,7 +31,7 @@ module Pod
 ### Error
 
 ```
-#{exception.class} - #{exception.message}
+#{exception.class} - #{exception.message.force_encoding("UTF-8")}
 #{exception.backtrace.join("\n") if exception.backtrace}
 ```
 

--- a/spec/unit/user_interface/error_report_spec.rb
+++ b/spec/unit/user_interface/error_report_spec.rb
@@ -155,6 +155,13 @@ https://github.com/cocoapods/cocoapods/search?q=Testing&type=Issues&utf8=✓
 EOS
         UI.output.should == result
       end
+
+      it 'doesn\'t crash on non UTF-8 error message' do
+        should.not.raise(Encoding::CompatibilityError) {
+          @exception.stubs(:message).returns('”ASCII-8BIT”'.force_encoding('ASCII-8BIT'))
+          @report.report(@exception)
+        }
+      end
     end
   end
 end

--- a/spec/unit/user_interface/error_report_spec.rb
+++ b/spec/unit/user_interface/error_report_spec.rb
@@ -157,10 +157,10 @@ EOS
       end
 
       it 'doesn\'t crash on non UTF-8 error message' do
-        should.not.raise(Encoding::CompatibilityError) {
+        should.not.raise(Encoding::CompatibilityError) do
           @exception.stubs(:message).returns('”ASCII-8BIT”'.force_encoding('ASCII-8BIT'))
           @report.report(@exception)
-        }
+        end
       end
     end
   end


### PR DESCRIPTION
# What's happening

`pod` crashs on such a message.

```
bundler: failed to load command: pod (/Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/bin/pod)
Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/cocoapods-1.9.1/lib/cocoapods/user_interface/error_report.rb:12:in `report'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/cocoapods-1.9.1/lib/cocoapods/command.rb:66:in `report_error'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/claide-1.0.3/lib/claide/command.rb:396:in `handle_exception'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/claide-1.0.3/lib/claide/command.rb:337:in `rescue in run'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/claide-1.0.3/lib/claide/command.rb:324:in `run'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/cocoapods-1.9.1/lib/cocoapods/command.rb:52:in `run'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/gems/cocoapods-1.9.1/bin/pod:55:in `<top (required)>'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/bin/pod:23:in `load'
  /Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/bin/pod:23:in `<top (required)>'
```

# Reason

The command calling by `pod` emits such a error.
(Please ignore why this error happening, not related this PR)

```
2020-04-09 23:56:48.367 xcodebuild[94751:864259]  DVTDownloadable: Failed to preflight installation Error Domain=PKInstallErrorDomain Code=102 "The package “XcodeSystemResources.pkg” is untrusted." UserInfo={NSLocalizedDescription=The package “XcodeSystemResources.pkg” is untrusted., NSURL=XcodeSystemResources.pkg -- file:///Applications/Xcode.app/Contents/Resources/Packages/, PKInstallPackageIdentifier=com.apple.pkg.XcodeSystemResources, NSUnderlyingError=0x7fce15616500 {Error Domain=NSOSStatusErrorDomain Code=-2147409654 "CSSMERR_TP_CERT_EXPIRED" UserInfo={SecTrustResult=5, PKTrustLevel=PKTrustLevelExpiredCertificate, NSLocalizedFailureReason=CSSMERR_TP_CERT_EXPIRED}}}
xcodebuild: error: The package “XcodeSystemResources.pkg” is untrusted.

Usage: xcodebuild [-project <projectname>] [[-target <targetname>]...|-alltargets] [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings [-json]] [<buildsetting>=<value>]... [<buildaction>]...
       xcodebuild [-project <projectname>] -scheme <schemeName> [-destination <destinationspecifier>]... [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings [-json]] [-showdestinations] [<buildsetting>=<value>]... [<buildaction>]...
       xcodebuild -workspace <workspacename> -scheme <schemeName> [-destination <destinationspecifier>]... [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings] [-showdestinations] [<buildsetting>=<value>]... [<buildaction>]...
       xcodebuild -version [-sdk [<sdkfullpath>|<sdkname>] [-json] [<infoitem>] ]
       xcodebuild -list [[-project <projectname>]|[-workspace <workspacename>]] [-json]
       xcodebuild -showsdks [-json]
       xcodebuild -exportArchive -archivePath <xcarchivepath> [-exportPath <destinationpath>] -exportOptionsPlist <plistpath>
       xcodebuild -exportNotarizedApp -archivePath <xcarchivepath> -exportPath <destinationpath>
       xcodebuild -exportLocalizations -localizationPath <path> -project <projectname> [-exportLanguage <targetlanguage>...]
       xcodebuild -importLocalizations -localizationPath <path> -project <projectname>
       xcodebuild -resolvePackageDependencies [-project <projectname>|-workspace <workspacename>] -clonedSourcePackagesDirPath <path>

Options:
    -usage                                                   print brief usage
    -help                                                    print complete usage
    -verbose                                                 provide additional status output
    -license                                                 show the Xcode and SDK license agreements
    -checkFirstLaunchStatus                                  Check if any First Launch tasks need to be performed
    -runFirstLaunch                                          install packages and agree to the license
    -project NAME                                            build the project NAME
    -target NAME                                             build the target NAME
    -alltargets                                              build all targets
    -workspace NAME                                          build the workspace NAME
    -scheme NAME                                             build the scheme NAME
    -configuration NAME                                      use the build configuration NAME for building each target
    -xcconfig PATH                                           apply the build settings defined in the file at PATH as overrides
    -arch ARCH                                               build each target for the architecture ARCH; this will override architectures defined in the project
    -sdk SDK                                                 use SDK as the name or path of the base SDK when building the project
    -toolchain NAME                                          use the toolchain with identifier or name NAME
    -destination DESTINATIONSPECIFIER                        use the destination described by DESTINATIONSPECIFIER (a comma-separated set of key=value pairs describing the destination to use)
    -destination-timeout TIMEOUT                             wait for TIMEOUT seconds while searching for the destination device
    -parallelizeTargets                                      build independent targets in parallel
    -jobs NUMBER                                             specify the maximum number of concurrent build operations
    -maximum-concurrent-test-device-destinations NUMBER      the maximum number of device destinations to test on concurrently
    -maximum-concurrent-test-simulator-destinations NUMBER   the maximum number of simulator destinations to test on concurrently
    -parallel-testing-enabled YES|NO                         overrides the per-target setting in the scheme
    -parallel-testing-worker-count NUMBER                    the exact number of test runners that will be spawned during parallel testing
    -maximum-parallel-testing-workers NUMBER                 the maximum number of test runners that will be spawned during parallel testing
    -dry-run                                                 do everything except actually running the commands
    -quiet                                                   do not print any output except for warnings and errors
    -hideShellScriptEnvironment                              don't show shell script environment variables in build log
    -showsdks                                                display a compact list of the installed SDKs
    -showdestinations                                        display a list of destinations
    -showBuildSettings                                       display a list of build settings and values
    -list                                                    lists the targets and configurations in a project, or the schemes in a workspace
    -find-executable NAME                                    display the full path to executable NAME in the provided SDK and toolchain
    -find-library NAME                                       display the full path to library NAME in the provided SDK and toolchain
    -version                                                 display the version of Xcode; with -sdk will display info about one or all installed SDKs
    -enableAddressSanitizer YES|NO                           turn the address sanitizer on or off
    -enableThreadSanitizer YES|NO                            turn the thread sanitizer on or off
    -enableUndefinedBehaviorSanitizer YES|NO                 turn the undefined behavior sanitizer on or off
    -resultBundlePath PATH                                   specifies the directory where a result bundle describing what occurred will be placed
    -clonedSourcePackagesDirPath PATH                        specifies the directory to which remote source packages are fetch or expected to be found
    -derivedDataPath PATH                                    specifies the directory where build products and other derived data will go
    -archivePath PATH                                        specifies the directory where any created archives will be placed, or the archive that should be exported
    -exportArchive                                           specifies that an archive should be exported
    -exportNotarizedApp                                      export an archive that has been notarized by Apple
    -exportOptionsPlist PATH                                 specifies a path to a plist file that configures archive exporting
    -enableCodeCoverage YES|NO                               turn code coverage on or off when testing
    -exportPath PATH                                         specifies the destination for the product exported from an archive
    -skipUnavailableActions                                  specifies that scheme actions that cannot be performed should be skipped instead of causing a failure
    -exportLocalizations                                     exports completed and outstanding project localizations
    -importLocalizations                                     imports localizations for a project, assuming any necessary localized resources have been created in Xcode
    -localizationPath                                        specifies a path to XLIFF localization files
    -exportLanguage                                          specifies multiple optional ISO 639-1 languages included in a localization export
    -xctestrun                                               specifies a path to a test run specification
    -only-testing:TEST-IDENTIFIER                            constrains testing by specifying tests to include, and excluding other tests
    -skip-testing:TEST-IDENTIFIER                            constrains testing by specifying tests to exclude, but including other tests
    -testLanguage                                            constrains testing by specifying ISO 639-1 language in which to run the tests
    -testRegion                                              constrains testing by specifying ISO 3166-1 region in which to run the tests
    -resolvePackageDependencies                              resolves any package dependencies referenced by the project or workspace
    -json                                                    output as JSON (note: -json implies -quiet)
    -allowProvisioningUpdates                                Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode's Accounts preference pane.
    -allowProvisioningDeviceRegistration                     Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed.
    -showBuildTimingSummary                                  display a report of the timings of all the commands invoked during the build
/Applications/Xcode.app/Contents/Developer/usr/bin/simctl: line 6: /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/Resources/bin/simctl: No such file or directory
/Applications/Xcode.app/Contents/Developer/usr/bin/simctl: line 6: exec: /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/Resources/bin/simctl: cannot execute: No such file or directory

```

This message can't convert to UTF-8, so `pod` dies.

# Fix

Force convert non UTF-8 message to UTF8 one.

# Behavior after fix

`pod` emits this error.

````
――― MARKDOWN TEMPLATE ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

### Command

```
/Users/k_kato/work/myproject/vendor/bundle/ruby/2.5.0/bin/pod install
```

### Report

* What did you do?

* What did you expect to happen?

* What happened instead?


### Stack

```
   CocoaPods : 1.9.1
        Ruby : ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-darwin19]
    RubyGems : 2.7.6.2
        Host : Mac OS X 10.15.3 (19D76)
       Xcode : 10.1 (10B61)
         Git : git version 2.21.0
Ruby lib dir : /Users/k_kato/.anyenv/envs/rbenv/versions/2.5.5/lib
Repositories : master - git - https://github.com/CocoaPods/Specs.git @ 34b950d876306cf150e7a8badcfa8f88055d6c97

               trunk - CDN - https://cdn.cocoapods.org/
```

### Plugins

```
cocoapods-binary      : 0.4.4
cocoapods-deintegrate : 1.0.4
cocoapods-plugins     : 1.0.0
cocoapods-search      : 1.0.0
cocoapods-stats       : 1.1.0
cocoapods-trunk       : 1.4.1
cocoapods-try         : 1.1.0
```

### Podfile

```ruby
plugin 'cocoapods-binary'

# Uncomment the next line to define a global platform for your project
platform :ios, '12.0'

target 'KusabiClient' do
  # Comment the next line if you don't want to use dynamic frameworks
  use_frameworks!
  enable_bitcode_for_prebuilt_frameworks!
  all_binary!
  keep_source_code_for_prebuilt_frameworks!

  # Pods for KusabiClient
  pod 'SwiftGRPC', '0.9.0'
  pod "SpringIndicator"
  pod 'Firebase/Core'
  pod 'Firebase/Messaging'
  pod 'Firebase/Analytics'
  pod 'Firebase/Auth'
  pod 'Fabric', '~> 1.10.2'
  pod 'Crashlytics', '~> 3.14.0'

  target 'KusabiClientTests' do
    inherit! :search_paths
    # Pods for testing
    pod 'SwiftGRPC', '0.9.0'
    pod "SpringIndicator"
    pod 'Firebase/Core'
    pod 'Firebase/Messaging'
    pod 'Firebase/Analytics'
    pod 'Firebase/Auth'
  end

  target 'KusabiClientUITests' do
    inherit! :search_paths
    # Pods for testing
    pod 'SwiftGRPC', '0.9.0'
    pod "SpringIndicator"
    pod 'Firebase/Core'
    pod 'Firebase/Messaging'
    pod 'Firebase/Analytics'
    pod 'Firebase/Auth'
  end

end
```

### Error

```
Fourflusher::Informative - /usr/bin/xcrun simctl list -j devices

Install Started
Install Failed: Error Domain=PKInstallErrorDomain Code=102 "The package “XcodeSystemResources.pkg” is untrusted." UserInfo={NSLocalizedDescription=The package “XcodeSystemResources.pkg” is untrusted., NSURL=XcodeSystemResources.pkg -- file:///Applications/Xcode.app/Contents/Resources/Packages/, PKInstallPackageIdentifier=com.apple.pkg.XcodeSystemResources, NSUnderlyingError=0x7fe53f700a00 {Error Domain=NSOSStatusErrorDomain Code=-2147409654 "CSSMERR_TP_CERT_EXPIRED" UserInfo={SecTrustResult=5, PKTrustLevel=PKTrustLevelExpiredCertificate, NSLocalizedFailureReason=CSSMERR_TP_CERT_EXPIRED}}}
2020-04-09 23:49:52.561 xcodebuild[93686:855614]  DVTDownloadable: Failed to preflight installation Error Domain=PKInstallErrorDomain Code=102 "The package “XcodeSystemResources.pkg” is untrusted." UserInfo={NSLocalizedDescription=The package “XcodeSystemResources.pkg” is untrusted., NSURL=XcodeSystemResources.pkg -- file:///Applications/Xcode.app/Contents/Resources/Packages/, PKInstallPackageIdentifier=com.apple.pkg.XcodeSystemResources, NSUnderlyingError=0x7fe53f700a00 {Error Domain=NSOSStatusErrorDomain Code=-2147409654 "CSSMERR_TP_CERT_EXPIRED" UserInfo={SecTrustResult=5, PKTrustLevel=PKTrustLevelExpiredCertificate, NSLocalizedFailureReason=CSSMERR_TP_CERT_EXPIRED}}}
xcodebuild: error: The package “XcodeSystemResources.pkg” is untrusted.

Usage: xcodebuild [-project <projectname>] [[-target <targetname>]...|-alltargets] [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings [-json]] [<buildsetting>=<value>]... [<buildaction>]...
       xcodebuild [-project <projectname>] -scheme <schemeName> [-destination <destinationspecifier>]... [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings [-json]] [-showdestinations] [<buildsetting>=<value>]... [<buildaction>]...
       xcodebuild -workspace <workspacename> -scheme <schemeName> [-destination <destinationspecifier>]... [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings] [-showdestinations] [<buildsetting>=<value>]... [<buildaction>]...
       xcodebuild -version [-sdk [<sdkfullpath>|<sdkname>] [-json] [<infoitem>] ]
       xcodebuild -list [[-project <projectname>]|[-workspace <workspacename>]] [-json]
       xcodebuild -showsdks [-json]
       xcodebuild -exportArchive -archivePath <xcarchivepath> [-exportPath <destinationpath>] -exportOptionsPlist <plistpath>
       xcodebuild -exportNotarizedApp -archivePath <xcarchivepath> -exportPath <destinationpath>
       xcodebuild -exportLocalizations -localizationPath <path> -project <projectname> [-exportLanguage <targetlanguage>...]
       xcodebuild -importLocalizations -localizationPath <path> -project <projectname>
       xcodebuild -resolvePackageDependencies [-project <projectname>|-workspace <workspacename>] -clonedSourcePackagesDirPath <path>

Options:
    -usage                                                   print brief usage
    -help                                                    print complete usage
    -verbose                                                 provide additional status output
    -license                                                 show the Xcode and SDK license agreements
    -checkFirstLaunchStatus                                  Check if any First Launch tasks need to be performed
    -runFirstLaunch                                          install packages and agree to the license
    -project NAME                                            build the project NAME
    -target NAME                                             build the target NAME
    -alltargets                                              build all targets
    -workspace NAME                                          build the workspace NAME
    -scheme NAME                                             build the scheme NAME
    -configuration NAME                                      use the build configuration NAME for building each target
    -xcconfig PATH                                           apply the build settings defined in the file at PATH as overrides
    -arch ARCH                                               build each target for the architecture ARCH; this will override architectures defined in the project
    -sdk SDK                                                 use SDK as the name or path of the base SDK when building the project
    -toolchain NAME                                          use the toolchain with identifier or name NAME
    -destination DESTINATIONSPECIFIER                        use the destination described by DESTINATIONSPECIFIER (a comma-separated set of key=value pairs describing the destination to use)
    -destination-timeout TIMEOUT                             wait for TIMEOUT seconds while searching for the destination device
    -parallelizeTargets                                      build independent targets in parallel
    -jobs NUMBER                                             specify the maximum number of concurrent build operations
    -maximum-concurrent-test-device-destinations NUMBER      the maximum number of device destinations to test on concurrently
    -maximum-concurrent-test-simulator-destinations NUMBER   the maximum number of simulator destinations to test on concurrently
    -parallel-testing-enabled YES|NO                         overrides the per-target setting in the scheme
    -parallel-testing-worker-count NUMBER                    the exact number of test runners that will be spawned during parallel testing
    -maximum-parallel-testing-workers NUMBER                 the maximum number of test runners that will be spawned during parallel testing
    -dry-run                                                 do everything except actually running the commands
    -quiet                                                   do not print any output except for warnings and errors
    -hideShellScriptEnvironment                              don't show shell script environment variables in build log
    -showsdks                                                display a compact list of the installed SDKs
    -showdestinations                                        display a list of destinations
    -showBuildSettings                                       display a list of build settings and values
    -list                                                    lists the targets and configurations in a project, or the schemes in a workspace
    -find-executable NAME                                    display the full path to executable NAME in the provided SDK and toolchain
    -find-library NAME                                       display the full path to library NAME in the provided SDK and toolchain
    -version                                                 display the version of Xcode; with -sdk will display info about one or all installed SDKs
    -enableAddressSanitizer YES|NO                           turn the address sanitizer on or off
    -enableThreadSanitizer YES|NO                            turn the thread sanitizer on or off
    -enableUndefinedBehaviorSanitizer YES|NO                 turn the undefined behavior sanitizer on or off
    -resultBundlePath PATH                                   specifies the directory where a result bundle describing what occurred will be placed
    -clonedSourcePackagesDirPath PATH                        specifies the directory to which remote source packages are fetch or expected to be found
    -derivedDataPath PATH                                    specifies the directory where build products and other derived data will go
    -archivePath PATH                                        specifies the directory where any created archives will be placed, or the archive that should be exported
    -exportArchive                                           specifies that an archive should be exported
    -exportNotarizedApp                                      export an archive that has been notarized by Apple
    -exportOptionsPlist PATH                                 specifies a path to a plist file that configures archive exporting
    -enableCodeCoverage YES|NO                               turn code coverage on or off when testing
    -exportPath PATH                                         specifies the destination for the product exported from an archive
    -skipUnavailableActions                                  specifies that scheme actions that cannot be performed should be skipped instead of causing a failure
    -exportLocalizations                                     exports completed and outstanding project localizations
    -importLocalizations                                     imports localizations for a project, assuming any necessary localized resources have been created in Xcode
    -localizationPath                                        specifies a path to XLIFF localization files
    -exportLanguage                                          specifies multiple optional ISO 639-1 languages included in a localization export
    -xctestrun                                               specifies a path to a test run specification
    -only-testing:TEST-IDENTIFIER                            constrains testing by specifying tests to include, and excluding other tests
    -skip-testing:TEST-IDENTIFIER                            constrains testing by specifying tests to exclude, but including other tests
    -testLanguage                                            constrains testing by specifying ISO 639-1 language in which to run the tests
    -testRegion                                              constrains testing by specifying ISO 3166-1 region in which to run the tests
    -resolvePackageDependencies                              resolves any package dependencies referenced by the project or workspace
    -json                                                    output as JSON (note: -json implies -quiet)
    -allowProvisioningUpdates                                Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode's Accounts preference pane.
    -allowProvisioningDeviceRegistration                     Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed.
    -showBuildTimingSummary                                  display a report of the timings of all the commands invoked during the build
/Applications/Xcode.app/Contents/Developer/usr/bin/simctl: line 6: /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/Resources/bin/simctl: No such file or directory
/Applications/Xcode.app/Contents/Developer/usr/bin/simctl: line 6: exec: /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/Resources/bin/simctl: cannot execute: No such file or directory

(snip backtrace)

――― TEMPLATE END ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

[!] Oh no, an error occurred.

Search for existing GitHub issues similar to yours:
https://github.com/CocoaPods/CocoaPods/search?q=%2Fusr%2Fbin%2Fxcrun+simctl+list+-j+devices%0A%0AInstall+Started%0AInstall+Failed%3A+Error+Domain%3DPKInstallErrorDomain+Code%3D102+%22The+package+%E2%80%9CXcodeSystemResources.pkg%E2%80%9D+is+untrusted.%22+UserInfo%3D%7BNSLocalizedDescription%3DThe+package+%E2%80%9CXcodeSystemResources.pkg%E2%80%9D+is+untrusted.%2C+NSURL%3DXcodeSystemResources.pkg+--+file%3A%2F%2F%2FApplications%2FXcode.app%2FContents%2FResources%2FPackages%2F%2C+PKInstallPackageIdentifier%3Dcom.apple.pkg.XcodeSystemResources%2C+NSUnderlyingError%3D0x7fe53f700a00+%7BError+Domain%3DNSOSStatusErrorDomain+Code%3D-2147409654+%22CSSMERR_TP_CERT_EXPIRED%22+UserInfo%3D%7BSecTrustResult%3D5%2C+PKTrustLevel%3DPKTrustLevelExpiredCertificate%2C+NSLocalizedFailureReason%3DCSSMERR_TP_CERT_EXPIRED%7D%7D%7D%0A2020-04-09+23%3A49%3A52.561+xcodebuild%5B93686%3A855614%5D++DVTDownloadable%3A+Failed+to+preflight+installation+Error+Domain%3DPKInstallErrorDomain+Code%3D102+%22The+package+%E2%80%9CXcodeSystemResources.pkg%E2%80%9D+is+untrusted.%22+UserInfo%3D%7BNSLocalizedDescription%3DThe+package+%E2%80%9CXcodeSystemResources.pkg%E2%80%9D+is+untrusted.%2C+NSURL%3DXcodeSystemResources.pkg+--+file%3A%2F%2F%2FApplications%2FXcode.app%2FContents%2FResources%2FPackages%2F%2C+PKInstallPackageIdentifier%3Dcom.apple.pkg.XcodeSystemResources%2C+NSUnderlyingError%3D0x7fe53f700a00+%7BError+Domain%3DNSOSStatusErrorDomain+Code%3D-2147409654+%22CSSMERR_TP_CERT_EXPIRED%22+UserInfo%3D%7BSecTrustResult%3D5%2C+PKTrustLevel%3DPKTrustLevelExpiredCertificate%2C+NSLocalizedFailureReason%3DCSSMERR_TP_CERT_EXPIRED%7D%7D%7D%0Axcodebuild%3A+error%3A+The+package+%E2%80%9CXcodeSystemResources.pkg%E2%80%9D+is+untrusted.%0A%0AUsage%3A+xcodebuild+%5B-project+%3Cprojectname%3E%5D+%5B%5B-target+%3Ctargetname%3E%5D...%7C-alltargets%5D+%5B-configuration+%3Cconfigurationname%3E%5D+%5B-arch+%3Carchitecture%3E%5D...+%5B-sdk+%5B%3Csdkname%3E%7C%3Csdkpath%3E%5D%5D+%5B-showBuildSettings+%5B-json%5D%5D+%5B%3Cbuildsetting%3E%3D%3Cvalue%3E%5D...+%5B%3Cbuildaction%3E%5D...%0A+++++++xcodebuild+%5B-project+%3Cprojectname%3E%5D+-scheme+%3CschemeName%3E+%5B-destination+%3Cdestinationspecifier%3E%5D...+%5B-configuration+%3Cconfigurationname%3E%5D+%5B-arch+%3Carchitecture%3E%5D...+%5B-sdk+%5B%3Csdkname%3E%7C%3Csdkpath%3E%5D%5D+%5B-showBuildSettings+%5B-json%5D%5D+%5B-showdestinations%5D+%5B%3Cbuildsetting%3E%3D%3Cvalue%3E%5D...+%5B%3Cbuildaction%3E%5D...%0A+++++++xcodebuild+-workspace+%3Cworkspacename%3E+-scheme+%3CschemeName%3E+%5B-destination+%3Cdestinationspecifier%3E%5D...+%5B-configuration+%3Cconfigurationname%3E%5D+%5B-arch+%3Carchitecture%3E%5D...+%5B-sdk+%5B%3Csdkname%3E%7C%3Csdkpath%3E%5D%5D+%5B-showBuildSettings%5D+%5B-showdestinations%5D+%5B%3Cbuildsetting%3E%3D%3Cvalue%3E%5D...+%5B%3Cbuildaction%3E%5D...%0A+++++++xcodebuild+-version+%5B-sdk+%5B%3Csdkfullpath%3E%7C%3Csdkname%3E%5D+%5B-json%5D+%5B%3Cinfoitem%3E%5D+%5D%0A+++++++xcodebuild+-list+%5B%5B-project+%3Cprojectname%3E%5D%7C%5B-workspace+%3Cworkspacename%3E%5D%5D+%5B-json%5D%0A+++++++xcodebuild+-showsdks+%5B-json%5D%0A+++++++xcodebuild+-exportArchive+-archivePath+%3Cxcarchivepath%3E+%5B-exportPath+%3Cdestinationpath%3E%5D+-exportOptionsPlist+%3Cplistpath%3E%0A+++++++xcodebuild+-exportNotarizedApp+-archivePath+%3Cxcarchivepath%3E+-exportPath+%3Cdestinationpath%3E%0A+++++++xcodebuild+-exportLocalizations+-localizationPath+%3Cpath%3E+-project+%3Cprojectname%3E+%5B-exportLanguage+%3Ctargetlanguage%3E...%5D%0A+++++++xcodebuild+-importLocalizations+-localizationPath+%3Cpath%3E+-project+%3Cprojectname%3E%0A+++++++xcodebuild+-resolvePackageDependencies+%5B-project+%3Cprojectname%3E%7C-workspace+%3Cworkspacename%3E%5D+-clonedSourcePackagesDirPath+%3Cpath%3E%0A%0AOptions%3A%0A++++-usage+++++++++++++++++++++++++++++++++++++++++++++++++++print+brief+usage%0A++++-help++++++++++++++++++++++++++++++++++++++++++++++++++++print+complete+usage%0A++++-verbose+++++++++++++++++++++++++++++++++++++++++++++++++provide+additional+status+output%0A++++-license+++++++++++++++++++++++++++++++++++++++++++++++++show+the+Xcode+and+SDK+license+agreements%0A++++-checkFirstLaunchStatus++++++++++++++++++++++++++++++++++Check+if+any+First+Launch+tasks+need+to+be+performed%0A++++-runFirstLaunch++++++++++++++++++++++++++++++++++++++++++install+packages+and+agree+to+the+license%0A++++-project+NAME++++++++++++++++++++++++++++++++++++++++++++build+the+project+NAME%0A++++-target+NAME+++++++++++++++++++++++++++++++++++++++++++++build+the+target+NAME%0A++++-alltargets++++++++++++++++++++++++++++++++++++++++++++++build+all+targets%0A++++-workspace+NAME++++++++++++++++++++++++++++++++++++++++++build+the+workspace+NAME%0A++++-scheme+NAME+++++++++++++++++++++++++++++++++++++++++++++build+the+scheme+NAME%0A++++-configuration+NAME++++++++++++++++++++++++++++++++++++++use+the+build+configuration+NAME+for+building+each+target%0A++++-xcconfig+PATH+++++++++++++++++++++++++++++++++++++++++++apply+the+build+settings+defined+in+the+file+at+PATH+as+overrides%0A++++-arch+ARCH+++++++++++++++++++++++++++++++++++++++++++++++build+each+target+for+the+architecture+ARCH%3B+this+will+override+architectures+defined+in+the+project%0A++++-sdk+SDK+++++++++++++++++++++++++++++++++++++++++++++++++use+SDK+as+the+name+or+path+of+the+base+SDK+when+building+the+project%0A++++-toolchain+NAME++++++++++++++++++++++++++++++++++++++++++use+the+toolchain+with+identifier+or+name+NAME%0A++++-destination+DESTINATIONSPECIFIER++++++++++++++++++++++++use+the+destination+described+by+DESTINATIONSPECIFIER+%28a+comma-separated+set+of+key%3Dvalue+pairs+describing+the+destination+to+use%29%0A++++-destination-timeout+TIMEOUT+++++++++++++++++++++++++++++wait+for+TIMEOUT+seconds+while+searching+for+the+destination+device%0A++++-parallelizeTargets++++++++++++++++++++++++++++++++++++++build+independent+targets+in+parallel%0A++++-jobs+NUMBER+++++++++++++++++++++++++++++++++++++++++++++specify+the+maximum+number+of+concurrent+build+operations%0A++++-maximum-concurrent-test-device-destinations+NUMBER++++++the+maximum+number+of+device+destinations+to+test+on+concurrently%0A++++-maximum-concurrent-test-simulator-destinations+NUMBER+++the+maximum+number+of+simulator+destinations+to+test+on+concurrently%0A++++-parallel-testing-enabled+YES%7CNO+++++++++++++++++++++++++overrides+the+per-target+setting+in+the+scheme%0A++++-parallel-testing-worker-count+NUMBER++++++++++++++++++++the+exact+number+of+test+runners+that+will+be+spawned+during+parallel+testing%0A++++-maximum-parallel-testing-workers+NUMBER+++++++++++++++++the+maximum+number+of+test+runners+that+will+be+spawned+during+parallel+testing%0A++++-dry-run+++++++++++++++++++++++++++++++++++++++++++++++++do+everything+except+actually+running+the+commands%0A++++-quiet+++++++++++++++++++++++++++++++++++++++++++++++++++do+not+print+any+output+except+for+warnings+and+errors%0A++++-hideShellScriptEnvironment++++++++++++++++++++++++++++++don%27t+show+shell+script+environment+variables+in+build+log%0A++++-showsdks++++++++++++++++++++++++++++++++++++++++++++++++display+a+compact+list+of+the+installed+SDKs%0A++++-showdestinations++++++++++++++++++++++++++++++++++++++++display+a+list+of+destinations%0A++++-showBuildSettings+++++++++++++++++++++++++++++++++++++++display+a+list+of+build+settings+and+values%0A++++-list++++++++++++++++++++++++++++++++++++++++++++++++++++lists+the+targets+and+configurations+in+a+project%2C+or+the+schemes+in+a+workspace%0A++++-find-executable+NAME++++++++++++++++++++++++++++++++++++display+the+full+path+to+executable+NAME+in+the+provided+SDK+and+toolchain%0A++++-find-library+NAME+++++++++++++++++++++++++++++++++++++++display+the+full+path+to+library+NAME+in+the+provided+SDK+and+toolchain%0A++++-version+++++++++++++++++++++++++++++++++++++++++++++++++display+the+version+of+Xcode%3B+with+-sdk+will+display+info+about+one+or+all+installed+SDKs%0A++++-enableAddressSanitizer+YES%7CNO+++++++++++++++++++++++++++turn+the+address+sanitizer+on+or+off%0A++++-enableThreadSanitizer+YES%7CNO++++++++++++++++++++++++++++turn+the+thread+sanitizer+on+or+off%0A++++-enableUndefinedBehaviorSanitizer+YES%7CNO+++++++++++++++++turn+the+undefined+behavior+sanitizer+on+or+off%0A++++-resultBundlePath+PATH+++++++++++++++++++++++++++++++++++specifies+the+directory+where+a+result+bundle+describing+what+occurred+will+be+placed%0A++++-clonedSourcePackagesDirPath+PATH++++++++++++++++++++++++specifies+the+directory+to+which+remote+source+packages+are+fetch+or+expected+to+be+found%0A++++-derivedDataPath+PATH++++++++++++++++++++++++++++++++++++specifies+the+directory+where+build+products+and+other+derived+data+will+go%0A++++-archivePath+PATH++++++++++++++++++++++++++++++++++++++++specifies+the+directory+where+any+created+archives+will+be+placed%2C+or+the+archive+that+should+be+exported%0A++++-exportArchive+++++++++++++++++++++++++++++++++++++++++++specifies+that+an+archive+should+be+exported%0A++++-exportNotarizedApp++++++++++++++++++++++++++++++++++++++export+an+archive+that+has+been+notarized+by+Apple%0A++++-exportOptionsPlist+PATH+++++++++++++++++++++++++++++++++specifies+a+path+to+a+plist+file+that+configures+archive+exporting%0A++++-enableCodeCoverage+YES%7CNO+++++++++++++++++++++++++++++++turn+code+coverage+on+or+off+when+testing%0A++++-exportPath+PATH+++++++++++++++++++++++++++++++++++++++++specifies+the+destination+for+the+product+exported+from+an+archive%0A++++-skipUnavailableActions++++++++++++++++++++++++++++++++++specifies+that+scheme+actions+that+cannot+be+performed+should+be+skipped+instead+of+causing+a+failure%0A++++-exportLocalizations+++++++++++++++++++++++++++++++++++++exports+completed+and+outstanding+project+localizations%0A++++-importLocalizations+++++++++++++++++++++++++++++++++++++imports+localizations+for+a+project%2C+assuming+any+necessary+localized+resources+have+been+created+in+Xcode%0A++++-localizationPath++++++++++++++++++++++++++++++++++++++++specifies+a+path+to+XLIFF+localization+files%0A++++-exportLanguage++++++++++++++++++++++++++++++++++++++++++specifies+multiple+optional+ISO+639-1+languages+included+in+a+localization+export%0A++++-xctestrun+++++++++++++++++++++++++++++++++++++++++++++++specifies+a+path+to+a+test+run+specification%0A++++-only-testing%3ATEST-IDENTIFIER++++++++++++++++++++++++++++constrains+testing+by+specifying+tests+to+include%2C+and+excluding+other+tests%0A++++-skip-testing%3ATEST-IDENTIFIER++++++++++++++++++++++++++++constrains+testing+by+specifying+tests+to+exclude%2C+but+including+other+tests%0A++++-testLanguage++++++++++++++++++++++++++++++++++++++++++++constrains+testing+by+specifying+ISO+639-1+language+in+which+to+run+the+tests%0A++++-testRegion++++++++++++++++++++++++++++++++++++++++++++++constrains+testing+by+specifying+ISO+3166-1+region+in+which+to+run+the+tests%0A++++-resolvePackageDependencies++++++++++++++++++++++++++++++resolves+any+package+dependencies+referenced+by+the+project+or+workspace%0A++++-json++++++++++++++++++++++++++++++++++++++++++++++++++++output+as+JSON+%28note%3A+-json+implies+-quiet%29%0A++++-allowProvisioningUpdates++++++++++++++++++++++++++++++++Allow+xcodebuild+to+communicate+with+the+Apple+Developer+website.+For+automatically+signed+targets%2C+xcodebuild+will+create+and+update+profiles%2C+app+IDs%2C+and+certificates.+For+manually+signed+targets%2C+xcodebuild+will+download+missing+or+updated+provisioning+profiles.+Requires+a+developer+account+to+have+been+added+in+Xcode%27s+Accounts+preference+pane.%0A++++-allowProvisioningDeviceRegistration+++++++++++++++++++++Allow+xcodebuild+to+register+your+destination+device+on+the+developer+portal+if+necessary.+This+flag+only+takes+effect+if+-allowProvisioningUpdates+is+also+passed.%0A++++-showBuildTimingSummary++++++++++++++++++++++++++++++++++display+a+report+of+the+timings+of+all+the+commands+invoked+during+the+build%0A%2FApplications%2FXcode.app%2FContents%2FDeveloper%2Fusr%2Fbin%2Fsimctl%3A+line+6%3A+%2FLibrary%2FDeveloper%2FPrivateFrameworks%2FCoreSimulator.framework%2FVersions%2FA%2FResources%2Fbin%2Fsimctl%3A+No+such+file+or+directory%0A%2FApplications%2FXcode.app%2FContents%2FDeveloper%2Fusr%2Fbin%2Fsimctl%3A+line+6%3A+exec%3A+%2FLibrary%2FDeveloper%2FPrivateFrameworks%2FCoreSimulator.framework%2FVersions%2FA%2FResources%2Fbin%2Fsimctl%3A+cannot+execute%3A+No+such+file+or+directory%0A&type=Issues

If none exists, create a ticket, with the template displayed above, on:
https://github.com/CocoaPods/CocoaPods/issues/new

Be sure to first read the contributing guide for details on how to properly submit a ticket:
https://github.com/CocoaPods/CocoaPods/blob/master/CONTRIBUTING.md

Don't forget to anonymize any private data!

Looking for related issues on cocoapods/cocoapods...
Searching for inspections failed: 785: unexpected token at '<html><body><h1>400 Bad request</h1>
Your browser sent an invalid request.
</body></html>
'
````

Please review, thanks.