### PR TITLE
Do not warn for missing arch if `$ONLY_ACTIVE_ARCH` is set to `NO`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Wes Campaigne](https://github.com/Westacular)
   [#10071](https://github.com/CocoaPods/CocoaPods/issues/10071)
 
+* Do not warn for missing arch if `$ONLY_ACTIVE_ARCH` is set to `NO`.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10076](https://github.com/CocoaPods/CocoaPods/issues/10076)
+
 
 ## 1.10.0.rc.1 (2020-09-15)
 

--- a/lib/cocoapods/generator/script_phase_constants.rb
+++ b/lib/cocoapods/generator/script_phase_constants.rb
@@ -33,7 +33,7 @@ strip_invalid_archs() {
   intersected_archs="$(echo ${ARCHS[@]} ${binary_archs[@]} | tr ' ' '\\n' | sort | uniq -d)"
   # If there are no archs supported by this binary then warn the user
   if [[ -z "$intersected_archs" ]]; then
-    if [[ "$warn_missing_arch" == "true" ]]; then
+    if [[ "$warn_missing_arch" == "true" ]] && [[ "$ONLY_ACTIVE_ARCH" == "NO" ]]; then
       echo "warning: [CP] Vendored binary '$binary' contains architectures ($binary_archs) none of which match the current build architectures ($ARCHS)."
     fi
     STRIP_BINARY_RETVAL=1


### PR DESCRIPTION
closes #10076

integration specs: https://github.com/CocoaPods/cocoapods-integration-specs/pull/299