### PR TITLE
[Installer] Warn users when local spec layout impedes installation performance

### DIFF
--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -190,6 +190,22 @@ module Pod
       # Whether to skip generating the `Pods.xcodeproj` and perform only dependency resolution and downloading.
       #
       option :skip_pods_project_generation, false
+
+      # Whether to emit a warning when the local spec layout impedes quick installation.
+      #
+      # @see https://github.com/CocoaPods/CocoaPods/issues/9982
+      #
+      option :warn_for_large_local_specs, false
+
+      # Minimum number of files for a spec to be considered large.
+      # Used with warn_for_large_local_specs.
+      #
+      option :warn_for_large_local_specs_files_count_threshold, 1000, :boolean => false
+
+      # Percentage of files resolved by the spec below which a spec is considered to impede performance of installation.
+      # Used with warn_for_large_local_specs.
+      #
+      option :warn_for_large_local_specs_resolved_files_percentage, 5, :boolean => false
     end
   end
 end

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -391,6 +391,57 @@ module Pod
         result.compact.flatten.sort
       end
 
+      class FileAccessorStat
+        # @return [Integer]
+        #
+        attr_reader :resolved_file_system_size
+
+        # @return [Integer]
+        #
+        attr_reader :read_file_system_size
+
+        # @return [String]
+        #
+        attr_reader :spec_name
+
+        # @param  [Integer] resolved_file_system_size
+        # @param  [Integer] read_file_system_size
+        # @param  [String] spec_name
+        #
+        def initialize(resolved_file_system_size, read_file_system_size, spec_name)
+          @resolved_file_system_size = resolved_file_system_size
+          @read_file_system_size = read_file_system_size
+          @spec_name = spec_name
+        end
+
+        # Percentage of the file system that is read by the accessor
+        #
+        # @return [Integer]
+        #
+        def resolved_file_system_percentage
+          if read_file_system_size != 0
+            used_files_ratio = resolved_file_system_size.to_f / read_file_system_size.to_f
+          else
+            used_files_ratio = 0.0
+          end
+          (used_files_ratio * 100.0).to_int
+        end
+      end
+
+      # A stat for the file accessor that accounts for how many files and directories were read and resolved.
+      #
+      # @note stat will be reset if PathList.read_file_system method is called
+      #
+      # @return [FileAccessorStat]
+      #
+      def stat
+        FileAccessorStat.new(
+          path_list.resolved_file_system_size,
+          path_list.read_file_system_size,
+          spec.name,
+        )
+      end
+
       #-----------------------------------------------------------------------#
 
       private

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -71,7 +71,7 @@ module Pod
 
         @dirs = dirs
         @files = files
-        @glob_cache = {}
+        @glob_cache.clear
       end
 
       #-----------------------------------------------------------------------#
@@ -156,6 +156,22 @@ module Pod
           list -= relative_glob(exclude_patterns, exclude_options)
         end
         list
+      end
+
+      # Number of files and directories that are read in the read_file_system.
+      #
+      # @return [Integer]
+      #
+      def read_file_system_size
+        (files + dirs).length
+      end
+
+      # Number of files and directories that are resolved by the glob search.
+      #
+      # @return [Integer]
+      #
+      def resolved_file_system_size
+        @glob_cache.values.flatten.uniq.length
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -72,6 +72,9 @@ module Pod
           'generate_multiple_pod_projects' => false,
           'incremental_installation' => false,
           'skip_pods_project_generation' => false,
+          'warn_for_large_local_specs' => false,
+          'warn_for_large_local_specs_files_count_threshold' => 1000,
+          'warn_for_large_local_specs_resolved_files_percentage' => 5,
         }
       end
 

--- a/spec/unit/sandbox/file_accessor_spec.rb
+++ b/spec/unit/sandbox/file_accessor_spec.rb
@@ -346,5 +346,34 @@ module Pod
     end
 
     #-------------------------------------------------------------------------#
+
+    describe 'Stat' do
+      it 'provides correct percentage when no files were read or resolved' do
+        stat = FileAccessor::FileAccessorStat.new(0, 0, 'name')
+        stat.resolved_file_system_percentage.should == 0
+      end
+
+      it 'provides correct percentage when half of the files have been read' do
+        stat = FileAccessor::FileAccessorStat.new(1, 2, 'name')
+        stat.resolved_file_system_percentage.should == 50
+      end
+
+      it 'changes after files have been resolved' do
+        @spec_consumer.stubs(:resource_bundles).returns('BananaLib' => 'Resources/*')
+        before_resolving_stat = @accessor.stat
+        before_resolving_stat.read_file_system_size.should == 555
+        before_resolving_stat.resolved_file_system_size.should == 0
+        before_resolving_stat.resolved_file_system_percentage.should == 0
+
+        @accessor.resource_bundles.values.flatten.size.should == 8
+        after_resolving_stat = @accessor.stat
+        after_resolving_stat.read_file_system_size.should == 555
+        after_resolving_stat.resolved_file_system_size.should == 8
+        after_resolving_stat.resolved_file_system_percentage.should == 1
+      end
+    end
+
+    #-------------------------------------------------------------------------#
+
   end
 end

--- a/spec/unit/sandbox/path_list_spec.rb
+++ b/spec/unit/sandbox/path_list_spec.rb
@@ -239,6 +239,32 @@ module Pod
       end
     end
 
+    describe 'File system size' do
+      describe 'Read size' do
+        it 'includes all read files and directories' do
+          @path_list.read_file_system_size.should == 555
+        end
+      end
+
+      describe 'Resolved size' do
+        it 'is 0 when no files have been resolved' do
+          @path_list.resolved_file_system_size.should == 0
+        end
+
+        it 'counts resolved files' do
+          @path_list.glob('Classes/*.{h,m}').size.should == 3
+          @path_list.resolved_file_system_size.should == 3
+        end
+
+        it "doesn't count same files twice" do
+          @path_list.glob('Classes/Banana.h').size.should == 1
+          @path_list.resolved_file_system_size.should == 1
+          @path_list.glob('Classes/*.{h,m}').size.should == 3
+          @path_list.resolved_file_system_size.should == 3
+        end
+      end
+    end
+
     #-------------------------------------------------------------------------#
 
     describe 'Private Helpers' do


### PR DESCRIPTION
As per #9982:

This PR adds a `warn_for_large_local_specs` option that is further configurable with `warn_for_large_local_specs_files_count_threshold`, and `warn_for_large_local_specs_resolved_files_percentage` options. I feel like the naming could be better. Perhaps "percentage" should be replaced with a ratio and specified as a `Float`?

I chose to implement `PathList.resolved_file_system_size` by counting entries in the `glob_cache` property so that the warning itself doesn't impact the installation performance. Such implementation has a downside that `PathList.resolved_file_system_size` will reset any time  `PathList.read_file_system` is called, but since local specs call `read_file_system` only once, it should be ok.