### PR TITLE
Do not add dependencies to 'Link Binary With Libraries' phase.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not add dependencies to 'Link Binary With Libraries' phase.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10133](https://github.com/CocoaPods/CocoaPods/pull/10133)
+
 * Ensure cache integrity on concurrent installations.  
   [Erik Blomqvist](https://github.com/codiophile)
   [#10013](https://github.com/CocoaPods/CocoaPods/issues/10013)

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -624,9 +624,15 @@ module Pod
                 select { |xcf| xcf.build_type.static_framework? }.
                 map(&:name).
                 uniq
+
+              # Include direct dynamic dependencies to the linker flags. We used to add those in the 'Link Binary With Libraries'
+              # phase but we no longer do since we cannot differentiate between debug or release configurations within
+              # that phase.
+              frameworks.concat target.dependent_targets_by_config[@configuration].flat_map { |pt| pt.build_settings[@configuration].dynamic_frameworks_to_import }
+            else
+              # Also include any vendored dynamic frameworks of dependencies.
+              frameworks.concat dependent_targets.reject(&:should_build?).flat_map { |pt| pt.build_settings[@configuration].dynamic_frameworks_to_import }
             end
-            # Also include any vendored dynamic frameworks of dependencies.
-            frameworks.concat dependent_targets.reject(&:should_build?).flat_map { |pt| pt.build_settings[@configuration].dynamic_frameworks_to_import }
           else
             frameworks.concat dependent_targets_to_link.flat_map { |pt| pt.build_settings[@configuration].frameworks_to_import }
           end

--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -468,7 +468,7 @@ module Pod
               message.should.include '`CoconutLib-iOS-unit-Tests` manually specifies an app host but has not specified `requires_app_host = true`.'
           end
 
-          it 'adds framework file references for framework pod targets that require building' do
+          it 'does not add framework file references for framework pod targets that require building' do
             @orangeframework_pod_target.stubs(:build_type => BuildType.dynamic_framework)
             @coconut_ios_pod_target.stubs(:build_type => BuildType.dynamic_framework)
             @coconut_ios_pod_target.stubs(:should_build?).returns(true)
@@ -479,7 +479,6 @@ module Pod
             native_target.isa.should == 'PBXNativeTarget'
             native_target.frameworks_build_phase.file_display_names.sort.should == [
               'Foundation.framework',
-              'OrangeFramework.framework',
             ]
           end
 

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -336,7 +336,7 @@ module Pod
               message.should.include '`CoconutLib-iOS-unit-Tests` manually specifies an app host but has not specified `requires_app_host = true`.'
           end
 
-          it 'adds framework file references for framework pod targets that require building' do
+          it 'does not add framework file references for framework pod targets that require building' do
             @orangeframework_pod_target.stubs(:build_type).returns(BuildType.dynamic_framework)
             @coconut_ios_pod_target.stubs(:build_type).returns(BuildType.dynamic_framework)
             @coconut_ios_pod_target.stubs(:should_build?).returns(true)
@@ -345,7 +345,6 @@ module Pod
             native_target.isa.should == 'PBXNativeTarget'
             native_target.frameworks_build_phase.file_display_names.sort.should == [
               'Foundation.framework',
-              'OrangeFramework.framework',
             ]
           end
 

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -236,6 +236,7 @@ module Pod
                                  :vendored_static_libraries => [config.sandbox.root + 'StaticLibrary.a'],
                                  :vendored_dynamic_frameworks => [config.sandbox.root + 'VendoredFramework.framework'],
                                  :vendored_dynamic_libraries => [config.sandbox.root + 'VendoredDyld.dyld'],
+                                 :vendored_xcframeworks => [],
                                 )
             pod_target = stub('pod_target',
                               :file_accessors => [file_accessor],
@@ -253,7 +254,7 @@ module Pod
             @generator.spec_consumers.each { |sc| sc.stubs(:frameworks => []) }
             @generator.stubs(:dependent_targets => [pod_target])
             @generator.other_ldflags.should.
-              be == %w(-l"BananaStaticLib" -l"xml2" -framework "BananaFramework" -weak_framework "iAd")
+              be == %w(-l"BananaStaticLib" -l"xml2" -framework "BananaFramework" -framework "VendoredFramework" -framework "dynamic-monkey" -weak_framework "iAd")
           end
         end
 


### PR DESCRIPTION
With the introduction of per-configuration dependencies, we cant add dependencies to 'Link Binary With Libraries' phase in Xcode because Xcode cannot differentiate between adding a dependency for only DEBUG or only RELEASE.

We rely on CocoaPods xcconfig to provide all linker flags and we maintain the part that we add dependencies in the 'Dependencies' phase as we expect them to be built so we can then embed them to targets.

@paulb777 I'd appreciate if you have the time to run this change against your Firebase CI as this code is kinda old...

This is for 1.11.0 so it will be a while before it ships.

Integration specs: https://github.com/CocoaPods/cocoapods-integration-specs/pull/302