### PR TITLE
[Cache] Don't delete cache for other versions of CocoaPods.

### DIFF
--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -7,7 +7,7 @@ module Pod
     # them in a cache directory.
     #
     class Cache
-      # @return [Pathname] The root directory where this cache store its
+      # @return [Pathname] The root directory where this cache stores its
       #         downloads.
       #
       attr_reader :root
@@ -18,8 +18,8 @@ module Pod
       #         see {#root}
       #
       def initialize(root)
-        @root = Pathname(root)
-        ensure_matching_version
+        @root = Pathname(root) + Pod::VERSION
+        @root.mkpath
       end
 
       # Downloads the Pod from the given `request`
@@ -155,21 +155,6 @@ module Pod
       end
 
       private
-
-      # Ensures the cache on disk was created with the same CocoaPods version as
-      # is currently running.
-      #
-      # @return [Void]
-      #
-      def ensure_matching_version
-        version_file = root + 'VERSION'
-        version = version_file.read.strip if version_file.file?
-
-        root.rmtree if version != Pod::VERSION && root.exist?
-        root.mkpath
-
-        version_file.open('w') { |f| f << Pod::VERSION }
-      end
 
       # @param  [Request] request
       #         the request to be downloaded.

--- a/spec/spec_helper/temporary_cache.rb
+++ b/spec/spec_helper/temporary_cache.rb
@@ -12,10 +12,11 @@ module SpecHelper
       FileUtils.rm_rf(destination)
       destination.mkpath
       FileUtils.cp_r(fixture_path, destination)
-      # Add version file so that the cache isn't imploded on version mismatch
-      # (We don't include it in the tar.gz as we don't want to regenerate it each time)
-      version_file = tmp_cache_path + 'Pods/VERSION'
-      version_file.open('w') { |f| f << Pod::VERSION }
+      tmpdir = Pathname(Dir.mktmpdir)
+      FileUtils.mv(tmp_cache_path + 'Pods', tmpdir)
+      versioned_cache = tmp_cache_path + "Pods/#{Pod::VERSION}"
+      versioned_cache.mkpath
+      FileUtils.mv(Dir.glob(tmpdir + 'Pods/*'), versioned_cache)
     end
 
     def tmp_cache_path
@@ -23,7 +24,7 @@ module SpecHelper
     end
 
     def test_cache_yaml(short = false)
-      cache_root = "#{tmp_cache_path}/Pods"
+      cache_root = "#{tmp_cache_path}/Pods/#{Pod::VERSION}"
       root_path = short ? '' : "#{cache_root}/"
       yaml = {
         'AFNetworking' => [

--- a/spec/unit/downloader/cache_spec.rb
+++ b/spec/unit/downloader/cache_spec.rb
@@ -30,13 +30,15 @@ module Pod
       @cache.root.should.be.directory?
     end
 
-    it 'implodes when the cache is from a different CocoaPods version' do
+    it 'creates versioned directory and leaves other versions of the cache' do
       root = Pathname(Dir.mktmpdir)
-      root.+('VERSION').open('w') { |f| f << '0.0.0' }
-      root.+('FILE').open('w') { |f| f << '0.0.0' }
+      old_version = root + '0.0.0'
+      old_version.mkpath
+      old_version.+('FILE').open('w') { |f| f << '0.0.0' }
       @cache = Downloader::Cache.new(root)
-      root.+('VERSION').read.should == Pod::VERSION
-      root.+('FILE').should.not.exist?
+      root.+(Pod::VERSION).should.be.directory?
+      old_version.should.be.directory?
+      old_version.+('FILE').should.exist?
     end
 
     it 'groups subspecs by platform' do


### PR DESCRIPTION
This is the simplest and safest way to accomplish this. Still waiting for feedback on how and whether we could version the cache independently from CocoaPods, so that all compatible versions of CocoaPods would use the same cache.

Fixes #10030