### PR TITLE
Fix adding developer library search paths during pod validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix adding developer library search paths during pod validation.  
+  [Nick Entin](https://github.com/NickEntin)
+  [#9736](https://github.com/CocoaPods/CocoaPods/pull/9736)
+
 * Fix an issue that caused multiple xcframework scripts to produce the same output files  
   [Eric Amorde](https://github.com/amorde)
   [#9670](https://github.com/CocoaPods/CocoaPods/issues/9670)

--- a/lib/cocoapods/generator/app_target_helper.rb
+++ b/lib/cocoapods/generator/app_target_helper.rb
@@ -127,9 +127,17 @@ module Pod
       # @return [void]
       #
       def self.add_xctest_search_paths(target)
+        requires_libs = target.platform_name == :ios &&
+          Version.new(target.deployment_target) < Version.new('12.2')
+
         target.build_configurations.each do |configuration|
-          search_paths = configuration.build_settings['FRAMEWORK_SEARCH_PATHS'] ||= '$(inherited)'
-          search_paths << ' "$(PLATFORM_DIR)/Developer/Library/Frameworks"'
+          framework_search_paths = configuration.build_settings['FRAMEWORK_SEARCH_PATHS'] ||= '$(inherited)'
+          framework_search_paths << ' "$(PLATFORM_DIR)/Developer/Library/Frameworks"'
+
+          if requires_libs
+            library_search_paths = configuration.build_settings['LIBRARY_SEARCH_PATHS'] ||= '$(inherited)'
+            library_search_paths << ' "$(PLATFORM_DIR)/Developer/usr/lib"'
+          end
         end
       end
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -588,7 +588,7 @@ module Pod
       app_target = app_project.targets.first
       pod_target = validation_pod_target
       Pod::Generator::AppTargetHelper.add_app_project_import(app_project, app_target, pod_target, consumer.platform_name)
-      Pod::Generator::AppTargetHelper.add_xctest_search_paths(app_target) if @installer.pod_targets.any? { |pt| pt.spec_consumers.any? { |c| c.frameworks.include?('XCTest') } }
+      Pod::Generator::AppTargetHelper.add_xctest_search_paths(app_target) if @installer.pod_targets.any? { |pt| pt.spec_consumers.any? { |c| c.frameworks.include?('XCTest') || c.weak_frameworks.include?('XCTest') } }
       Pod::Generator::AppTargetHelper.add_empty_swift_file(app_project, app_target) if @installer.pod_targets.any?(&:uses_swift?)
       app_project.save
       Xcodeproj::XCScheme.share_scheme(app_project.path, 'App')


### PR DESCRIPTION
Fixes adding developer library search paths during pod validation for pods that depend on XCTest.

cc @segiddins @dnkoutso 