### PR TITLE
Override Xcode 12 default for erroring on quoted imports in umbrellas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Override Xcode 12 default for erroring on quoted imports in umbrellas.  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#9902](https://github.com/CocoaPods/CocoaPods/issues/9902)
+
 * Remove bitcode symbol maps from embedded framework bundles  
   [Eric Amorde](https://github.com/amorde)
   [#9681](https://github.com/CocoaPods/CocoaPods/issues/9681)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -332,6 +332,13 @@ module Pod
         false
       end
 
+      # Xcode 12 turns on this warning by default which is problematic for CocoaPods-generated
+      # imports which use double-quoted paths.
+      # @return [Boolean]
+      define_build_settings_method :clang_warn_quoted_include_in_framework_header, :build_setting => true do
+        'NO'
+      end
+
       # @return [Array<String>]
       #   the `LD_RUNPATH_SEARCH_PATHS` needed for dynamically linking the {#target}
       #


### PR DESCRIPTION
Fix #9902

integration specs: https://github.com/CocoaPods/cocoapods-integration-specs/pull/287