### PR TITLE
Fix Archive failures when using header_mappings_dir and Catalyst

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -237,7 +237,7 @@ Lint/UselessAccessModifier:
 # Offense count: 373
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 1476
+  Max: 1493
 
 # Offense count: 7099
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix errors when archiving a Catalyst app which depends on a pod which uses header_mappings_dir.  
+  [Thomas Goyne](https://github.com/tgoyne)
+  [#10016](https://github.com/CocoaPods/CocoaPods/pull/10016)
 
 ## 1.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * Fix errors when archiving a Catalyst app which depends on a pod which uses header_mappings_dir.  
   [Thomas Goyne](https://github.com/tgoyne)
-  [#10016](https://github.com/CocoaPods/CocoaPods/pull/10016)
+  [#10224](https://github.com/CocoaPods/CocoaPods/pull/10224)
 
 ## 1.10.2
 

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
@@ -9,16 +9,24 @@
 /* Begin PBXBuildFile section */
 		295BB5621CEA95DE00E79F82 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295BB5611CEA95DE00E79F82 /* AppDelegate.swift */; };
 		295BB5641CEA95DE00E79F82 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 295BB5631CEA95DE00E79F82 /* Assets.xcassets */; };
-		44CEACDCCD13E316EE074DA1 /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD4F2DCE25281A4C3DAC43C7 /* Pods_App.framework */; };
+		3F49FDA22566CB6000DB4C28 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295BB5611CEA95DE00E79F82 /* AppDelegate.swift */; };
+		3F49FDA62566CB6000DB4C28 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 295BB5631CEA95DE00E79F82 /* Assets.xcassets */; };
+		44CEACDCCD13E316EE074DA1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		B4B33EF6E0070B20B05555D6 /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F60F2D3508AE8ED06682EB7 /* Pods_App.framework */; };
+		D58F29E1D5E5C3BFD7A7BFBC /* Pods_CatalystApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FD0F347465854673E869234 /* Pods_CatalystApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0DFB53AE16B90D7F289BBEC2 /* Pods-CatalystApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CatalystApp.debug.xcconfig"; path = "Target Support Files/Pods-CatalystApp/Pods-CatalystApp.debug.xcconfig"; sourceTree = "<group>"; };
 		295BB55E1CEA95DE00E79F82 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		295BB5611CEA95DE00E79F82 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		295BB5631CEA95DE00E79F82 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		295BB5681CEA95DE00E79F82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3F49FDAB2566CB6000DB4C28 /* CatalystApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CatalystApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F60F2D3508AE8ED06682EB7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FD0F347465854673E869234 /* Pods_CatalystApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CatalystApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8914945168DAAA34EFE099AF /* Pods-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.release.xcconfig"; path = "Target Support Files/Pods-App/Pods-App.release.xcconfig"; sourceTree = "<group>"; };
-		AD4F2DCE25281A4C3DAC43C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A695CAA98C383BCC61786E74 /* Pods-CatalystApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CatalystApp.release.xcconfig"; path = "Target Support Files/Pods-CatalystApp/Pods-CatalystApp.release.xcconfig"; sourceTree = "<group>"; };
 		E1928C2D408B1D2E8B3E2FA3 /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -27,7 +35,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				44CEACDCCD13E316EE074DA1 /* Pods_App.framework in Frameworks */,
+				44CEACDCCD13E316EE074DA1 /* BuildFile in Frameworks */,
+				B4B33EF6E0070B20B05555D6 /* Pods_App.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3F49FDA32566CB6000DB4C28 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D58F29E1D5E5C3BFD7A7BFBC /* Pods_CatalystApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37,10 +54,10 @@
 		295BB5551CEA95DE00E79F82 = {
 			isa = PBXGroup;
 			children = (
-				295BB5601CEA95DE00E79F82 /* HeaderMappingsDir Example */,
-				295BB55F1CEA95DE00E79F82 /* Products */,
-				66AD76830CE2BBB6379CA47B /* Pods */,
 				83215639ECD12CBC1F4DC4E3 /* Frameworks */,
+				295BB5601CEA95DE00E79F82 /* HeaderMappingsDir Example */,
+				66AD76830CE2BBB6379CA47B /* Pods */,
+				295BB55F1CEA95DE00E79F82 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
@@ -48,6 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				295BB55E1CEA95DE00E79F82 /* App.app */,
+				3F49FDAB2566CB6000DB4C28 /* CatalystApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -67,15 +85,17 @@
 			children = (
 				E1928C2D408B1D2E8B3E2FA3 /* Pods-App.debug.xcconfig */,
 				8914945168DAAA34EFE099AF /* Pods-App.release.xcconfig */,
