### PR TITLE
[Pod Target Installer] Add PRODUCT_BUNDLE_IDENTIFIER to build settings when info_plist defines a bundle id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix Xcode 11 warning when setting Bundle Identifier in `info_plist`  
+  [Sean Reinhardt](https://github.com/seanreinhardtapps)
+  [#9536](https://github.com/CocoaPods/CocoaPods/issues/9536)
+  
 * Fix `incompatible encoding regexp match` for linting non-ascii pod name  
   [banjun](https://github.com/banjun)
   [#9765](https://github.com/CocoaPods/CocoaPods/issues/9765)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -227,7 +227,28 @@ module Pod
               settings['SWIFT_VERSION'] = target.swift_version
             end
 
+            if info_plist_bundle_id
+              settings['PRODUCT_BUNDLE_IDENTIFIER'] = info_plist_bundle_id
+            end
+
             settings
+          end
+
+          # @return [String] Bundle Identifier found in the custom Info.plist entries
+          #
+          def info_plist_bundle_id
+            return @plist_bundle_id if defined?(@plist_bundle_id)
+            unless target.info_plist_entries.nil?
+              @plist_bundle_id = target.info_plist_entries['CFBundleIdentifier']
+              unless @plist_bundle_id.nil?
+                message = "The `#{target.name}` target " \
+              "sets a Bundle Identifier of `#{@plist_bundle_id}` in it's info.plist file. " \
+              'The Bundle Identifier should be set using pod_target_xcconfig: ' \
+              "s.pod_target_xcconfig = { 'PRODUCT_BUNDLE_IDENTIFIER': '#{@plist_bundle_id}' }`."
+                UI.warn message
+              end
+              @plist_bundle_id
+            end
           end
 
           # Filters the given resource file references discarding empty paths which are


### PR DESCRIPTION
Closes CocoaPods/CocoaPods#9536

Took a shot at resolving the warning.  I tried not setting the `PRODUCT_BUNDLE_IDENTIFIER` build setting when there is a `CFBundleIdentifier` set in the spec's info_plist, however an empty value will still log the warning, since the Empty String doesn't match the value in CFBundleIdentifier.

I did resolve the warning by using the `CFBundleIdentifier`  to set the build setting `PRODUCT_BUNDLE_IDENTIFIER`.  I'm unsure if this is an acceptable alteration of the target, but putting it up for review.  There's also an edge case where the Podspec configures the bundle id with both `pod_target_xcconfig` and `info_plist` and with different values; in this case the value set in `pod_target_xcconfig` will win and there will be the same warning logged.

Added a warning with a hint to set the bundle id using `pod_target_xcconfig`, since that appears to be the correct way to set the id with Xcode 11.