### PR TITLE
Remove defunct step from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Set Ruby Version
+          command:  echo "2.4" > ~/.ruby-version
       - restore_cache:
           keys:
             - v1-gems-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
       - run:
           name: Set Ruby Version
-          command:  echo 'chruby ruby-2.4' >> ~/.bash_profile
+          command:  echo "2.4" > ~/.ruby-version
       - restore_cache:
           keys:
             - v1-gems-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
       - run:
           name: Set Ruby Version
-          command:  echo "2.4" > ~/.ruby-version
+          command:  echo 'chruby ruby-2.4' >> ~/.bash_profile
       - restore_cache:
           keys:
             - v1-gems-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Set Ruby Version
-          command:  echo "2.4" > ~/.ruby-version
       - restore_cache:
           keys:
             - v1-gems-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Since 4d21f1c964896a1a1999c0b286d6c03f33a51132, this step no longer has any effect because [CircleCI images using macOS 10.15 (Xcode 11.2) and later no longer have the auto-switching feature enabled](https://circleci.com/docs/2.0/testing-ios/#using-ruby).