### PR TITLE
Fix vendored .bcsymbolmap on new build system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,15 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Re-implement `bcsymbolmap` copying to avoid duplicate outputs.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [mplorentz](https://github.com/mplorentz)
+  [#9734](https://github.com/CocoaPods/CocoaPods/pull/9734)
+
 * Fix Xcode 11 warning when setting Bundle Identifier in `info_plist`  
   [Sean Reinhardt](https://github.com/seanreinhardtapps)
   [#9536](https://github.com/CocoaPods/CocoaPods/issues/9536)
-  
+
 * Fix `incompatible encoding regexp match` for linting non-ascii pod name  
   [banjun](https://github.com/banjun)
   [#9765](https://github.com/CocoaPods/CocoaPods/issues/9765)
@@ -77,7 +82,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Re-implement `dSYM` copying and stripping to avoid duplicate outputs.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
-  [#9185](https://github.com/CocoaPods/CocoaPods/issues/9185)  
+  [#9185](https://github.com/CocoaPods/CocoaPods/issues/9185)
 
 * Add support for running tests through the scheme of the app spec host of a test spec    
   [Eric Amorde](https://github.com/amorde)

--- a/lib/cocoapods/generator/copy_dsyms_script.rb
+++ b/lib/cocoapods/generator/copy_dsyms_script.rb
@@ -5,12 +5,18 @@ module Pod
       #
       attr_reader :dsym_paths
 
+      # @return [Array<Pathname>] bcsymbolmap_paths the bcsymbolmap paths to include in the script contents.
+      #
+      attr_reader :bcsymbolmap_paths
+
       # Initialize a new instance
       #
       # @param  [Array<Pathname>] dsym_paths @see dsym_paths
+      # @param  [Array<Pathname>] bcsymbolmap_paths @see bcsymbolmap_paths
       #
-      def initialize(dsym_paths)
-        @dsym_paths = dsym_paths
+      def initialize(dsym_paths, bcsymbolmap_paths)
+        @dsym_paths = Array(dsym_paths)
+        @bcsymbolmap_paths = Array(bcsymbolmap_paths)
       end
 
       # Saves the copy dSYMs script to the given pathname.
@@ -35,9 +41,13 @@ module Pod
 #{Pod::Generator::ScriptPhaseConstants::STRIP_INVALID_ARCHITECTURES_METHOD}
 #{Pod::Generator::ScriptPhaseConstants::RSYNC_PROTECT_TMP_FILES}
 #{Pod::Generator::ScriptPhaseConstants::INSTALL_DSYM_METHOD}
+#{Pod::Generator::ScriptPhaseConstants::INSTALL_BCSYMBOLMAP_METHOD}
         SH
         dsym_paths.each do |dsym_path|
           script << %(install_dsym "#{dsym_path}"\n)
+        end
+        bcsymbolmap_paths.each do |bcsymbolmap_path|
+          script << %(install_bcsymbolmap "#{bcsymbolmap_path}"\n)
         end
         script
       end

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -130,14 +130,7 @@ install_framework()
 }
 #{Pod::Generator::ScriptPhaseConstants::INSTALL_DSYM_METHOD}
 #{Pod::Generator::ScriptPhaseConstants::STRIP_INVALID_ARCHITECTURES_METHOD}
-# Copies the bcsymbolmap files of a vendored framework
-install_bcsymbolmap() {
-    local bcsymbolmap_path="$1"
-    local destination="${BUILT_PRODUCTS_DIR}"
-    echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
-    rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"
-}
-
+#{Pod::Generator::ScriptPhaseConstants::INSTALL_BCSYMBOLMAP_METHOD}
 # Signs a framework with the provided identity
 code_sign_if_enabled() {
   if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
@@ -159,11 +152,6 @@ code_sign_if_enabled() {
         frameworks_by_config.each do |config, frameworks|
           frameworks.each do |framework|
             contents_by_config[config] << %(  install_framework "#{framework.source_path}"\n)
-            unless framework.bcsymbolmap_paths.nil?
-              framework.bcsymbolmap_paths.each do |bcsymbolmap_path|
-                contents_by_config[config] << %(  install_bcsymbolmap "#{bcsymbolmap_path}"\n)
-              end
-            end
           end
         end
         xcframeworks_by_config.each do |config, xcframeworks|

--- a/lib/cocoapods/generator/script_phase_constants.rb
+++ b/lib/cocoapods/generator/script_phase_constants.rb
@@ -84,6 +84,16 @@ install_dsym() {
   fi
 }
       SH
+
+      INSTALL_BCSYMBOLMAP_METHOD = <<-SH.strip_heredoc.freeze
+# Copies the bcsymbolmap files of a vendored framework
+install_bcsymbolmap() {
+    local bcsymbolmap_path="$1"
+    local destination="${BUILT_PRODUCTS_DIR}"
+    echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
+    rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"
+}
+      SH
     end
   end
 end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -797,15 +797,16 @@ module Pod
             end
           end
 
-          # Creates a script that copies and strips vendored dSYMs.
+          # Creates a script that copies and strips vendored dSYMs and bcsymbolmaps.
           #
           # @return [void]
           #
           def create_copy_dsyms_script
             dsym_paths = PodTargetInstaller.dsym_paths(target)
+            bcsymbolmap_paths = PodTargetInstaller.bcsymbolmap_paths(target)
             path = target.copy_dsyms_script_path
-            unless dsym_paths.empty?
-              generator = Generator::CopydSYMsScript.new(dsym_paths)
+            unless dsym_paths.empty? && bcsymbolmap_paths.empty?
+              generator = Generator::CopydSYMsScript.new(dsym_paths, bcsymbolmap_paths)
               update_changed_file(generator, path)
               add_file_to_support_group(path)
             end
@@ -1172,6 +1173,16 @@ module Pod
               dsym_paths = target.framework_paths.values.flatten.reject { |fmwk_path| fmwk_path.dsym_path.nil? }.map(&:dsym_path)
               dsym_paths.concat(target.xcframeworks.values.flatten.flat_map { |xcframework| xcframework_dsyms(xcframework.path) })
               dsym_paths
+            end
+
+            # @param [PodTarget] target the target to be installed
+            #
+            # @return [Array<String>] the bcsymbolmap paths for the given target
+            #
+            def bcsymbolmap_paths(target)
+              target.framework_paths.values.flatten.reject do |fmwk_path|
+                fmwk_path.bcsymbolmap_paths.nil?
+              end.flat_map(&:bcsymbolmap_paths)
             end
 
             # @param  [Pathname] xcframework_path

--- a/lib/cocoapods/xcode/framework_paths.rb
+++ b/lib/cocoapods/xcode/framework_paths.rb
@@ -9,7 +9,7 @@ module Pod
       #
       attr_reader :dsym_path
 
-      # @return [Array, Nil] the bcsymbolmap files path array, if one exists
+      # @return [Array<String>, Nil] the bcsymbolmap files path array, if one exists
       #
       attr_reader :bcsymbolmap_paths
 

--- a/spec/unit/generator/embed_frameworks_script_spec.rb
+++ b/spec/unit/generator/embed_frameworks_script_spec.rb
@@ -4,8 +4,9 @@ module Pod
   describe Generator::EmbedFrameworksScript do
     it 'installs frameworks by config' do
       frameworks = {
-        'Debug' => [Xcode::FrameworkPaths.new('Pods/Loopback.framework'), Xcode::FrameworkPaths.new('Reveal.framework')],
-        'Release' => [Xcode::FrameworkPaths.new('CrashlyticsFramework.framework')],
+        'Debug' => [Xcode::FrameworkPaths.new('Pods/Loopback.framework'),
+                    Xcode::FrameworkPaths.new('Reveal.framework')],
+        'Release' => [Xcode::FrameworkPaths.new('Crashlytics.framework')],
       }
       generator = Pod::Generator::EmbedFrameworksScript.new(frameworks, {})
       result = generator.send(:script)
@@ -17,34 +18,39 @@ module Pod
       SH
       result.should.include <<-SH.strip_heredoc
         if [[ "$CONFIGURATION" == "Release" ]]; then
-          install_framework "CrashlyticsFramework.framework"
+          install_framework "Crashlytics.framework"
         fi
       SH
     end
 
-    it 'installs bcsymbolmaps if specified' do
+    it 'does not install dSYMs or bcsymbolmaps if specified' do
       frameworks = {
-        'Debug' => [Xcode::FrameworkPaths.new('Pods/Loopback.framework', nil,
-                                              ['7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap', 'B724D6B4-C7DD-31F0-80C6-EE818ED30B0B.bcsymbolmap']),
+        'Debug' => [Xcode::FrameworkPaths.new('Pods/Loopback.framework', 'Pods/Loopback.framework.dSYM',
+                                              ['7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap',
+                                               'B724D6B4-C7DD-31F0-80C6-EE818ED30B0B.bcsymbolmap']),
                     Xcode::FrameworkPaths.new('Reveal.framework')],
-        'Release' => [Xcode::FrameworkPaths.new('CrashlyticsFramework.framework', nil, ['ABCD1234.bcsymbolmap'])],
+        'Release' => [Xcode::FrameworkPaths.new('Crashlytics.framework', 'Crashlytics.framework.dSYM',
+                                                ['ABCD1234.bcsymbolmap', 'WXYZ5678.bcsymbolmap'])],
       }
       generator = Pod::Generator::EmbedFrameworksScript.new(frameworks, {})
       result = generator.send(:script)
       result.should.include <<-SH.strip_heredoc
         if [[ "$CONFIGURATION" == "Debug" ]]; then
           install_framework "Pods/Loopback.framework"
-          install_bcsymbolmap "7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap"
-          install_bcsymbolmap "B724D6B4-C7DD-31F0-80C6-EE818ED30B0B.bcsymbolmap"
           install_framework "Reveal.framework"
         fi
       SH
       result.should.include <<-SH.strip_heredoc
         if [[ "$CONFIGURATION" == "Release" ]]; then
-          install_framework "CrashlyticsFramework.framework"
-          install_bcsymbolmap "ABCD1234.bcsymbolmap"
+          install_framework "Crashlytics.framework"
         fi
       SH
+      result.should.not.include 'Pods/Loopback.framework.dSYM'
+      result.should.not.include 'Crashlytics.framework.dSYM'
+      result.should.not.include '7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap'
+      result.should.not.include 'B724D6B4-C7DD-31F0-80C6-EE818ED30B0B.bcsymbolmap'
+      result.should.not.include 'ABCD1234.bcsymbolmap'
+      result.should.not.include 'WXYZ5678.bcsymbolmap'
     end
 
     it 'installs intermediate XCFramework slices' do

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -455,15 +455,15 @@ module Pod
           @target_integrator.integrate!
           target = @target_integrator.send(:native_targets).first
           phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          # dSYM and bcsymbolmaps are intentionally excluded as they are handled by a different script phase within
+          # the pod target.
           phase.input_paths.sort.should == %w(
             ${BUILT_PRODUCTS_DIR}/DebugCompiledFramework/DebugCompiledFramework.framework
-            ${PODS_ROOT}/DebugVendoredFramework/ios/A6621399-62A0-3DC3-A6E3-B6B51BD287AD.bcsymbolmap
             ${PODS_ROOT}/DebugVendoredFramework/ios/DebugVendoredFramework.framework
             ${PODS_ROOT}/ReleaseVendoredFramework/ios/ReleaseVendoredFramework.framework
             ${PODS_ROOT}/Target\ Support\ Files/Pods/Pods-frameworks.sh
           )
           phase.output_paths.sort.should == %w(
-            ${BUILT_PRODUCTS_DIR}/A6621399-62A0-3DC3-A6E3-B6B51BD287AD.bcsymbolmap
             ${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DebugCompiledFramework.framework
             ${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DebugVendoredFramework.framework
             ${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReleaseVendoredFramework.framework

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_integrator_spec.rb
@@ -237,7 +237,8 @@ module Pod
 
                 it 'integrates native target with copy dSYM script phase' do
                   framework_paths = [Pod::Xcode::FrameworkPaths.new('${PODS_ROOT}/Vendored/Vendored.framework',
-                                                                    '${PODS_ROOT}/Vendored/Vendored.framework.dSYM')]
+                                                                    '${PODS_ROOT}/Vendored/Vendored.framework.dSYM',
+                                                                    ['${PODS_ROOT}/Vendored/7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap'])]
                   @watermelon_pod_target.stubs(:framework_paths).returns('WatermelonLib' => framework_paths)
                   installation_result = TargetInstallationResult.new(@watermelon_pod_target, @native_target, [], [])
                   PodTargetIntegrator.new(installation_result, :use_input_output_paths => true).integrate!
@@ -247,16 +248,19 @@ module Pod
                   ]
                   @native_target.build_phases[0].input_paths.should == [
                     '${PODS_ROOT}/Vendored/Vendored.framework.dSYM',
+                    '${PODS_ROOT}/Vendored/7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap',
                   ]
                   @native_target.build_phases[0].output_paths.should == [
                     '${DWARF_DSYM_FOLDER_PATH}/Vendored.framework.dSYM',
+                    '${DWARF_DSYM_FOLDER_PATH}/7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap',
                   ]
                 end
 
                 it 'integrates native target with copy dSYM script phase and xcfilelists' do
                   @project.stubs(:object_version).returns('50')
                   framework_paths = [Pod::Xcode::FrameworkPaths.new('${PODS_ROOT}/Vendored/Vendored.framework',
-                                                                    '${PODS_ROOT}/Vendored/Vendored.framework.dSYM')]
+                                                                    '${PODS_ROOT}/Vendored/Vendored.framework.dSYM',
+                                                                    ['${PODS_ROOT}/Vendored/7724D6B4-C7DD-31F0-80C6-EE818ED30B07.bcsymbolmap'])]
                   @watermelon_pod_target.stubs(:framework_paths).returns('WatermelonLib' => framework_paths)
                   installation_result = TargetInstallationResult.new(@watermelon_pod_target, @native_target, [], [])
                   PodTargetIntegrator.new(installation_result, :use_input_output_paths => true).integrate!


### PR DESCRIPTION
🌈 Fix for #9419

I moved the .bcsymbolmap copy command out of the Embed Frameworks phase and into the new Copy dSYMs phase that was added in #9547.

I got a good start on this but I'm not sure if I have bandwidth to take it over the finish line. I haven't used submodules before so I'm not sure how to get those changes to show up in this PR. I'm also unsure how to update the "after" folder in the integration test fixtures with a new xcproj file. Happy for a maintainer to clean this up if they are interested.

edit by dnkoutso:

integration specs https://github.com/CocoaPods/cocoapods-integration-specs/pull/282