### PR TITLE
Fix file extension replacement for resource paths when using static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix file extension replacement for resource paths when using static frameworks.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10206](https://github.com/CocoaPods/CocoaPods/issues/10206)
+
 * Fix processing of xcassets resources when pod target is static framework  
   [Federico Trimboli](https://github.com/fedetrim)
   [#10175](https://github.com/CocoaPods/CocoaPods/pull/10175)

--- a/lib/cocoapods/target/aggregate_target.rb
+++ b/lib/cocoapods/target/aggregate_target.rb
@@ -292,7 +292,7 @@ module Pod
                 extname = File.extname(resource_path)
                 if self.class.resource_extension_compilable?(extname)
                   output_extname = self.class.output_extension_for_resource(extname)
-                  built_product_dir.join(File.basename(resource_path, extname)).sub_ext(output_extname).to_s
+                  built_product_dir.join(File.basename(resource_path)).sub_ext(output_extname).to_s
                 else
                   resource_path
                 end

--- a/spec/unit/target/aggregate_target_spec.rb
+++ b/spec/unit/target/aggregate_target_spec.rb
@@ -190,11 +190,23 @@ module Pod
         it 'checks resource paths for compilable are converted for static frameworks' do
           @pod_target.stubs(:should_build?).returns(true)
           @pod_target.stubs(:build_type => BuildType.static_framework)
-          convertible_files = %w[.storyboard .xib .xcdatamodel .xcdatamodeld .xcmappingmodel].map { |ext| "Filename#{ext}" }
+          convertible_files = %w[.storyboard .xib .xcdatamodel .xcdatamodeld .xcmappingmodel].map { |ext| "${PODS_ROOT}/Filename#{ext}" }
           @pod_target.stubs(:resource_paths).returns('BananaLib' => convertible_files)
           @target.stubs(:bridge_support_file).returns(nil)
           resource_paths_by_config = @target.resource_paths_by_config
           expected_files = %w[.storyboardc .nib .mom .momd .cdm].map { |ext| "${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework/Filename#{ext}" }
+          resource_paths_by_config['Debug'].should == expected_files
+          resource_paths_by_config['Release'].should == expected_files
+        end
+
+        it 'checks resource paths for compilable are converted for static frameworks with multiple file extensions' do
+          @pod_target.stubs(:should_build?).returns(true)
+          @pod_target.stubs(:build_type => BuildType.static_framework)
+          convertible_files = %w[.storyboard .xib .xcdatamodel .xcdatamodeld .xcmappingmodel].map { |ext| "${PODS_ROOT}/Filename.Suffix#{ext}" }
+          @pod_target.stubs(:resource_paths).returns('BananaLib' => convertible_files)
+          @target.stubs(:bridge_support_file).returns(nil)
+          resource_paths_by_config = @target.resource_paths_by_config
+          expected_files = %w[.storyboardc .nib .mom .momd .cdm].map { |ext| "${BUILT_PRODUCTS_DIR}/BananaLib/BananaLib.framework/Filename.Suffix#{ext}" }
           resource_paths_by_config['Debug'].should == expected_files
           resource_paths_by_config['Release'].should == expected_files
         end


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/10206