### PR TITLE
Stop adding app spec dependencies to library target in incremental installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [jerbob92](https://github.com/jerbob92)
   [#9790](https://github.com/CocoaPods/CocoaPods/pull/9790)
 
+* Don't add app spec dependencies to the parent library's target in Xcode,
+  which was happening when the dependency's project was not being regenerated
+  due to incremental installation.  
+  [segiddins][https://github.com/segiddins]
+
+
 ## 1.9.2 (2020-05-22)
 
 ##### Enhancements

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -187,7 +187,7 @@ module Pod
                 # Hit the cache
                 cached_dependency = metadata_cache.target_label_by_metadata[app_dependent_target.label]
                 project.add_cached_pod_subproject(sandbox, cached_dependency, is_local)
-                Project.add_cached_dependency(sandbox, native_target, cached_dependency)
+                Project.add_cached_dependency(sandbox, app_native_target, cached_dependency)
               end
             end
           end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -53,8 +53,8 @@ module Pod
 
             # Wire up app native targets.
             unless pod_target_installation_result.app_native_targets.empty?
-              wire_app_native_targets(pod_target, native_target, pod_target_installation_result,
-                                      pod_target_installation_results, project, frameworks_group, metadata_cache)
+              wire_app_native_targets(pod_target, pod_target_installation_result, pod_target_installation_results,
+                                      project, frameworks_group, metadata_cache)
             end
           end
         end
@@ -160,7 +160,7 @@ module Pod
           end
         end
 
-        def wire_app_native_targets(pod_target, native_target, installation_result, pod_target_installation_results, project, frameworks_group, metadata_cache)
+        def wire_app_native_targets(pod_target, installation_result, pod_target_installation_results, project, frameworks_group, metadata_cache)
           installation_result.app_specs_by_native_target.each do |app_native_target, app_spec|
             resource_bundle_native_targets = installation_result.app_resource_bundle_targets[app_spec.name] || []
             resource_bundle_native_targets.each do |app_resource_bundle_target|


### PR DESCRIPTION
@sebastianv1 any pointers where I should look to add a test for this? I couldn't see any covering dependency wiring