### PR TITLE
Force a clean install if installation options are changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Force a clean install if installation options change.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#10016](https://github.com/CocoaPods/CocoaPods/pull/10016)
+
 * Honor test spec deployment target during validation.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9999](https://github.com/CocoaPods/CocoaPods/pull/9999)

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -199,7 +199,7 @@ module Pod
 
           force_clean_install = clean_install || project_cache_version.version != Version.create(VersionMetadata.project_cache_version)
           cache_result = ProjectCache::ProjectCacheAnalyzer.new(sandbox, installation_cache, analysis_result.all_user_build_configurations,
-                                                                object_version, plugins, pod_targets, aggregate_targets, :clean_install => force_clean_install).analyze
+                                                                object_version, plugins, pod_targets, aggregate_targets, installation_options.to_h, :clean_install => force_clean_install).analyze
           aggregate_targets_to_generate = cache_result.aggregate_targets_to_generate || []
           pod_targets_to_generate = cache_result.pod_targets_to_generate
           (aggregate_targets_to_generate + pod_targets_to_generate).each do |target|
@@ -815,6 +815,7 @@ module Pod
       installation_cache.update_project_object_version!(cache_analysis_result.project_object_version)
       installation_cache.update_build_configurations!(cache_analysis_result.build_configurations)
       installation_cache.update_podfile_plugins!(plugins)
