### PR TITLE
Add quotes around SWIFT_INCLUDE_PATHS in xcconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Add quotes around SWIFT_INCLUDE_PATHS in xcconfig.  
+  [Nick Entin](https://github.com/NickEntin)
+  [#9716](https://github.com/CocoaPods/CocoaPods/pull/9716)
+
 * Fix setting `swift_version` when deduplicate targets is turned off.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9689](https://github.com/CocoaPods/CocoaPods/pull/9689)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -40,6 +40,13 @@ module Pod
         WARNING_LDFLAGS
       ).to_set.freeze
 
+      # @return [Set<String>]
+      #   The build settings that are arrays, but should be wrapped in quotes.
+      #
+      QUOTE_WRAPPED_SETTINGS = %w(
+        SWIFT_INCLUDE_PATHS
+      ).to_set.freeze
+
       # @return [String]
       #   The variable for the configuration build directory used when building pod targets.
       #
@@ -371,7 +378,16 @@ module Pod
           if PLURAL_SETTINGS.include?(key)
             raise ArgumentError, "#{key} is a plural setting, cannot have #{value.inspect} as its value" unless value.is_a? Array
 
-            value = "$(inherited) #{quote_array(value)}"
+            if QUOTE_WRAPPED_SETTINGS.include?(key)
+              if value.empty?
+                value = "$(inherited)"
+              else
+                value_to_wrap = "$(inherited) #{quote_array(value)}".strip
+                value = "\"#{value_to_wrap}\""
+              end
+            else
+              value = "$(inherited) #{quote_array(value)}"
+            end
           else
             raise ArgumentError, "#{key} is not a plural setting, cannot have #{value.inspect} as its value" unless value.is_a? String
           end


### PR DESCRIPTION
This fixes an issue where Xcode doesn't read the SWIFT_INCLUDE_PATHS config correctly for pods that rely on XCTest.