### PR TITLE
Fix XCFramework slice selection when having more archs in slice than requested with $ARCHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Kenji KATO](https://github.com/katoken-0215)
   [#9706](https://github.com/CocoaPods/CocoaPods/pull/9706)
 
+* Fix XCFramework slice selection when having more slices than requested  
+  [jerbob92](https://github.com/jerbob92)
+  [#9790](https://github.com/CocoaPods/CocoaPods/pull/9790)
+
 ## 1.9.1 (2020-03-09)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Kenji KATO](https://github.com/katoken-0215)
   [#9706](https://github.com/CocoaPods/CocoaPods/pull/9706)
 
-* Fix XCFramework slice selection when having more slices than requested  
+* Fix XCFramework slice selection when having more archs in slice than requested with $ARCHS  
   [jerbob92](https://github.com/jerbob92)
   [#9790](https://github.com/CocoaPods/CocoaPods/pull/9790)
 

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -82,7 +82,7 @@ select_slice() {
   local target_path=""
 
   # Split archs on space so we can find a slice that has all the needed archs
-  local target_archs=$(echo $ARCHS | tr " " "\n")
+  local target_archs=$(echo $ARCHS | tr " " "\\n")
 
   local target_variant=""
   if [[ "$PLATFORM_NAME" == *"simulator" ]]; then
@@ -104,7 +104,7 @@ select_slice() {
       # We match the following: -armv7_, _armv7s_, _arm64_ and _arm64e/.
       # If we have a specific variant: ios-i386_x86_64-simulator/CoconutLib.framework
       # We match the following: -i386_ and _x86_64-
-      local target_arch_regex="[_\-]${target_arch}[\/_\-]"
+      local target_arch_regex="[_\\-]${target_arch}[\\/_\\-]"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
       fi

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -98,7 +98,14 @@ select_slice() {
       if ! [[ "${paths[$i]}" == *"$target_variant"* ]]; then
         matched_all_archs="0"
       fi
-      if ! [[ "${paths[$i]}" == *"$target_arch"* ]]; then
+
+      # This regex matches all possible variants of the arch in the folder name:
+      # Let's say the folder name is: ios-armv7_armv7s_arm64_arm64e/CoconutLib.framework
+      # We match the following: -armv7_, _armv7s_, _arm64_ and _arm64e/.
+      # If we have a specific variant: ios-i386_x86_64-simulator/CoconutLib.framework
+      # We match the following: -i386_x86_ and _x86_64-
+      local target_arch_regex="[_\-]${target_arch}[_\-\/]"
+      if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
       fi
     done

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -97,7 +97,7 @@ select_slice() {
     do
       if ! [[ "${paths[$i]}" == *"$target_variant"* ]]; then
         matched_all_archs="0"
-        continue
+        break
       fi
 
       # This regex matches all possible variants of the arch in the folder name:
@@ -108,7 +108,7 @@ select_slice() {
       local target_arch_regex="[_\\-]${target_arch}[\\/_\\-]"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
-        continue
+        break
       fi
     done
 

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -103,7 +103,7 @@ select_slice() {
       # Let's say the folder name is: ios-armv7_armv7s_arm64_arm64e/CoconutLib.framework
       # We match the following: -armv7_, _armv7s_, _arm64_ and _arm64e/.
       # If we have a specific variant: ios-i386_x86_64-simulator/CoconutLib.framework
-      # We match the following: -i386_x86_ and _x86_64-
+      # We match the following: -i386_ and _x86_64-
       local target_arch_regex="[_\-]${target_arch}[_\-\/]"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -80,10 +80,9 @@ select_slice() {
   local paths=("$@")
   # Locate the correct slice of the .xcframework for the current architectures
   local target_path=""
-  local target_arch="$ARCHS"
 
-  # Replace spaces in compound architectures with _ to match slice format
-  target_arch=${target_arch//\ /_}
+  # Split archs on space so we can find a slice that has all the needed archs
+  local target_archs=$(echo $ARCHS | tr " " "\n")
 
   local target_variant=""
   if [[ "$PLATFORM_NAME" == *"simulator" ]]; then
@@ -93,7 +92,18 @@ select_slice() {
     target_variant="maccatalyst"
   fi
   for i in ${!paths[@]}; do
-    if [[ "${paths[$i]}" == *"$target_arch"* ]] && [[ "${paths[$i]}" == *"$target_variant"* ]]; then
+    local matched_all_archs="1"
+    for target_arch in $target_archs
+    do
+      if ! [[ "${paths[$i]}" == *"$target_variant"* ]]; then
+        matched_all_archs="0"
+      fi
+      if ! [[ "${paths[$i]}" == *"$target_arch"* ]]; then
+        matched_all_archs="0"
+      fi
+    done
+
+    if [[ "$matched_all_archs" == *"1" ]]; then
       # Found a matching slice
       echo "Selected xcframework slice ${paths[$i]}"
       SELECT_SLICE_RETVAL=${paths[$i]}

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -97,6 +97,7 @@ select_slice() {
     do
       if ! [[ "${paths[$i]}" == *"$target_variant"* ]]; then
         matched_all_archs="0"
+        continue
       fi
 
       # This regex matches all possible variants of the arch in the folder name:
@@ -107,14 +108,15 @@ select_slice() {
       local target_arch_regex="[_\\-]${target_arch}[\\/_\\-]"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
+        continue
       fi
     done
 
-    if [[ "$matched_all_archs" == *"1" ]]; then
+    if [[ "$matched_all_archs" == "1" ]]; then
       # Found a matching slice
       echo "Selected xcframework slice ${paths[$i]}"
       SELECT_SLICE_RETVAL=${paths[$i]}
-      break;
+      break
     fi
   done
 }

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -104,7 +104,7 @@ select_slice() {
       # We match the following: -armv7_, _armv7s_, _arm64_ and _arm64e/.
       # If we have a specific variant: ios-i386_x86_64-simulator/CoconutLib.framework
       # We match the following: -i386_ and _x86_64-
-      local target_arch_regex="[_\-]${target_arch}[_\-\/]"
+      local target_arch_regex="[_\-]${target_arch}[\/_\-]"
       if ! [[ "${paths[$i]}" =~ $target_arch_regex ]]; then
         matched_all_archs="0"
       fi


### PR DESCRIPTION
Currently, the XCFramework slice selection uses the whole folder path to select the correct slice.
This works fine when you are building the exact same ARCHS as the one in the slice. But this fails when you build less ARCHS than are in the slice, for example:

Your slice folder name is `ios-armv7_armv7s_arm64_arm64e/CoconutLib.framework`, you `$ARCHS` is `armv7 arm64`. The current code replaces all spaces with underscores, so it becomes `armv7_arm64`, it then tries to find `armv7_arm64` in the folder name, but because `armv7s` is in between, it won't find it.

This PR splits the `ARCHS` on whitespace and then tries to find a slice that contains all separate `ARCHS` in the folder name. This is a continuation of work done in #9569, #9575 and #9720.

Note that this still has an issue that the current code also has: if you are building `armv7`, and your slice doesn't contain `armv7`, but does contain `armv7s`, it will still match it.
So my suggestion for a more robust slice matching in the future is using the actual `Info.plist` slice information, but I'm not sure how much work this is.