### PR TITLE
Allow app/test targets to not need empty .swift files when their deps use swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   produce warnings.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Allow building app & test spec targets that depend on a library that uses
+  Swift without requiring an empty Swift file be present.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Ensure cache integrity on concurrent installations.  

--- a/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/xcshareddata/xcschemes/TestLib.xcscheme
+++ b/examples/multiple test specs Example/InstallMultipleTestSpecs.xcodeproj/xcshareddata/xcschemes/TestLib.xcscheme
@@ -48,6 +48,16 @@
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "795874B04DB7F28773F99BF9DBF99000"
+               BuildableName = "TestLib-Unit-UnitTests5.xctest"
+               BlueprintName = "TestLib-Unit-UnitTests5"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/examples/multiple test specs Example/Podfile
+++ b/examples/multiple test specs Example/Podfile
@@ -12,7 +12,7 @@ target 'InstallMultipleTestSpecs' do
   use_frameworks!
 
   # Pods for InstallMultipleTestSpecs
-  pod 'TestLib', :path => 'TestLib', :testspecs => %w[UnitTests1 UnitTests2]
+  pod 'TestLib', :path => 'TestLib', :testspecs => %w[UnitTests1 UnitTests2 UnitTests5]
   pod 'HostedTestLib', :path => 'HostedTestLib', :testspecs => %w[UnitTests3 UnitTests4]
   pod 'ByConfig', path: 'ByConfig', appspecs: %w[App]
 end

--- a/examples/multiple test specs Example/TestLib/TestLib.podspec
+++ b/examples/multiple test specs Example/TestLib/TestLib.podspec
@@ -22,6 +22,10 @@ Pod::Spec.new do |s|
     test_spec.source_files = 'TestLib/UnitTests2/**/*'
   end
 
+  s.test_spec 'UnitTests5' do |test_spec|
+    test_spec.source_files = 'TestLib/UnitTests5/**/*'
+  end
+
   s.app_spec 'App' do |app_spec|
     app_spec.source_files = 'TestLib/App/**/*'
   end

--- a/examples/multiple test specs Example/TestLib/TestLib/UnitTests5/Test5.m
+++ b/examples/multiple test specs Example/TestLib/TestLib/UnitTests5/Test5.m
@@ -1,0 +1,12 @@
+@import XCTest;
+
+@interface Test5 : XCTestCase
+@end
+
+@implementation Test5
+
+- (void)testExample {
+    XCTAssertTrue(YES);
+}
+
+@end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -651,10 +651,6 @@ module Pod
                 scoped_test_resource_bundle_targets = test_resource_bundle_targets[test_spec.name]
                 apply_xcconfig_file_ref_to_targets([test_native_target] + scoped_test_resource_bundle_targets, test_xcconfig_file_ref, names)
               end
-
-              test_native_target.build_configurations.each do |test_native_target_bc|
-                test_target_swift_debug_hack(test_spec, test_native_target_bc)
-              end
             end
           end
 
@@ -831,18 +827,6 @@ module Pod
             generator = Generator::CopyXCFrameworksScript.new(target.xcframeworks.values.flatten, sandbox.root, target.platform)
             update_changed_file(generator, path)
             add_file_to_support_group(path)
-          end
-
-          # Manually add `libswiftSwiftOnoneSupport.dylib` as it seems there is an issue with tests that do not include it for Debug configurations.
-          # Possibly related to Swift module optimization.
-          #
-          # @return [void]
-          #
-          def test_target_swift_debug_hack(test_spec, test_target_bc)
-            return unless test_target_bc.debug?
-            return unless target.dependent_targets_for_test_spec(test_spec).any?(&:uses_swift?)
-            ldflags = test_target_bc.build_settings['OTHER_LDFLAGS'] ||= '$(inherited)'
-            ldflags << ' -lswiftSwiftOnoneSupport'
           end
 
           # Creates a build phase which links the versioned header folders

--- a/spec/functional/command/repo/list_spec.rb
+++ b/spec/functional/command/repo/list_spec.rb
@@ -51,7 +51,7 @@ module Pod
 
       it 'shows the current git branch configuration' do
         output = run_command('repo', 'list')
-        output.should.include? '- Type: git (master)'
+        output.should.include? '- Type: git (main)'
       end
 
       it 'shows the git URL (when an upstream is not configured)' do

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -73,7 +73,7 @@ module Pod
         `git remote add origin #{@upstream}`
         `git remote -v`
         `git fetch -q`
-        `git branch --set-upstream-to=origin/master master`
+        `git branch --set-upstream-to=origin/main main`
       end
 
       # prepare the spec
@@ -156,7 +156,7 @@ module Pod
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
       cmd.expects(:validate_podspec_files).returns(true)
       Dir.chdir(temporary_directory) { cmd.run }
