### PR TITLE
Incremental installation works for a test host in a separate (not-regenerated) project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Ensure that incremental installation is able to set target dependencies for a
+  test spec that uses a custom `app_host_name` that is in a project that is not
+  regenerated.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 1.10.0.beta.2 (2020-08-12)

--- a/lib/cocoapods/installer/project_cache/project_metadata_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_metadata_cache.rb
@@ -54,6 +54,10 @@ module Pod
           installation_results.each do |installation_result|
             native_target = installation_result.native_target
             target_label_by_metadata[native_target.name] = TargetMetadata.from_native_target(sandbox, native_target)
+            # app targets need to be added to the cache because they can be used as app hosts for test targets, even if those test targets live inside a different pod (and thus project)
+            installation_result.app_native_targets.each_value do |app_target|
+              target_label_by_metadata[app_target.name] = TargetMetadata.from_native_target(sandbox, app_target)
+            end
           end
         end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -152,11 +152,13 @@ module Pod
             target_attributes[test_native_target.uuid.to_s] = { 'TestTargetID' => app_native_target.uuid.to_s }
             project.root_object.attributes['TargetAttributes'] = target_attributes
             test_native_target.add_dependency(app_native_target)
-          else
+          elsif cached_dependency = metadata_cache.target_label_by_metadata[app_host_target_label]
             # Hit the cache
-            cached_dependency = metadata_cache.target_label_by_metadata[app_host_target_label]
             project.add_cached_subproject_reference(sandbox, cached_dependency, project.dependencies_group)
             Project.add_cached_dependency(sandbox, test_native_target, cached_dependency)
+          else
+            raise "Expected to either have an installation or cache result for #{app_host_target_label} (from pod #{app_host_pod_target_label}) " \
+              "for target #{test_native_target.name} in project #{project.project_name}"
           end
         end
 


### PR DESCRIPTION
Unfortunately, much like https://github.com/CocoaPods/CocoaPods/pull/9847 there's no existing test coverage for this area of the code