+				0DFB53AE16B90D7F289BBEC2 /* Pods-CatalystApp.debug.xcconfig */,
+				A695CAA98C383BCC61786E74 /* Pods-CatalystApp.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
 		83215639ECD12CBC1F4DC4E3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				AD4F2DCE25281A4C3DAC43C7 /* Pods_App.framework */,
+				4F60F2D3508AE8ED06682EB7 /* Pods_App.framework */,
+				6FD0F347465854673E869234 /* Pods_CatalystApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -102,6 +122,25 @@
 			productReference = 295BB55E1CEA95DE00E79F82 /* App.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3F49FD9F2566CB6000DB4C28 /* CatalystApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3F49FDA82566CB6000DB4C28 /* Build configuration list for PBXNativeTarget "CatalystApp" */;
+			buildPhases = (
+				3F49FDA02566CB6000DB4C28 /* [CP] Check Pods Manifest.lock */,
+				3F49FDA12566CB6000DB4C28 /* Sources */,
+				3F49FDA32566CB6000DB4C28 /* Frameworks */,
+				3F49FDA52566CB6000DB4C28 /* Resources */,
+				3F49FDA72566CB6000DB4C28 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CatalystApp;
+			productName = "HeaderMappingsDir Example";
+			productReference = 3F49FDAB2566CB6000DB4C28 /* CatalystApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -122,6 +161,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -131,6 +171,7 @@
 			projectRoot = "";
 			targets = (
 				295BB55D1CEA95DE00E79F82 /* App */,
+				3F49FD9F2566CB6000DB4C28 /* CatalystApp */,
 			);
 		};
 /* End PBXProject section */
@@ -144,9 +185,53 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3F49FDA52566CB6000DB4C28 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F49FDA62566CB6000DB4C28 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3F49FDA02566CB6000DB4C28 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CatalystApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3F49FDA72566CB6000DB4C28 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CatalystApp/Pods-CatalystApp-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/HeaderMappingsDirPod-iOS/HeaderMappingsDirPod.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/HeaderMappingsDirPod.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CatalystApp/Pods-CatalystApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		62E9CD52D31153978437D4C2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -172,7 +257,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App/Pods-App-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HeaderMappingsDirPod/HeaderMappingsDirPod.framework",
+				"${BUILT_PRODUCTS_DIR}/HeaderMappingsDirPod-macOS/HeaderMappingsDirPod.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -191,6 +276,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				295BB5621CEA95DE00E79F82 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3F49FDA12566CB6000DB4C28 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F49FDA22566CB6000DB4C28 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,7 +338,8 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 			};
@@ -292,7 +386,8 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = macosx;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 			};
@@ -308,6 +403,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,4";
 			};
 			name = Debug;
 		};
@@ -321,6 +419,39 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,4";
+			};
+			name = Release;
+		};
+		3F49FDA92566CB6000DB4C28 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0DFB53AE16B90D7F289BBEC2 /* Pods-CatalystApp.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "HeaderMappingsDir Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,4";
+			};
+			name = Debug;
+		};
+		3F49FDAA2566CB6000DB4C28 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A695CAA98C383BCC61786E74 /* Pods-CatalystApp.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "HeaderMappingsDir Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,4";
 			};
 			name = Release;
 		};
@@ -341,6 +472,15 @@
 			buildConfigurations = (
 				295BB56C1CEA95DE00E79F82 /* Debug */,
 				295BB56D1CEA95DE00E79F82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3F49FDA82566CB6000DB4C28 /* Build configuration list for PBXNativeTarget "CatalystApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F49FDA92566CB6000DB4C28 /* Debug */,
+				3F49FDAA2566CB6000DB4C28 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example/AppDelegate.swift
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example/AppDelegate.swift
@@ -1,10 +1,23 @@
-import Cocoa
+
 import HeaderMappingsDirPod
 import HeaderMappingsDirPod.Private
 
+#if os(iOS)
+
+import UIKit
+@UIApplicationMain
+class AppDelegate: NSObject, UIApplicationDelegate {
+
+    @IBOutlet weak var window: UIWindow?
+}
+
+#else
+
+import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var window: NSWindow!
 }
 
+#endif

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDirPod/HeaderMappingsDirPod.podspec
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDirPod/HeaderMappingsDirPod.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
   s.preserve_paths          = %w(include)
 
   s.osx.deployment_target   = '10.9'
+  s.ios.deployment_target   = '13.0'
 end