-      Dir.chdir(@upstream) { `git checkout master -q` }
+      Dir.chdir(@upstream) { `git checkout main -q` }
       (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
     end
 
@@ -165,7 +165,7 @@ module Pod
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
       cmd.expects(:validate_podspec_files).returns(true)
       Dir.chdir(temporary_directory) { cmd.run }
-      Dir.chdir(@upstream) { `git checkout master -q` }
+      Dir.chdir(@upstream) { `git checkout main -q` }
       (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
     end
 
@@ -174,7 +174,7 @@ module Pod
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
       cmd.expects(:validate_podspec_files).returns(true)
       Dir.chdir(temporary_directory) { cmd.run }
-      Dir.chdir(@upstream) { `git checkout master -q` }
+      Dir.chdir(@upstream) { `git checkout main -q` }
       (@upstream + 'PushTest/1.4/PushTest.podspec.json').read.should.include('PushTest')
     end
 

--- a/spec/functional/command/repo/update_spec.rb
+++ b/spec/functional/command/repo/update_spec.rb
@@ -18,7 +18,7 @@ module Pod
         Pod::Executable.capture_command!('git', %W(remote add origin #{upstream}))
         Pod::Executable.capture_command!('git', %w(remote -v))
         Pod::Executable.capture_command!('git', %w(fetch -q))
-        Pod::Executable.capture_command!('git', %w(branch --set-upstream-to=origin/master master))
+        Pod::Executable.capture_command!('git', %w(branch --set-upstream-to=origin/main main))
       end
       config.sources_manager.expects(:update_search_index_if_needed_in_background).with({}).returns(nil)
       lambda { command('repo', 'update').run }.should.not.raise

--- a/spec/spec_helper/temporary_repos.rb
+++ b/spec/spec_helper/temporary_repos.rb
@@ -20,6 +20,7 @@ module SpecHelper
       path.mkpath
       Dir.chdir(path) do
         Pod::Executable.capture_command!('git', %w(init))
+        Pod::Executable.capture_command!('git', %w(checkout -b main))
         repo_make_readme_change(name, 'Added')
         Pod::Executable.capture_command!('git', %w(add .))
         Pod::Executable.capture_command!('git', %w(commit -nm Initialized.))

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -360,16 +360,6 @@ module Pod
                     include 'Unable to install the `WatermelonLib` pod, because the `WatermelonLib-App` target in Xcode would have no sources to compile.'
               end
 
-              it 'adds swiftSwiftOnoneSupport ld flag to the debug configuration' do
-                @watermelon_ios_pod_target.stubs(:uses_swift?).returns(true)
-                @ios_installer.install!
-                test_native_target = @project.targets[1]
-                debug_configuration = test_native_target.build_configurations.find(&:debug?)
-                debug_configuration.build_settings['OTHER_LDFLAGS'].should == '$(inherited) -lswiftSwiftOnoneSupport'
-                release_configuration = test_native_target.build_configurations.find { |bc| bc.type == :release }
-                release_configuration.build_settings['OTHER_LDFLAGS'].should.be.nil
-              end
-
               it 'adds files to build phases correctly depending on the native target' do
                 @ios_installer.install!
                 @project.targets.count.should == 9

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -399,13 +399,12 @@ module Pod
 
           it 'includes default runpath search path list for a non host target' do
             @target.stubs(:requires_host_target?).returns(false)
-            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'"
+            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) /usr/lib/swift '@executable_path/Frameworks' '@loader_path/Frameworks'"
           end
 
           it 'includes default runpath search path list for a host target' do
             @target.stubs(:requires_host_target?).returns(true)
-            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks' '@executable_path/../../Frameworks' " \
-              '"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}" "$(PLATFORM_DIR)/Developer/Library/Frameworks"'
+            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) /usr/lib/swift '@executable_path/Frameworks' '@loader_path/Frameworks' '@executable_path/../../Frameworks'"
           end
 
           it 'includes correct default runpath search path list for OSX unit test bundle user target' do
@@ -413,7 +412,7 @@ module Pod
             mock_user_target = mock('usertarget')
             mock_user_target.stubs(:symbol_type).returns(:unit_test_bundle)
             @target.stubs(:user_targets).returns([mock_user_target])
-            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks' \"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\""
+            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == %q[$(inherited) /usr/lib/swift "$(PLATFORM_DIR)/Developer/Library/Frameworks" '@executable_path/../Frameworks' '@loader_path/../Frameworks' "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"]
           end
 
           it 'includes correct default runpath search path list for OSX application user target' do
@@ -421,7 +420,7 @@ module Pod
             mock_user_target = mock('usertarget')
             mock_user_target.stubs(:symbol_type).returns(:application)
             @target.stubs(:user_targets).returns([mock_user_target])
-            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/../Frameworks' '@loader_path/Frameworks'"
+            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == %q[$(inherited) /usr/lib/swift '@executable_path/../Frameworks' '@loader_path/Frameworks' "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"]
           end
 
           it 'uses the target definition swift version' do

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -404,7 +404,8 @@ module Pod
 
           it 'includes default runpath search path list for a host target' do
             @target.stubs(:requires_host_target?).returns(true)
-            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks' '@executable_path/../../Frameworks'"
+            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks' '@executable_path/../../Frameworks' " \
+              '"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}" "$(PLATFORM_DIR)/Developer/Library/Frameworks"'
           end
 
           it 'includes correct default runpath search path list for OSX unit test bundle user target' do
@@ -412,7 +413,7 @@ module Pod
             mock_user_target = mock('usertarget')
             mock_user_target.stubs(:symbol_type).returns(:unit_test_bundle)
             @target.stubs(:user_targets).returns([mock_user_target])
-            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks'"
+            @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks' \"${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}\""
           end
 
           it 'includes correct default runpath search path list for OSX application user target' do


### PR DESCRIPTION
* Allow building app & test spec targets that depend on a library that uses
  Swift without requiring an empty Swift file be present.  