+      installation_cache.update_installation_options!(installation_options.to_h)
       installation_cache.save_as(sandbox.project_installation_cache_path)
 
       metadata_cache.update_metadata!(target_installation_results.pod_target_installation_results || {},

--- a/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
@@ -34,6 +34,10 @@ module Pod
         #
         attr_reader :aggregate_targets
 
+        # @return [Hash<Symbol, Object>] Hash of installation options.
+        #
+        attr_reader :installation_options
+
         # @return [Bool] Flag indicating if we want to ignore the cache and force a clean installation.
         #
         attr_reader :clean_install
@@ -47,9 +51,10 @@ module Pod
         # @param [Hash<String, Hash>] podfile_plugins @see #podfile_plugins
         # @param [Array<PodTarget>] pod_targets @see #pod_targets
         # @param [Array<AggregateTarget>] aggregate_targets @see #aggregate_targets
+        # @param [Hash<Symbol, Object>] installation_options @see #installation_options
         # @param [Bool] clean_install @see #clean_install
         #
-        def initialize(sandbox, cache, build_configurations, project_object_version, podfile_plugins, pod_targets, aggregate_targets,
+        def initialize(sandbox, cache, build_configurations, project_object_version, podfile_plugins, pod_targets, aggregate_targets, installation_options,
                        clean_install: false)
           @sandbox = sandbox
           @cache = cache
@@ -58,6 +63,7 @@ module Pod
           @pod_targets = pod_targets
           @aggregate_targets = aggregate_targets
           @project_object_version = project_object_version
+          @installation_options = installation_options
           @clean_install = clean_install
         end
 
@@ -78,7 +84,8 @@ module Pod
           # Bail out early since these properties affect all targets and their associate projects.
           if cache.build_configurations != build_configurations ||
               cache.project_object_version != project_object_version ||
-              YAMLHelper.convert(cache.podfile_plugins) != YAMLHelper.convert(podfile_plugins)
+              YAMLHelper.convert(cache.podfile_plugins) != YAMLHelper.convert(podfile_plugins) ||
+              YAMLHelper.convert(cache.installation_options) != YAMLHelper.convert(installation_options)
             UI.message 'Ignoring project cache due to project configuration changes.'
             return full_install_results
           end

--- a/lib/cocoapods/installer/project_cache/project_installation_cache.rb
+++ b/lib/cocoapods/installer/project_cache/project_installation_cache.rb
@@ -26,18 +26,25 @@ module Pod
         #
         attr_reader :podfile_plugins
 
+        # @return [Hash<Symbol, Object>]
+        #         Configured installation options
+        #
+        attr_reader :installation_options
+
         # Initializes a new instance.
         #
         # @param [Hash{String => TargetCacheKey}] cache_key_by_target_label @see #cache_key_by_target_label
         # @param [Hash{String => Symbol}] build_configurations @see #build_configurations
         # @param [Integer] project_object_version @see #project_object_version
         # @param [Hash<String, Hash>] podfile_plugins @see #podfile_plugins
+        # @param [Hash<Symbol, Object>] installation_options @see #installation_options
         #
-        def initialize(cache_key_by_target_label = {}, build_configurations = nil, project_object_version = nil, podfile_plugins = {})
+        def initialize(cache_key_by_target_label = {}, build_configurations = nil, project_object_version = nil, podfile_plugins = {}, installation_options = {})
           @cache_key_by_target_label = cache_key_by_target_label
           @build_configurations = build_configurations
           @project_object_version = project_object_version
           @podfile_plugins = podfile_plugins
+          @installation_options = installation_options
         end
 
         def update_cache_key_by_target_label!(cache_key_by_target_label)
@@ -56,6 +63,10 @@ module Pod
           @podfile_plugins = podfile_plugins
         end
 
+        def update_installation_options!(installation_options)
+          @installation_options = installation_options
+        end
+
         def save_as(path)
           Pathname(path).dirname.mkpath
           Sandbox.update_changed_file(path, YAMLHelper.convert(to_hash))
@@ -71,7 +82,8 @@ module Pod
           project_object_version = contents['OBJECT_VERSION']
           build_configurations = contents['BUILD_CONFIGURATIONS']
           podfile_plugins = contents['PLUGINS']
-          ProjectInstallationCache.new(cache_key_by_target_label, build_configurations, project_object_version, podfile_plugins)
+          installation_options = contents['INSTALLATION_OPTIONS']
+          ProjectInstallationCache.new(cache_key_by_target_label, build_configurations, project_object_version, podfile_plugins, installation_options)
         end
 
         def to_hash
@@ -82,6 +94,7 @@ module Pod
           contents['BUILD_CONFIGURATIONS'] = build_configurations if build_configurations
           contents['OBJECT_VERSION'] = project_object_version if project_object_version
           contents['PLUGINS'] = podfile_plugins if podfile_plugins
+          contents['INSTALLATION_OPTIONS'] = installation_options if installation_options
           contents
         end
       end

--- a/lib/cocoapods/version_metadata.rb
+++ b/lib/cocoapods/version_metadata.rb
@@ -1,6 +1,6 @@
 module Pod
   module VersionMetadata
-    CACHE_VERSION = '002'.freeze
+    CACHE_VERSION = '003'.freeze
 
     def self.gem_version
       Pod::VERSION

--- a/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
+++ b/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
@@ -32,7 +32,7 @@ module Pod
           it 'returns all pod targets if there is no cache' do
             empty_cache = ProjectInstallationCache.new
             analyzer = ProjectCacheAnalyzer.new(@sandbox, empty_cache, @build_configurations, @project_object_version, {},
-                                                @pod_targets, [@main_aggregate_target])
+                                                @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(@pod_targets)
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -43,7 +43,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal(nil)
@@ -55,7 +55,7 @@ module Pod
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             @banana_lib.root_spec.stubs(:checksum).returns('Blah')
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([@banana_lib])
             result.aggregate_targets_to_generate.should.equal(nil)
@@ -66,7 +66,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations.merge('Production' => :release), @project_object_version, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations.merge('Production' => :release), @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(@pod_targets)
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -77,7 +77,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, {})
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins' => {} }, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins' => {} }, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(@pod_targets)
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -88,7 +88,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, 'my-plugins' => %w[B A])
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins' => %w[A B] }, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins' => %w[A B] }, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal(nil)
@@ -99,7 +99,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, 'my-plugins-1' => {}, 'my-plugins-2' => {})
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins-2' => { 'input' => 1 }, 'my-plugins-1' => {} }, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins-2' => { 'input' => 1 }, 'my-plugins-1' => {} }, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(@pod_targets)
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -110,7 +110,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, 'my-plugins-1' => {}, 'my-plugins-2' => {})
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins-2' => {}, 'my-plugins-1' => {} }, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins-2' => {}, 'my-plugins-1' => {} }, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal(nil)
@@ -121,7 +121,7 @@ module Pod
             cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, 2, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, 2, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(@pod_targets)
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -133,7 +133,7 @@ module Pod
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             @banana_lib.stubs(:project_name).returns('SomeProject')
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(@pod_targets)
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -148,7 +148,7 @@ module Pod
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
 
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target, @secondary_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target, @secondary_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target, @secondary_aggregate_target])
@@ -163,7 +163,7 @@ module Pod
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
 
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
@@ -175,7 +175,7 @@ module Pod
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
 
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, [], [@main_aggregate_target, @secondary_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, [], [@main_aggregate_target, @secondary_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal([@main_aggregate_target, @secondary_aggregate_target])
@@ -183,7 +183,7 @@ module Pod
 
           it 'returns an empty list of aggregate targets when podfile has no targets and empty cache' do
             cache = ProjectInstallationCache.new
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, [], [])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, [], [], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal([])
@@ -193,7 +193,7 @@ module Pod
             FileUtils.rm_rf @orange_lib.support_files_dir
             cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([@orange_lib])
             result.aggregate_targets_to_generate.should.be.nil
@@ -203,7 +203,7 @@ module Pod
             FileUtils.rm_rf @sandbox.pod_target_project_path(@orange_lib.pod_name)
             cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([@orange_lib])
             result.aggregate_targets_to_generate.should.be.nil
@@ -218,7 +218,7 @@ module Pod
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
 
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal([@monkey_lib])
             result.aggregate_targets_to_generate.should.equal(nil)
@@ -240,7 +240,7 @@ module Pod
               subspec_target_2.label => TargetCacheKey.from_cache_hash(@sandbox, 'BUILD_SETTINGS_CHECKSUM' => 'Blah'),
             }
             cache = ProjectInstallationCache.new(cache_key_by_aggregate_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, subspec_pods, [])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, subspec_pods, [], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(subspec_pods)
             result.aggregate_targets_to_generate.should.equal([])
