### PR TITLE
Add a new option for updating sources before a podspec push action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add a `--update-sources` option to `pod repo push` so one can ensure sources are up-to-date. 
+  [Elton Gao](https://github.com/gyfelton)
+  [Justin Martin](https://github.com/justinseanmartin)
+  
 * Installing a local (`:path`) pod that defines script phases will no longer
   produce warnings.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -180,12 +180,16 @@ module Pod
           git!(%W(-C #{repo_dir} pull))
         end
 
+        # Update sources if present
+        #
+        # @return [void]
+        #
         def update_sources
           return if @source_urls.nil?
           @source_urls.each do |source_url|
             source = config.sources_manager.source_with_name_or_url(source_url)
             dir = source.specs_dir
-            UI.puts "Updating source at #{dir} for #{source}"
+            UI.puts "Updating a source at #{dir} for #{source}"
             git!(%W(-C #{dir} pull))
           end
         end

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -178,6 +178,16 @@ module Pod
       (@upstream + 'PushTest/1.4/PushTest.podspec.json').read.should.include('PushTest')
     end
 
+    it 'successfully pushes a spec with flag update-sources' do
+      cmd = command('repo', 'push', 'master', '--update-sources')
+      Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
+      cmd.expects(:validate_podspec_files).returns(true)
+      cmd.expects(:update_sources)
+      Dir.chdir(temporary_directory) { cmd.run }
+      Dir.chdir(@upstream) { `git checkout main -q` }
+      cmd.instance_variable_get(:@update_sources).should.equal true
+    end
+
     it 'initializes with default sources if no custom sources specified' do
       cmd = command('repo', 'push', 'master')
       cmd.instance_variable_get(:@source_urls).should.equal [@upstream.to_s, Pod::TrunkSource::TRUNK_REPO_URL]


### PR DESCRIPTION
### why this change
When there are sources specified, there are some cases where the source repo is not up-to-date. One case for this is that there is a previous spec gets pushed that the current spec pending to be pushed depending on. This option only has effect if sources are specified and it does a `git pull` just like `update_repo` 

### Tests
Added some spec to ensure the flag and method are set/called when this option is specified. 