### PR TITLE
[Command] Allow gem to run as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Igor Makarov](https://github.com/igor-makarov)
   [#9882](https://github.com/CocoaPods/CocoaPods/pull/9882)
 
+* Allow gem to run as root when passing argument flag `--allow-root`  
+  [Sean Reinhardt](https://github.com/seanreinhardtapps)
+  [#8929](https://github.com/CocoaPods/CocoaPods/issues/8929)
+  
 * Warn users to delete the master specs repo if its not explicitly used.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9871](https://github.com/CocoaPods/CocoaPods/pull/9871)

--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -60,6 +60,11 @@ module Pod
     attr_accessor :silent
     alias_method :silent?, :silent
 
+    # @return [Bool] Whether CocoaPods is allowed to run as root.
+    #
+    attr_accessor :allow_root
+    alias_method :allow_root?, :allow_root
+
     # @return [Bool] Whether a message should be printed when a new version of
     #         CocoaPods is available.
     #

--- a/spec/unit/command_spec.rb
+++ b/spec/unit/command_spec.rb
@@ -47,6 +47,47 @@ module Pod
       end
     end
 
+    describe 'ensure_not_root_or_allowed!' do
+      it 'passes check with ENV["COCOAPODS_ALLOW_ROOT"]' do
+        stored_env = ENV['COCOAPODS_ALLOW_ROOT']
+        ENV['COCOAPODS_ALLOW_ROOT'] = '1'
+        lambda { Command.ensure_not_root_or_allowed!([], 123, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!([], 0, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!([], 123, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!([], 0, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 0, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 0, true) }.should.not.raise
+        ENV['COCOAPODS_ALLOW_ROOT'] = stored_env
+      end
+
+      it 'prevents the gem from running as root without flag' do
+        lambda { Command.ensure_not_root_or_allowed!([], 0, false) }.should.raise CLAide::Help
+      end
+
+      it 'skips root check on Widnows' do
+        lambda { Command.ensure_not_root_or_allowed!([], 0, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!([], 123, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 0, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, true) }.should.not.raise
+      end
+
+      it 'passes check when Process.uid != 0' do
+        lambda { Command.ensure_not_root_or_allowed!([], 123, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!([], 123, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, false) }.should.not.raise
+      end
+
+      it 'passes check with --allow-root flag' do
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 0, false) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 123, true) }.should.not.raise
+        lambda { Command.ensure_not_root_or_allowed!(['--allow-root'], 0, true) }.should.not.raise
+      end
+    end
+
     describe 'git version extraction' do
       git_versions = [
         ['git version 1.2.4', Gem::Version.new('1.2.4')],


### PR DESCRIPTION
Closes #8929

Adds argument flag `--allow-root`  and environment variable `COCOAPODS_ALLOW_ROOT`