### PR TITLE
Added static binary check before embedding framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Ensure that static frameworks are not embedded  
+  [Bernard Gatt](https://github.com/BernardGatt)
+  [#9943](https://github.com/CocoaPods/CocoaPods/issues/9943)
+
 * Ensure that the non-compilable resource skipping in static frameworks happens only for the pod itself  
   [Igor Makarov](https://github.com/igor-makarov)
   [#9922](https://github.com/CocoaPods/CocoaPods/pull/9922)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -158,7 +158,7 @@ code_sign_if_enabled() {
           end
         end
         xcframeworks_by_config.each do |config, xcframeworks|
-          xcframeworks.each do |xcframework|
+          xcframeworks.select { |xcf| xcf.build_type.dynamic_framework? }.each do |xcframework|
             name = xcframework.name
             contents_by_config[config] << %(  install_framework "#{Target::BuildSettings::XCFRAMEWORKS_BUILD_DIR_VARIABLE}/#{name}/#{name}.framework"\n)
           end

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -318,6 +318,11 @@ describe_cli 'pod' do
                             'install --no-repo-update --no-verbose'
     end
 
+    describe 'Integrates a Pod using a vendored static xcframework' do
+      behaves_like cli_spec 'install_vendored_static_xcframework',
+                            'install --no-repo-update'
+    end
+
     describe 'Integrates a Pod using a vendored xcframework' do
       behaves_like cli_spec 'install_vendored_xcframework',
                             'install --no-repo-update'


### PR DESCRIPTION
Static binaries are currently being embedded into the app, this causes a Mach-O error.

[Apple Documentation](https://developer.apple.com/library/archive/technotes/tn2435/_index.html#//apple_ref/doc/uid/DTS40017543-CH1-TROUBLESHOOTING_BUNDLE_ERRORS-EMBEDDED_STATIC_LIBRARIES)

Addresses issue: https://github.com/CocoaPods/CocoaPods/issues/9943