### PR TITLE
Add the App Clip product symbol to the list of products that need embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add the App Clip product symbol to the list of products that need embedding.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9882](https://github.com/CocoaPods/CocoaPods/pull/9882)
+
 * Warn users to delete the master specs repo if its not explicitly used.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9871](https://github.com/CocoaPods/CocoaPods/pull/9871)

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -32,7 +32,7 @@ module Pod
         # For messages extensions, this only applies if it's embedded in a messages
         # application.
         #
-        EMBED_FRAMEWORK_TARGET_TYPES = [:application, :unit_test_bundle, :ui_test_bundle, :watch2_extension, :messages_application].freeze
+        EMBED_FRAMEWORK_TARGET_TYPES = [:application, :application_on_demand_install_capable, :unit_test_bundle, :ui_test_bundle, :watch2_extension, :messages_application].freeze
 
         # @return [String] the name of the embed frameworks phase
         #

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -168,6 +168,15 @@ module Pod
           phase.nil?.should == false
         end
 
+        it 'adds an embed frameworks build phase if the target to integrate is an app clip' do
+          @pod_bundle.stubs(:build_type => BuildType.dynamic_framework)
+          target = @target_integrator.send(:native_targets).first
+          target.stubs(:symbol_type).returns(:application_on_demand_install_capable)
+          @target_integrator.integrate!
+          phase = target.shell_script_build_phases.find { |bp| bp.name == @embed_framework_phase_name }
+          phase.nil?.should == false
+        end
+
         it 'does not add an embed frameworks build phase if the target to integrate is a framework' do
           @pod_bundle.stubs(:build_type => BuildType.dynamic_framework)
           target = @target_integrator.send(:native_targets).first


### PR DESCRIPTION
An App Clip is a standalone app, therefore frameworks need to be embedded into it.