### PR TITLE
Resolve new Xcode 12 deployment target warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Resolve new Xcode 12 deployment target warning  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#9392](https://github.com/CocoaPods/CocoaPods/issues/9884) 
 
 ## 1.10.0.rc.1 (2020-09-15)
 

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -860,6 +860,8 @@ module Pod
           minimum = Version.new('8.0')
           deployment_target = [deployment_target, minimum].max
         end
+        # Set deployment_target to max of the Podfile and podspec specifications.
+        deployment_target = [deployment_target, target_definitions.first.platform.deployment_target].max
         Platform.new(platform_name, deployment_target)
       end
 


### PR DESCRIPTION
Fix #9884

Sets deployment_target to max of the Podfile and podspec specifications

Integration test PR at https://github.com/CocoaPods/cocoapods-integration-specs/pull/294