### PR TITLE
remove some non-required architectures from xcframework select_slice

### DIFF
--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -84,6 +84,10 @@ select_slice() {
   # Split archs on space so we can find a slice that has all the needed archs
   local target_archs=$(echo $ARCHS | tr " " "\\n")
 
+  # arm64e and arm7vs are not required architectures for a device slice
+  target_archs=( "${target_archs[@]/arm64e}" )
+  target_archs=( "${target_archs[@]/armv7s}" )
+  
   local target_variant=""
   if [[ "$PLATFORM_NAME" == *"simulator" ]]; then
     target_variant="simulator"
@@ -158,7 +162,7 @@ install_xcframework_library() {
   local target_path="$SELECT_SLICE_RETVAL"
   if [[ -z "$target_path" ]]; then
     echo "warning: [CP] Unable to find matching .xcframework slice in '${paths[@]}' for the current build architectures ($ARCHS)."
-    return
+    exit 1
   fi
 
   install_framework "$basepath/$target_path" "$name"
@@ -175,7 +179,7 @@ install_xcframework() {
   local target_path="$SELECT_SLICE_RETVAL"
   if [[ -z "$target_path" ]]; then
     echo "warning: [CP] Unable to find matching .xcframework slice in '${paths[@]}' for the current build architectures ($ARCHS)."
-    return
+    exit 1
   fi
   local source="$basepath/$target_path"
 


### PR DESCRIPTION
After looking at #9794, I had a couple thoughts about the copy_xcframework_script.
There are a couple of arm architectures, arm64e and armv7s, that could be part of the app's Valid Architectures, but as far as I'm aware are not required to have a complete FAT binary. (arm64e is backwards compatible to arm64 and same with armv7s and armv7).  I'm wondering if these should be excluded from the required architectures in select_slice().

I also wanted to propose returning code 1 when an architecture couldn't be found, to help point out the error.