### PR TITLE
Prevent "source changed" message for every version change when using trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Prevent "source changed" message for every version change when using trunk source  
+  [cltnschlosser](https://github.com/cltnschlosser)
+  [#9865](https://github.com/CocoaPods/CocoaPods/issues/9865)
+
 * Re-implement `bcsymbolmap` copying to avoid duplicate outputs.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [mplorentz](https://github.com/mplorentz)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -498,8 +498,7 @@ module Pod
             previous_version = sandbox.manifest.version(spec.name)
             has_changed_version = current_version != previous_version
             current_repo = analysis_result.specs_by_source.detect { |key, values| break key if values.map(&:name).include?(spec.name) }
-            current_repo &&= Pod::TrunkSource::TRUNK_REPO_NAME if current_repo.name == Pod::TrunkSource::TRUNK_REPO_NAME
-            current_repo &&= current_repo.url || current_repo.name
+            current_repo &&= (Pod::TrunkSource::TRUNK_REPO_NAME if current_repo.name == Pod::TrunkSource::TRUNK_REPO_NAME) || current_repo.url || current_repo.name
             previous_spec_repo = sandbox.manifest.spec_repo(spec.name)
             has_changed_repo = !previous_spec_repo.nil? && current_repo && !current_repo.casecmp(previous_spec_repo).zero?
             title = "Installing #{spec.name} #{spec.version}"

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -498,14 +498,8 @@ module Pod
             previous_version = sandbox.manifest.version(spec.name)
             has_changed_version = current_version != previous_version
             current_repo = analysis_result.specs_by_source.detect { |key, values| break key if values.map(&:name).include?(spec.name) }
-            if current_repo
-              # trunk is always saved by name, so force the name
-              if current_repo.name == Pod::TrunkSource::TRUNK_REPO_NAME
-                current_repo = Pod::TrunkSource::TRUNK_REPO_NAME
-              else
-                current_repo = current_repo.url || current_repo.name
-              end
-            end
+            current_repo &&= Pod::TrunkSource::TRUNK_REPO_NAME if current_repo.name == Pod::TrunkSource::TRUNK_REPO_NAME
+            current_repo &&= current_repo.url || current_repo.name
             previous_spec_repo = sandbox.manifest.spec_repo(spec.name)
             has_changed_repo = !previous_spec_repo.nil? && current_repo && !current_repo.casecmp(previous_spec_repo).zero?
             title = "Installing #{spec.name} #{spec.version}"

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -498,7 +498,14 @@ module Pod
             previous_version = sandbox.manifest.version(spec.name)
             has_changed_version = current_version != previous_version
             current_repo = analysis_result.specs_by_source.detect { |key, values| break key if values.map(&:name).include?(spec.name) }
-            current_repo &&= current_repo.url || current_repo.name
+            if current_repo
+              # trunk is always saved by name, so force the name
+              if current_repo.name == Pod::TrunkSource::TRUNK_REPO_NAME
+                current_repo = Pod::TrunkSource::TRUNK_REPO_NAME
+              else
+                current_repo = current_repo.url || current_repo.name
+              end
+            end
             previous_spec_repo = sandbox.manifest.spec_repo(spec.name)
             has_changed_repo = !previous_spec_repo.nil? && current_repo && !current_repo.casecmp(previous_spec_repo).zero?
             title = "Installing #{spec.name} #{spec.version}"


### PR DESCRIPTION
Resolves #9865 

Based off the logic in cocoapods-core for creating lockfiles.
```ruby
      def generate_spec_repos(spec_repos)
        Hash[spec_repos.map do |source, specs|
          next unless source
          next if specs.empty?
          key = source.url || source.name

          # save `trunk` as 'trunk' so that the URL itself can be changed without lockfile churn
          key = Pod::TrunkSource::TRUNK_REPO_NAME if source.name == Pod::TrunkSource::TRUNK_REPO_NAME

          value = specs.map { |s| s.root.name }.uniq
          [key, YAMLHelper.sorted_array(value)]
        end.compact]
      end
```