--- a/examples/HeaderMappingsDir Example/Podfile
+++ b/examples/HeaderMappingsDir Example/Podfile
@@ -2,12 +2,17 @@ if (repo = ENV['COCOAPODS_SPEC_REPO'])
     source "#{repo}"
 end
 
-platform :osx, '10.9'
 use_frameworks!
 
 workspace 'Examples.xcworkspace'
 project 'HeaderMappingsDir Example.xcodeproj'
 
 target 'App' do
+  platform :osx, '10.9'
+  pod 'HeaderMappingsDirPod', :path => 'HeaderMappingsDirPod'
+end
+
+target 'CatalystApp' do
+  platform :ios, '13.0'
   pod 'HeaderMappingsDirPod', :path => 'HeaderMappingsDirPod'
 end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -850,7 +850,7 @@ module Pod
           end
 
           # Creates a build phase which links the versioned header folders
-          # of the OS X into the framework bundle's root root directory.
+          # of the OS X framework into the framework bundle's root directory.
           # This is only necessary because the way how headers are copied
           # via custom copy file build phases in combination with
           # header_mappings_dir interferes with xcodebuild's expectations
@@ -862,11 +862,16 @@ module Pod
           # @return [void]
           #
           def create_build_phase_to_symlink_header_folders(native_target)
-            return unless target.platform.name == :osx && any_header_mapping_dirs?
+            # This is required on iOS for Catalyst, which uses macOS framework layouts
+            return unless (target.platform.name == :osx || target.platform.name == :ios) && any_header_mapping_dirs?
 
             build_phase = native_target.new_shell_script_build_phase('Create Symlinks to Header Folders')
             build_phase.shell_script = <<-eos.strip_heredoc
               cd "$CONFIGURATION_BUILD_DIR/$WRAPPER_NAME" || exit 1
+              if [ ! -d Versions ]; then
+                # Not a versioned framework, so no need to do anything
+                exit 0
+              fi
 
               public_path="${PUBLIC_HEADERS_FOLDER_PATH\#\$CONTENTS_FOLDER_PATH/}"
               if [ ! -f "$public_path" ]; then

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -1405,7 +1405,7 @@ module Pod
                 end
 
                 it 'creates a build phase to symlink header folders on iOS' do
-                  @pod_target.stubs(:platform).returns(Platform.osx)
+                  @pod_target.stubs(:platform).returns(Platform.ios)
 
                   @installer.install!
 

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -1282,6 +1282,7 @@ module Pod
                   'Sources',
                   'Frameworks',
                   'Resources',
+                  'Create Symlinks to Header Folders',
                 ]
 
                 copy_files_build_phases = target.copy_files_build_phases.sort_by(&:name)
@@ -1311,6 +1312,18 @@ module Pod
 
               it 'creates a build phase to symlink header folders on OS X' do
                 @pod_target.stubs(:platform).returns(Platform.osx)
+
+                @installer.install!
+
+                target = @project.native_targets.first
+                build_phase = target.shell_script_build_phases.find do |bp|
+                  bp.name == 'Create Symlinks to Header Folders'
+                end
+                build_phase.should.not.be.nil
+              end
+
+              it 'creates a build phase to symlink header folders on iOS' do
+                @pod_target.stubs(:platform).returns(Platform.ios)
 
                 @installer.install!
 
@@ -1380,6 +1393,18 @@ module Pod
                 end
 
                 it 'creates a build phase to symlink header folders on OS X' do
+                  @pod_target.stubs(:platform).returns(Platform.osx)
+
+                  @installer.install!
+
+                  target = @project.native_targets.first
+                  build_phase = target.shell_script_build_phases.find do |bp|
+                    bp.name == 'Create Symlinks to Header Folders'
+                  end
+                  build_phase.should.not.be.nil
+                end
+
+                it 'creates a build phase to symlink header folders on iOS' do
                   @pod_target.stubs(:platform).returns(Platform.osx)
 
                   @installer.install!


### PR DESCRIPTION
Catalyst uses the macOS-style versioned framework layout, so it needs the same workaround for header_mappings_dir as macOS frameworks do. We don't know at install time if a pod will be used with Catalyst, so I made it always add the build step for iOS targets and adjusted the script to do nothing if it's running on a non-versioned framework.

I updated the things added in https://github.com/CocoaPods/CocoaPods/pull/5352 to also test the equivalent thing for iOS, but there doesn't appear to be any existing tests which verify that the end result can actually be archived. I manually tested it on both the example project and on Realm, but is there anything further I should do here test-wise?