### PR TITLE
Add pre-integrate hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add a post_integrate_hook API  
+  [dcvz](https://github.com/dcvz)
+  [#9935](https://github.com/CocoaPods/CocoaPods/pull/9935)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add a post_integrate_hook API  
+  [dcvz](https://github.com/dcvz)
+  [#9935](https://github.com/CocoaPods/CocoaPods/pull/9935)
+
 * Add a `--update-sources` option to `pod repo push` so one can ensure sources are up-to-date. 
   [Elton Gao](https://github.com/gyfelton)
   [Justin Martin](https://github.com/justinseanmartin)
@@ -55,9 +59,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* Add a post_integrate_hook API  
-  [dcvz](https://github.com/dcvz)
-  [#9935](https://github.com/CocoaPods/CocoaPods/pull/9935)
+* None.
 
 ##### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: f4d4f16f0d92f422f15b1f27e2073276098f8f73
+  revision: 9584a94db960979a0182acfbf4de5e677c848847
   branch: master
   specs:
     cocoapods-core (1.10.1)

--- a/lib/cocoapods/installer/pre_integrate_hooks_context.rb
+++ b/lib/cocoapods/installer/pre_integrate_hooks_context.rb
@@ -1,0 +1,9 @@
+module Pod
+  class Installer
+    # Context object designed to be used with the HooksManager which describes
+    # the context of the installer.
+    #
+    class PreIntegrateHooksContext < BaseInstallHooksContext
+    end
+  end
+end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -932,6 +932,14 @@ module Pod
         @installer.send(:run_plugins_pre_install_hooks)
       end
 
+      it 'runs plugins pre integrate hook' do
+        context = stub
+        Installer::PreIntegrateHooksContext.expects(:generate).returns(context)
+        HooksManager.expects(:run).with(:pre_integrate, context, Installer::DEFAULT_PLUGINS)
+        @installer.expects(:any_plugin_pre_integrate_hooks?).returns(true)
+        @installer.send(:run_plugins_pre_integrate_hooks)
+      end
+
       it 'runs plugins post install hook' do
         context = stub
         Installer::PostInstallHooksContext.expects(:generate).returns(context)


### PR DESCRIPTION
Add support for a pre-integrate hook that will allow plugins to make changes to downloaded pods before the integration into projects.

This is useful for a plugin such as a cocoapods-patch that allows users to create patch files for pod dependencies.. whose changes might include a file deletion (which needs to happen before the integration to not cause problems).

Core PR: https://github.com/CocoaPods/Core/pull/643