### PR TITLE
Remove unused generate install_xcframework_library function

### DIFF
--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -157,22 +157,6 @@ install_framework()
   echo "Copied $source to $destination"
 }
 
-install_xcframework_library() {
-  local basepath="$1"
-  local name="$2"
-  local paths=("$@")
-
-  # Locate the correct slice of the .xcframework for the current architectures
-  select_slice "${paths[@]}"
-  local target_path="$SELECT_SLICE_RETVAL"
-  if [[ -z "$target_path" ]]; then
-    echo "warning: [CP] Unable to find matching .xcframework slice in '${paths[@]}' for the current build architectures ($ARCHS)."
-    return
-  fi
-
-  install_framework "$basepath/$target_path" "$name"
-}
-
 install_xcframework() {
   local basepath="$1"
   local name="$2"


### PR DESCRIPTION
I was hunting down the source of a "`[CP] Unable to find matching .xcframework slice in...`" warning when I noticed that the string appears twice in the generated `-xcframework.sh` script. In particular, in the `install_xcframework_library()` and `install_xcframework()` functions.

The former doesn't have any usages in the script and removing it didn't compromise the script execution in my project.

I also run `git grep install_xcframework_*` and couldn't find any usage or any interpolation that might have resulted in it being called.

<details>
<summary>Click to reveal `git grep` output</summary>

```
lib/cocoapods/generator/copy_xcframework_script.rb:install_xcframework_library() {
lib/cocoapods/generator/copy_xcframework_script.rb:install_xcframework() {
lib/cocoapods/generator/copy_xcframework_script.rb:          args = install_xcframework_args(xcframework, slices)
lib/cocoapods/generator/copy_xcframework_script.rb:          script << "install_xcframework #{args}\n"
lib/cocoapods/generator/copy_xcframework_script.rb:      def install_xcframework_args(xcframework, slices)
spec/unit/generator/copy_xcframeworks_script_spec.rb:        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "ios-armv7_arm64/CoconutLib.framework" "ios-i386_x86_64-simulator/CoconutLib.framework"
spec/unit/generator/copy_xcframeworks_script_spec.rb:        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "macos-x86_64/CoconutLib.framework"
spec/unit/generator/copy_xcframeworks_script_spec.rb:        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "ios-armv7_arm64/CoconutLib.framework" "ios-i386_x86_64-simulator/CoconutLib.framework"
spec/unit/generator/copy_xcframeworks_script_spec.rb:        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "watchos-i386-simulator/CoconutLib.framework" "watchos-armv7k_arm64_32/CoconutLib.framework"
spec/unit/generator/copy_xcframeworks_script_spec.rb:        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "tvos-x86_64-simulator/CoconutLib.framework" "tvos-arm64/CoconutLib.framework"
spec/unit/generator/copy_xcframeworks_script_spec.rb:      # Second argument to `install_xcframework` is a boolean indicating whether to embed the framework
```

</details>

Because of all that, I think it's safe to remove it. 

Please tell me if I'm wrong, and feel free to close the PR 😄 .