### PR TITLE
[Target Integrator] check compatibilityVersion to decide when to use xcfilelists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9871](https://github.com/CocoaPods/CocoaPods/pull/9871)
 
+* Use User Project's compatibilityVersion instead of objectVersion when
+  deciding when to use xcfilelists.  
+  [Sean Reinhardt](https://github.com/seanreinhardtapps)
+  [#9140](https://github.com/CocoaPods/CocoaPods/issues/9140)
+  
 * add a `--configuration` option to `pod lib lint` and `pod spec lint`.  
   [Gereon Steffens](https://github.com/gereons)
   [#9686](https://github.com/CocoaPods/CocoaPods/issues/9686)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -60,6 +60,14 @@ module Pod
           'Prepare Artifacts'.freeze,
         ].freeze
 
+        # @return [float] Returns Minimum Xcode Compatibility version for FileLists
+        #
+        MIN_FILE_LIST_COMPATIBILITY_VERSION = 9.3
+
+        # @return [String] Returns Minimum Xcode Object version for FileLists
+        #
+        MIN_FILE_LIST_OBJECT_VERSION = 50
+
         # @return [AggregateTarget] the target that should be integrated.
         #
         attr_reader :target
@@ -90,7 +98,14 @@ module Pod
           #         should be stored in a file list file.
           #
           def input_output_paths_use_filelist?(object)
-            object.project.object_version.to_i >= 50
+            unless object.project.root_object.compatibility_version.nil?
+              version_match = object.project.root_object.compatibility_version.match(/Xcode ([0-9]*\.[0-9]*)/).to_a
+            end
+            if version_match&.at(1).nil?
+              object.project.object_version.to_i >= MIN_FILE_LIST_OBJECT_VERSION
+            else
+              Pod::Version.new(version_match[1]) >= Pod::Version.new(MIN_FILE_LIST_COMPATIBILITY_VERSION)
+            end
           end
 
           # Sets the input & output paths for the given script build phase.


### PR DESCRIPTION
integration specs PR: https://github.com/CocoaPods/cocoapods-integration-specs/pull/285

Closes #9140.
This PR changes the logic for using file lists to check the `compatibilityVersion` of the Xcode Project, instead of the `objectVersion`. 
I did notice in my own testing that changing the compatibility version from the Xcode UI did change both values.  It seems to me that only manually updating the Compatibility Version in the pbxproj file would result in a situation where either value doesn't correctly describe whether file lists can be used.
Also, the previous logic enabled file lists whenever the `objectVersion` was >= 50 (Xcode 9.3), but to the best of my knowledge .xcfilelists were introduced in Xcode 10.0 (objectVersion 51).