### PR TITLE
Add the trunk repo to the default `sources` for the `repo push` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   due to incremental installation.  
   [segiddins][https://github.com/segiddins]
 
+* Add the trunk repo to the default `sources` for the `repo push` command  
+  [Elf Sundae](https://github.com/ElfSundae)
+  [#9840](https://github.com/CocoaPods/CocoaPods/pull/9840)
 
 ## 1.9.3 (2020-05-29)
 
@@ -133,9 +136,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * None.  
 
-* Add the trunk repo to the default `sources` for the `repo push` command  
-  [Elf Sundae](https://github.com/ElfSundae)
-  [#9840](https://github.com/CocoaPods/CocoaPods/pull/9840)
 
 ## 1.9.2 (2020-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * None.  
 
+* Add the trunk repo to the default `sources` for the `repo push` command  
+  [Elf Sundae](https://github.com/ElfSundae)
+  [#9840](https://github.com/CocoaPods/CocoaPods/pull/9840)
 
 ## 1.9.2 (2020-05-22)
 

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -45,7 +45,7 @@ module Pod
           @local_only = argv.flag?('local-only')
           @repo = argv.shift_argument
           @source = source_for_repo
-          @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).join(',')).split(',')
+          @source_urls = argv.option('sources', config.sources_manager.all.map(&:url).append(Pod::TrunkSource::TRUNK_REPO_URL).uniq.join(',')).split(',')
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
           @use_modular_headers = argv.flag?('use-modular-headers', false)

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -180,7 +180,7 @@ module Pod
 
     it 'initializes with default sources if no custom sources specified' do
       cmd = command('repo', 'push', 'master')
-      cmd.instance_variable_get(:@source_urls).should.equal [@upstream.to_s]
+      cmd.instance_variable_get(:@source_urls).should.equal [@upstream.to_s, Pod::TrunkSource::TRUNK_REPO_URL]
     end
 
     it 'initializes with custom sources if specified' do


### PR DESCRIPTION
Related issue #9833

Currently, if the trunk repo has not been set up, pushing a podspec file that depends on some libraries published in the trunk repo will fail: Unable to find a specification.

This PR adds the trunk repo to the default `sources` option value, then the trunk repo will be set up correctly before resolving dependencies when running `pod repo push` command. Like `pod install`, `pod update` or `pod lib lint` does.

I am not familiar with CocoaPods development, and this is my first Ruby code, I hope that there is no big mess. 😄 