### PR TITLE
Support for CocoaPods registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Support for CocoaPods registries.
+  [yahavi](https://github.com/yahavi)
+  [#9959](https://github.com/CocoaPods/CocoaPods/pull/9959)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/repo.rb
+++ b/lib/cocoapods/command/repo.rb
@@ -22,6 +22,9 @@ module Pod
       extend Executable
       executable :git
 
+      extend Executable
+      executable :curl
+
       def dir
         config.repos_dir + @name
       end

--- a/spec/functional/command/repo/add_spec.rb
+++ b/spec/functional/command/repo/add_spec.rb
@@ -35,6 +35,14 @@ module Pod
       Dir.chdir(repo2.dir) { `git symbolic-ref HEAD` }.should.include? 'my-branch'
     end
 
+    it 'adds a registry repo' do
+      run_command('repo', 'add', 'registry', 'https://github.com/CocoaPods/cocoapods-test-specs/archive/master.zip', '--registry')
+      Dir.chdir(config.repos_dir + 'registry') do
+        registry_rc = YAML.safe_load(File.read('.registry-rc.yml'))
+        registry_rc['registry_url'].chomp.should == 'https://github.com/CocoaPods/cocoapods-test-specs/archive/master.zip'
+      end
+    end
+
     it 'raises an informative error when the repos directory fails to be created' do
       repos_dir = config.repos_dir
       def repos_dir.mkpath


### PR DESCRIPTION
Resolves #9690
Related Core PR: https://github.com/CocoaPods/Core/pull/644

This PR adds support for CocoaPods registries, which proxy GitHub. The code is covered by tests, but I also ran thorough tests with Artifactory.

To work with a repository hosted on a CocoaPods registry, a new `--registry` options has been added to the `pod repo add` command. Usage:
```
pod repo add NAME URL --registry
```
The URL should be a download link of an archive containing the repository. For instance, in artifactory it would be:
`https://<artifactory-url>/api/pods/<cocoapods-repository-name>/index/fetchIndex`
For authenticated requests:
`https://<user>:<password>@<artifactory-url>/api/pods/<cocoapods-repository-name>/index/fetchIndex`

Another URL example (though impractical) is using the zip of a GitHub repository. Example:
```
Pod repo add artsy-repo https://github.com/artsy/Specs/archive/master.zip --registry
```

The local repository structure for a registry hosted repository looks the same as git repositories, with one exception - Instead of a .git directory, it contains a yaml file at the root.

.registry-rc.yml:
```
---
registry_url: URL
```

.registry-rc.yml Example:
```
---
registry_url: https://github.com/artsy/Specs/archive/master.zip
```

Finally, as expected in private repositories, the podfile should contain a source to the repository:
```
source 'URL'
```

Example:
```
Source 'https://github.com/artsy/Specs/archive/master.zip'
```

I'm open to making any changes to the design, APIs or code following your feedback.
Thank you!