### PR TITLE
This is a patch for # 8431

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Fixed 'Pods' directory' * . Xcassets 'files are copied and compied twice.
+* Fixed `Pods` directory  `*.xcassets` files are copied and compied twice.  
   [linhay](https://github.com/linhay)
-  [#8431](https://github.com/CocoaPods/CocoaPods/issues/#8431)
-  
+  [#8431](https://github.com/CocoaPods/CocoaPods/issues/8431)
+
 * Remove bitcode symbol maps from embedded framework bundles  
   [Eric Amorde](https://github.com/amorde)
   [#9681](https://github.com/CocoaPods/CocoaPods/issues/9681)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fixed 'Pods' directory' * . Xcassets 'files are copied and compied twice.
+  [linhay](https://github.com/linhay)
+  [#8431](https://github.com/CocoaPods/CocoaPods/issues/#8431)
+  
 * Remove bitcode symbol maps from embedded framework bundles  
   [Eric Amorde](https://github.com/amorde)
   [#9681](https://github.com/CocoaPods/CocoaPods/issues/9681)

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -204,7 +204,7 @@ EOS
 if [[ -n "${WRAPPER_EXTENSION}" ]] && [ "`xcrun --find actool`" ] && [ -n "${XCASSET_FILES:-}" ]
 then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
-  OTHER_XCASSETS=$(find -L "$PWD" -iname "*.xcassets" -not -path "${PODS_ROOT}/*")
+  OTHER_XCASSETS=$(find "$PWD" -type d -path "${PODS_ROOT}" -prune -o -iname '*.xcassets' -print)
   while read line; do
     XCASSET_FILES+=("$line")
   done <<<"$OTHER_XCASSETS"

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -204,11 +204,9 @@ EOS
 if [[ -n "${WRAPPER_EXTENSION}" ]] && [ "`xcrun --find actool`" ] && [ -n "${XCASSET_FILES:-}" ]
 then
   # Find all other xcassets (this unfortunately includes those of path pods and other targets).
-  OTHER_XCASSETS=$(find -L "$PWD" -iname "*.xcassets" -type d)
+  OTHER_XCASSETS=$(find -L "$PWD" -iname "*.xcassets" -not -path "${PODS_ROOT}/*")
   while read line; do
-    if [[ $line != "${PODS_ROOT}*" ]]; then
-      XCASSET_FILES+=("$line")
-    fi
+    XCASSET_FILES+=("$line")
   done <<<"$OTHER_XCASSETS"
 
   if [ -z ${ASSETCATALOG_COMPILER_APPICON_NAME+x} ]; then


### PR DESCRIPTION
The 'Pods' directory will be correctly excluded when using the 'find' command.
```shell
  OTHER_XCASSETS=$(find "$PWD" -type d -path "${PODS_ROOT}" -prune -o -iname '*.xcassets' -print)
  while read line; do
    XCASSET_FILES+=("$line")
  done <<<"$OTHER_XCASSETS"
```