### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Tests
         run: bundle exec rake spec:all
         env: 
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COCOAPODS_CI_TASKS: LINT
 
 on:

--- a/spec/integration.rb
+++ b/spec/integration.rb
@@ -175,23 +175,8 @@ describe_cli 'pod' do
     # they are somewhat non-deteministic and non-essential to testing integration
     s.replace_pattern /.*CDN:.*\n/, ''
 
-    # get rid of the git warning about detached HEAD as it is user-configurable
-    s.replace_pattern /\s+Note: (checking out|switching to) \'.*\'\./, ''
-    s.replace_pattern /\s+You are in \'detached HEAD\' state\. You can look around, make experimental/, ''
-    s.replace_pattern /\s+changes and commit them, and you can discard any commits you make in this/, ''
-    s.replace_pattern /\s+state without impacting any branches by performing another checkout\./, ''
-    s.replace_pattern /\s+state without impacting any branches by switching back to a branch\./, ''
-    s.replace_pattern /\s+If you want to create a new branch to retain commits you create, you may/, ''
-    s.replace_pattern /\s+do so \(now or later\) by using -b with the checkout command again. Example:/, ''
-    s.replace_pattern /\s+do so \(now or later\) by using -c with the switch command. Example:/, ''
-    s.replace_pattern /\s+(git checkout -b new_branch_name\n|git switch -c <new-branch-name>)/, ''
-    s.replace_pattern /\s+If you want to create a new branch to retain commits you create, you may/, ''
-    s.replace_pattern /\s+Or undo this operation with:/, ''
-    s.replace_pattern /\s+git switch \-/, ''
-    s.replace_pattern /\s+Turn off this advice by setting config variable advice.detachedHead to false\n/, ''
-
-    # remove more git noise
-    s.replace_pattern /\s*Updating files:  .*\% \(.*\)\s*/, ''
+    # replace all git downloader output with just the command
+    s.replace_pattern %r{ > Git download\n(     \$ GIT_BIN [^\n]+\n)(     [^\n]*\n|\n)+}m, " > Git download\n\\1\n"
   end
 
   describe 'Pod install' do


### PR DESCRIPTION
* replace a tower of regex with one pattern that suppresses all git downloader output except command line
* fix GH token for Danger

Explanation for the git back-and-forth:  
Different CI runners have different git version that differ in output and warnings (detached HEAD, progress printing).  
This PR ensures that all the output coming from the `Git` pod downloader is limited to the git command invocation string and removes all subsequent lines.