### PR TITLE
Fix processing of xcassets resources when pod target is static framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix processing of xcassets resources when pod target is static framework  
+  [Federico Trimboli](https://github.com/fedetrim)
+  [#10175](https://github.com/CocoaPods/CocoaPods/pull/10175)
+  [#10170](https://github.com/CocoaPods/CocoaPods/issues/10170)
 
 
 ## 1.10.0 (2020-10-20)

--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -350,7 +350,7 @@ module Pod
     end
 
     def self.resource_extension_compilable?(input_extension)
-      output_extension_for_resource(input_extension) != input_extension
+      output_extension_for_resource(input_extension) != input_extension && input_extension != '.xcassets'
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -772,6 +772,24 @@ module Pod
               resource.should.be.nil
             end
 
+            it 'doesn\'t add xcassets resources to the static framework target' do
+              @pod_target.stubs(:build_type => BuildType.static_framework)
+              @installer.install!
+              resources = @project.targets.first.resources_build_phase.files
+              resources.count.should > 0
+              resource = resources.find { |res| res.file_ref.path.include?('Images.xcassets') }
+              resource.should.be.nil
+            end
+
+            it 'adds xcassets resources to the dynamic framework target' do
+              @pod_target.stubs(:build_type => BuildType.dynamic_framework)
+              @installer.install!
+              resources = @project.targets.first.resources_build_phase.files
+              resources.count.should > 0
+              resource = resources.find { |res| res.file_ref.path.include?('Images.xcassets') }
+              resource.should.be.not.nil
+            end
+
             it 'includes spec info_plist entries for dynamic frameworks' do
               @pod_target.stubs(:build_type => BuildType.dynamic_framework)
               expected_entries = {

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -199,6 +199,17 @@ module Pod
           resource_paths_by_config['Release'].should == expected_files
         end
 
+        it 'checks xcassets resource paths are not converted for static frameworks' do
+          @pod_target.stubs(:should_build?).returns(true)
+          @pod_target.stubs(:build_type => BuildType.static_framework)
+          @pod_target.stubs(:resource_paths).returns('BananaLib' => ['/some/absolute/path/to/Images.xcassets'])
+          @target.stubs(:bridge_support_file).returns(nil)
+          resource_paths_by_config = @target.resource_paths_by_config
+          expected_files = ['/some/absolute/path/to/Images.xcassets']
+          resource_paths_by_config['Debug'].should == expected_files
+          resource_paths_by_config['Release'].should == expected_files
+        end
+
         it 'returns non vendored frameworks by config with different release and debug targets' do
           @pod_target_release.stubs(:should_build?).returns(true)
           @pod_target_release.stubs(:build_type => BuildType.dynamic_framework)


### PR DESCRIPTION
#9441 introduced an optimization for static framework pod targets by copying compiled resources (storyboards, xcdatamodels, etc) instead of the original resources and therefore avoiding duplicate work (once in the framework's `Copy Bundle Resources` phase, and another in the final target's integration phase `[CP] Copy Pods Resources`).

This optimization assumes that each `<name>.xcassets` has a compiled `<name>.car` counterpart, and that you can have many `.car` files in a single bundle.
However, in reality, all `<name>.xcassets` from the same framework are merged and compiled into a single `Assets.car`, meaning that the  `[CP] Copy Pods Resources` integration phase is failing because it's not able to find the compiled resources:
<img width="1062" alt="Screen Shot 2020-10-28 at 16 58 31" src="https://user-images.githubusercontent.com/3900360/97462321-dd83c800-193e-11eb-8abd-0d3cc76f4080.png">

With the failing piece of code being within `Pods-<target>-resources.sh`:
```ruby
if [[ "$CONFIGURATION" == "Debug" ]]; then
  install_resource "${BUILT_PRODUCTS_DIR}/DevPod/DevPod.framework/AnotherOne.car"
  install_resource "${BUILT_PRODUCTS_DIR}/DevPod/DevPod.framework/Images.car"
fi
```

In order for that to not fail, it should look like this:
```ruby
if [[ "$CONFIGURATION" == "Debug" ]]; then
  install_resource "${BUILT_PRODUCTS_DIR}/DevPod/DevPod.framework/Assets.car"
fi
```

Even if we addressed that issue by correcting the path of the compiled resources, we still wouldn't be able to copy more than one `Assets.car` (one per each framework) to the main bundle.

The only way of handling xcassets is by merging+building them all at once, and then copying that single `Assets.car` to the main bundle (which is what was being done before this optimization).

This PR solves the issue by adding the original xcassets back to being processed by the `[CP] Copy Pods Resources` integration phase, and removes the resources from the frameworks' `Copy Bundle Resources` phase so that the compiling is only done once.

Closes #10170