### PR TITLE
Bump minimum version of cocoapods-downloader

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,10 +54,10 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-downloader.git
-  revision: d90399cce64a078efa64d639d68504016c9a05cc
+  revision: e2c4ac9f7536c3f31594b26ba2c4c09639f3dca8
   branch: master
   specs:
-    cocoapods-downloader (1.3.0)
+    cocoapods-downloader (1.4.0)
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-plugins.git
@@ -112,7 +112,7 @@ PATH
       claide (>= 1.0.2, < 2.0)
       cocoapods-core (= 1.9.3)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.4.0, < 2.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'claide',                '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'cocoapods-deintegrate', '>= 1.0.3', '< 2.0'
-  s.add_runtime_dependency 'cocoapods-downloader',  '>= 1.2.2', '< 2.0'
+  s.add_runtime_dependency 'cocoapods-downloader',  '>= 1.4.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-plugins',     '>= 1.0.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-search',      '>= 1.0.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.4.0', '< 2.0'

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -51,6 +51,7 @@ require 'colored2'
 
 require 'cocoapods-core/lockfile'
 require 'cocoapods-core/yaml_helper'
+require 'cocoapods-downloader'
 require 'fileutils'
 require 'integration/file_tree'
 require 'integration/xcodeproj_project_yaml'
@@ -146,6 +147,8 @@ describe_cli 'pod' do
     s.replace_pattern /#{Dir.tmpdir}\/[\w-]+/io, 'TMPDIR'
     s.replace_pattern /\d{4}-\d\d-\d\d \d\d:\d\d:\d\d [-+]\d{4}/, '<#DATE#>'
     s.replace_pattern /\(Took \d+.\d+ seconds\)/, '(Took <#DURATION#> seconds)'
+    s.replace_pattern /\b#{Regexp.escape(Pod::VERSION)}\b/, '<#Pod::VERSION#>'
+    s.replace_pattern /\b#{Regexp.escape(Pod::Downloader::VERSION)}\b/, '<#Pod::Downloader::VERSION#>'
 
     # This was changed in a very recent git version
     s.replace_pattern /git checkout -b <new-branch-name>/, 'git checkout -b new_branch_name'


### PR DESCRIPTION
In preparation of 1.10 release.

Integration specs: https://github.com/CocoaPods/cocoapods-integration-specs/pull/288