### PR TITLE
bugfix: lint subspec error when the name of subspec start with the po…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Fix lint subspec error when the name of subspec start with the pod name
+* Fix lint subspec error when the name of subspec start with the pod name  
   [XianpuMeng](https://github.com/XianpuMeng)
-  [#9914](https://github.com/CocoaPods/CocoaPods/pull/9914)
+  [#9906](https://github.com/CocoaPods/CocoaPods/issues/9906)
 
 * Override Xcode 12 default for erroring on quoted imports in umbrellas.  
   [Paul Beusterien](https://github.com/paulb777)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix lint subspec error when the name of subspec start with the pod name
+  [XianpuMeng](https://github.com/XianpuMeng)
+  [#9914](https://github.com/CocoaPods/CocoaPods/pull/9914)
+
 * Override Xcode 12 default for erroring on quoted imports in umbrellas.  
   [Paul Beusterien](https://github.com/paulb777)
   [#9902](https://github.com/CocoaPods/CocoaPods/issues/9902)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -118,7 +118,7 @@ module Pod
       # Replace default spec with a subspec if asked for
       a_spec = spec
       if spec && @only_subspec
-        subspec_name = @only_subspec.start_with?(spec.root.name) ? @only_subspec : "#{spec.root.name}/#{@only_subspec}"
+        subspec_name = @only_subspec.start_with?("#{spec.root.name}/") ? @only_subspec : "#{spec.root.name}/#{@only_subspec}"
         a_spec = spec.subspec_by_name(subspec_name, true, true)
         @subspec_name = a_spec.name
       end

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -108,6 +108,18 @@ module Pod
           @validator.send(:subspec_name).should == 'RestKit/CoreData'
         end
 
+        it 'handles a relative subspec name which starts with the pod name' do
+          @validator.only_subspec = 'RestKitSubspec'
+          @validator.validate
+          @validator.send(:subspec_name).should == 'RestKit/RestKitSubspec'
+        end
+
+        it 'handles an absolute subspec name which starts with the pod name' do
+          @validator.only_subspec = 'RestKit/RestKitSubspec'
+          @validator.validate
+          @validator.send(:subspec_name).should == 'RestKit/RestKitSubspec'
+        end
+
         it 'handles a missing subspec name' do
           @validator.only_subspec = 'RestKit/Missing'
           should.raise(Informative) { @validator.validate }.message.


### PR DESCRIPTION
fix the bug that lint subspec error when the name of subspec start with the pod name.