### PR TITLE
Don't print the script phase warning when installing local pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Installing a local (`:path`) pod that defines script phases will no longer
+  produce warnings.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -747,7 +747,7 @@ module Pod
     def warn_for_installed_script_phases
       pods_to_install = sandbox_state.added | sandbox_state.changed
       pod_targets.group_by(&:pod_name).each do |name, pod_targets|
-        if pods_to_install.include?(name)
+        if pods_to_install.include?(name) && !sandbox.local?(name)
           script_phase_count = pod_targets.inject(0) { |sum, target| sum + target.script_phases.count }
           unless script_phase_count.zero?
             UI.warn "#{name} has added #{script_phase_count} #{'script phase'.pluralize(script_phase_count)}. " \

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -833,6 +833,22 @@ module Pod
           UI.warnings.should.be.empty
         end
 
+        it 'does not print a warning for a local pod that include script phases' do
+          spec = fixture_spec('coconut-lib/CoconutLib.podspec')
+          spec.test_specs.first.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
+          pod_target = PodTarget.new(config.sandbox, BuildType.static_library, {}, [], Platform.ios, [spec, *spec.test_specs],
+                                     [fixture_target_definition], nil)
+          pod_target.stubs(:platform).returns(:ios)
+          config.sandbox.stubs(:local?).with('CoconutLib').returns(true)
+          sandbox_state = Installer::Analyzer::SpecsState.new
+          sandbox_state.changed << 'CoconutLib'
+          @installer.stubs(:pod_targets).returns([pod_target])
+          @installer.stubs(:root_specs).returns([spec])
+          @installer.stubs(:sandbox_state).returns(sandbox_state)
+          @installer.send(:warn_for_installed_script_phases)
+          UI.warnings.should.be.empty
+        end
+
         #--------------------------------------#
 
         describe '#clean' do


### PR DESCRIPTION
Local pods can change very frequently, leading to potentially hundreds of lines of non-actionable warnings

Since the pod is local, it is likely that the user installing it is the one who has added the script phases, so warning the user will only desensitize them to these warnings, which is counter-productive