### PR TITLE
Fix a couple more 2.7.0 warnings

### DIFF
--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -97,7 +97,7 @@ module Pod
       #         `request`.
       #
       def path_for_pod(request, slug_opts = {})
-        root + request.slug(slug_opts)
+        root + request.slug(**slug_opts)
       end
 
       # @param  [Request] request
@@ -111,7 +111,7 @@ module Pod
       #         `request`.
       #
       def path_for_spec(request, slug_opts = {})
-        path = root + 'Specs' + request.slug(slug_opts)
+        path = root + 'Specs' + request.slug(**slug_opts)
         path.sub_ext('.podspec.json')
       end
 


### PR DESCRIPTION
```
/Users/dnkoutso/Development/ios/cocoapods-mine/lib/cocoapods/downloader/cache.rb:114: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/dnkoutso/Development/ios/cocoapods-mine/lib/cocoapods/downloader/request.rb:61: warning: The called method `slug' is defined here
/Users/dnkoutso/Development/ios/cocoapods-mine/lib/cocoapods/downloader/cache.rb:100: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/dnkoutso/Development/ios/cocoapods-mine/lib/cocoapods/downloader/request.rb:61: warning: The called method `slug' is defined here
```