### PR TITLE
Bump minimum Xcodeproj version to 1.17.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ PATH
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.14.0, < 2.0)
+      xcodeproj (>= 1.17.0, < 2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.4.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-try',         '>= 1.1.0', '< 2.0'
   s.add_runtime_dependency 'molinillo',             '~> 0.6.6'
-  s.add_runtime_dependency 'xcodeproj',             '>= 1.14.0', '< 2.0'
+  s.add_runtime_dependency 'xcodeproj',             '>= 1.17.0', '< 2.0'
 
   s.add_runtime_dependency 'activesupport', '> 5'
   s.add_runtime_dependency 'colored2',       '~> 3.1'


### PR DESCRIPTION
In preparation of 1.10 release and Ruby 2.7 support of Xcodeproj so there are no warnings.