### PR TITLE
Set `knownRegions` on generated projects to include all resource localization regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * fix: ensure cached spec path uniq  
   [SolaWing](https://github.com/SolaWing)
   [#10231](https://github.com/CocoaPods/CocoaPods/issues/10231)
+  
+* Set `knownRegions` on generated projects with localized resources to prevent Xcode from re-saving projects to disk.  
+  [Eric Amorde](https://github.com/amorde)
+  [#10290](https://github.com/CocoaPods/CocoaPods/pull/10290)
 
 ## 1.10.0 (2020-10-20)
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -6,6 +6,9 @@ module Pod
         # specifications in the Pods project.
         #
         class FileReferencesInstaller
+          # Regex for extracting the region portion of a localized file path. Ex. `Resources/en.lproj` --> `en`
+          LOCALIZATION_REGION_FILEPATTERN_REGEX = /(\/|^)(?<region>[^\/]*?)\.lproj(\/|$)/
+
           # @return [Sandbox] The sandbox of the installation.
           #
           attr_reader :sandbox
@@ -308,7 +311,7 @@ module Pod
           # @param [Array<PBXFileReferences>] file_references the resource file references
           #
           def add_known_regions(file_references)
-            pattern = /(\/|^)(?<region>[^\/]*?)\.lproj(\/|$)/
+            pattern = LOCALIZATION_REGION_FILEPATTERN_REGEX
             regions = file_references.map do |ref|
               if (match = ref.path.to_s.match(pattern))
                 match[:region]

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -308,7 +308,7 @@ module Pod
           # @param [Array<PBXFileReferences>] file_references the resource file references
           #
           def add_known_regions(file_references)
-            pattern = /.*(\/|^)(?<region>.*)\.lproj(\/|$)/
+            pattern = /(\/|^)(?<region>[^\/]*?)\.lproj(\/|$)/
             regions = file_references.map do |ref|
               if (match = ref.path.to_s.match(pattern))
                 match[:region]

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -126,8 +126,9 @@ module Pod
           #
           def add_resources
             UI.message '- Adding resources' do
-              add_file_accessors_paths_to_pods_group(:resources, :resources, true)
-              add_file_accessors_paths_to_pods_group(:resource_bundle_files, :resources, true)
+              refs = add_file_accessors_paths_to_pods_group(:resources, :resources, true)
+              refs.concat add_file_accessors_paths_to_pods_group(:resource_bundle_files, :resources, true)
+              add_known_regions(refs)
             end
           end
 
@@ -207,20 +208,20 @@ module Pod
           #         Whether organizing a local pod's files in subgroups inside
           #         the pod's group is allowed.
           #
-          # @return [void]
+          # @return [Array<PBXFileReference>] the added file references
           #
           def add_file_accessors_paths_to_pods_group(file_accessor_key, group_key = nil, reflect_file_system_structure = false)
-            file_accessors.each do |file_accessor|
+            file_accessors.flat_map do |file_accessor|
               paths = file_accessor.send(file_accessor_key)
               paths = allowable_project_paths(paths)
-              next if paths.empty?
+              next [] if paths.empty?
 
               pod_name = file_accessor.spec.name
               preserve_pod_file_structure_flag = (sandbox.local?(pod_name) || preserve_pod_file_structure) && reflect_file_system_structure
               base_path = preserve_pod_file_structure_flag ? common_path(paths) : nil
               actual_group_key = preserve_pod_file_structure_flag ? nil : group_key
               group = pods_project.group_for_spec(pod_name, actual_group_key)
-              paths.each do |path|
+              paths.map do |path|
                 pods_project.add_file_reference(path, group, preserve_pod_file_structure_flag, base_path)
               end
             end
@@ -300,6 +301,21 @@ module Pod
             result = Pathname.new(min[0...idx].join('/'))
             # Don't consider "/" a common path
             return result unless result.to_s == '' || result.to_s == '/'
+          end
+
+          # Adds the known localization regions to the root of the project
+          #
+          # @param [Array<PBXFileReferences>] file_references the resource file references
+          #
+          def add_known_regions(file_references)
+            pattern = /.*(\/|^)(?<region>.*)\.lproj(\/|$)/
+            regions = file_references.map do |ref|
+              if (match = ref.path.to_s.match(pattern))
+                match[:region]
+              end
+            end.compact
+
+            pods_project.root_object.known_regions = (pods_project.root_object.known_regions + regions).uniq.sort
           end
 
           #-----------------------------------------------------------------------#

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -315,7 +315,7 @@ module Pod
               end
             end.compact
 
-            pods_project.root_object.known_regions = (pods_project.root_object.known_regions + regions).uniq.sort
+            pods_project.root_object.known_regions = (pods_project.root_object.known_regions | regions).sort
           end
 
           #-----------------------------------------------------------------------#

--- a/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/file_references_installer_spec.rb
@@ -57,6 +57,12 @@ module Pod
               file_ref.path.should == 'Resources/en.lproj'
             end
 
+            it 'adds `knownRegions` for all resource localization regions' do
+              @installer.install!
+              regions = @installer.pods_project.root_object.known_regions
+              regions.sort.should == %w(Base de en)
+            end
+
             it 'adds file references for files within CoreData directories' do
               @installer.install!
               model_ref = @installer.pods_project['Pods/BananaLib/Resources/Sample.xcdatamodeld']


### PR DESCRIPTION
Xcode 11+ will re-save projects generated by CocoaPods when localizations other than the defaults (en & Base) exist in order to update `knownRegions` on the pods project(s). This is problematic for larger projects that use multi-project generation and have a high number of pods