### PR TITLE
Added static binary check before embedding framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Ensure that static frameworks are not embedded
+* Ensure that static frameworks are not embedded  
   [Bernard Gatt](https://github.com/BernardGatt)
   [#9943](https://github.com/CocoaPods/CocoaPods/issues/9943)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Ensure that static frameworks are not embedded
+  [Bernard Gatt](https://github.com/BernardGatt)
+  [#9943](https://github.com/CocoaPods/CocoaPods/issues/9943)
+
 * Ensure that the non-compilable resource skipping in static frameworks happens only for the pod itself  
   [Igor Makarov](https://github.com/igor-makarov)
   [#9922](https://github.com/CocoaPods/CocoaPods/pull/9922)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -71,6 +71,14 @@ BCSYMBOLMAP_DIR="BCSymbolMaps"
 # Copies and strips a vendored framework
 install_framework()
 {
+  local basename
+  basename="$(basename -s .framework "$1")"
+  source_binary="$1/${basename}"
+  if [[ $(file $source_binary | grep 'current ar archive') ]]; then
+    echo "Static binary $basename detected, skipping embed."
+    return
+  fi
+
   if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
     local source="${BUILT_PRODUCTS_DIR}/$1"
   elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
@@ -100,8 +108,6 @@ install_framework()
   echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${destination}\\""
   rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${destination}"
 
-  local basename
-  basename="$(basename -s .framework "$1")"
   binary="${destination}/${basename}.framework/${basename}"
 
   if ! [ -r "$binary" ]; then

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -74,7 +74,7 @@ install_framework()
   local basename
   basename="$(basename -s .framework "$1")"
   source_binary="$1/${basename}"
-  if [[ $(file $source_binary | grep 'current ar archive') ]]; then
+  if [[ $(file "$source_binary" | grep 'current ar archive') ]]; then
     echo "Static binary $basename detected, skipping embed."
     return
   fi


### PR DESCRIPTION
Static binaries are currently being embedded into the app, this causes a Mach-O error.

[Apple Documentation](https://developer.apple.com/library/archive/technotes/tn2435/_index.html#//apple_ref/doc/uid/DTS40017543-CH1-TROUBLESHOOTING_BUNDLE_ERRORS-EMBEDDED_STATIC_LIBRARIES)

Addresses issue: https://github.com/CocoaPods/CocoaPods/issues/9943