### PR TITLE
Fix broken install link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Installation & Update
 
-To install or update CocoaPods see this [guide](http://docs.cocoapods.org/guides/installing_cocoapods.html).
+To install or update CocoaPods see this [guide](https://guides.cocoapods.org/using/index.html).
 
 To install release candidates run `[sudo] gem install cocoapods --pre`
 


### PR DESCRIPTION
Previous link went to malfunctioning heroku app behind docs.cocoapods.org, this link harvested via cocoapods.org then clicking through to the using section