### PR TITLE
#10111 - Update XCFramework installation to support Xcode 12 debug symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Wes Campaigne](https://github.com/Westacular)
   [#10071](https://github.com/CocoaPods/CocoaPods/issues/10071)
 
+* Add support for automatically embeddeding XCFramework debug symbols for XCFrameworks generated with Xcode 12  
+  [johntmcintosh](https://github.com/johntmcintosh)
+  [#10111](https://github.com/CocoaPods/CocoaPods/issues/10111)
 
 ## 1.10.0.rc.1 (2020-09-15)
 

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -194,12 +194,8 @@ install_xcframework() {
     mkdir -p "$destination"
   fi
 
-  if [[ "$package_type" == "library" ]]; then
-    # Libraries can contain headers, module maps, and a binary, so we'll copy everything in the folder over
-    copy_dir "$source/" "$destination"
-  elif [[ "$package_type" == "framework" ]]; then
-    copy_dir "$source" "$destination"
-  fi
+  copy_dir "$source/" "$destination"
+
   echo "Copied $source to $destination"
 }
 
@@ -226,12 +222,7 @@ install_xcframework() {
         is_framework = xcframework.build_type.framework?
         args << shell_escape(is_framework ? 'framework' : 'library')
         slices.each do |slice|
-          args << if is_framework
-                    shell_escape(slice.path.relative_path_from(root))
-                  else
-                    # We don't want the path to the library binary, we want the dir that contains it
-                    shell_escape(slice.path.dirname.relative_path_from(root))
-                  end
+          args << shell_escape(slice.path.dirname.relative_path_from(root))
         end
         args.join(' ')
       end

--- a/spec/unit/generator/copy_xcframeworks_script_spec.rb
+++ b/spec/unit/generator/copy_xcframeworks_script_spec.rb
@@ -6,7 +6,7 @@ module Pod
       xcframework = Xcode::XCFramework.new(fixture('CoconutLib.xcframework'))
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.ios)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "ios-armv7_arm64/CoconutLib.framework" "ios-i386_x86_64-simulator/CoconutLib.framework"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "ios-armv7_arm64" "ios-i386_x86_64-simulator"
       SH
     end
 
@@ -14,19 +14,19 @@ module Pod
       xcframework = Xcode::XCFramework.new(fixture('CoconutLib.xcframework'))
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.macos)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "macos-x86_64/CoconutLib.framework"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "macos-x86_64"
       SH
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.ios)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "ios-armv7_arm64/CoconutLib.framework" "ios-i386_x86_64-simulator/CoconutLib.framework"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "ios-armv7_arm64" "ios-i386_x86_64-simulator"
       SH
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.watchos)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "watchos-i386-simulator/CoconutLib.framework" "watchos-armv7k_arm64_32/CoconutLib.framework"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "watchos-i386-simulator" "watchos-armv7k_arm64_32"
       SH
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.tvos)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "tvos-x86_64-simulator/CoconutLib.framework" "tvos-arm64/CoconutLib.framework"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "tvos-x86_64-simulator" "tvos-arm64"
       SH
     end
 


### PR DESCRIPTION
#10111 - Update XCFramework installation to support Xcode 12 debug symbols placed as siblings of the .framework inside each architecture's directory

Related integration-specs PR: https://github.com/CocoaPods/cocoapods-integration-specs/pull/301