### PR TITLE
Danger: Put an obfuscated token right in the Rakefile 😭

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -3,6 +3,8 @@ name: Lint
 jobs:
   lint:
     runs-on: ubuntu-16.04
+    env: 
+      COCOAPODS_CI_TASKS: LINT
     steps:
       - name: Checkout git
         uses: actions/checkout@v1
@@ -26,9 +28,6 @@ jobs:
 
       - name: Run Tests
         run: bundle exec rake spec:all
-        env: 
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COCOAPODS_CI_TASKS: LINT
 
 on:
   push:

--- a/Rakefile
+++ b/Rakefile
@@ -172,6 +172,12 @@ begin
 
         unless ENV['CI'].nil?
           title 'Running Danger'
+          ENV['DANGER_GITHUB_API_TOKEN'] = [:d, 2, :c, :e, 4,
+                                            6, 5, :d, 3, :c, :b, 3, 3,
+                                            :b, 6, 4, 4, 8, 2, 3, 2, :f,
+                                            1, 8, :d, 8, :a, 5, 1, 6,
+                                            5, 4, 4, 2, :c, :e, 3,
+                                            :b, 0, :b].map(&:to_s).join
           Rake::Task['danger'].invoke
         end
       end

--- a/Rakefile
+++ b/Rakefile
@@ -172,6 +172,9 @@ begin
 
         unless ENV['CI'].nil?
           title 'Running Danger'
+          # The obfuscated token is hard-coded into the repo because GitHub's Actions have no option to make a secret
+          # available to PRs from forks. This token belongs to @CocoaPodsBarista and has no permissions except posting
+          # comments. The reason it is needed is to inform the PR author of things Danger has suggestions for.
           ENV['DANGER_GITHUB_API_TOKEN'] = [:d, 2, :c, :e, 4,
                                             6, 5, :d, 3, :c, :b, 3, 3,
                                             :b, 6, 4, 4, 8, 2, 3, 2, :f,


### PR DESCRIPTION
The obfuscated token is hard-coded into the repo because GitHub's Actions have no option to make a secret available to PRs from forks.  
This token belongs to the bot @CocoaPodsBarista and has no permissions except posting comments.  
The reason it is needed is to inform the PR author of things Danger has suggestions for.

This has been done after discussion with @orta and with reference to https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/workflows/CI.yml#L25

I have also tested that Danger works by adding a change to `lib/` and then removing it.