@@ -264,9 +264,31 @@ module Pod
             }
 
             cache = ProjectInstallationCache.new(cache_key_by_aggregate_target_labels, @build_configurations, @project_object_version)
-            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, subspec_pods, [])
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, subspec_pods, [], {})
             result = analyzer.analyze
             result.pod_targets_to_generate.should.equal(subspec_pods)
+            result.aggregate_targets_to_generate.should.equal(nil)
+          end
+
+          it 'returns all pod targets when installation options change' do
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
+            cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, {}, 'share_schemes_for_development_pods' => false, 'lock_pod_sources' => true)
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], 'share_schemes_for_development_pods' => false)
+            result = analyzer.analyze
+            result.pod_targets_to_generate.should.equal(@pod_targets)
+            result.aggregate_targets_to_generate.should.equal([@main_aggregate_target])
+          end
+
+          it 'returns empty list when installation options do not change' do
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
+            cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, {}, 'share_schemes_for_development_pods' => false, 'lock_pod_sources' => true)
+            analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], 'lock_pod_sources' => true, 'share_schemes_for_development_pods' => false)
+            result = analyzer.analyze
+            result.pod_targets_to_generate.should.equal([])
             result.aggregate_targets_to_generate.should.equal(nil)
           end
         end


### PR DESCRIPTION
Incremental installation does not track any installation options in the cache. Some installation options do affect project generation, so it's safer to force a clean install if any of the podfile options have changed.