### PR TITLE
Update molinillo requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,9 @@ group :development do
   cp_gem 'cocoapods-search',      'cocoapods-search'
   cp_gem 'cocoapods-trunk',       'cocoapods-trunk'
   cp_gem 'cocoapods-try',         'cocoapods-try'
-  cp_gem 'molinillo',             'Molinillo'
+  gem 'molinillo', :git => 'https://github.com/CocoaPods/Molinillo.git', :tag => '0.6.6'
   cp_gem 'nanaimo',               'Nanaimo'
+
   cp_gem 'xcodeproj',             'Xcodeproj'
 
   gem 'cocoapods-dependencies', '~> 1.0.beta.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo.git
-  revision: db572ea89ff7391fcfb81a8ecfbc9872a9e8613f
-  branch: master
+  revision: 3bce9d12dcd9678109306eb2aef2275d1a05893b
+  tag: 0.6.6
   specs:
     molinillo (0.6.6)
 


### PR DESCRIPTION
In 1-10-stable molinillo requirements are set to ~> 0.6.6 but we are pointing to master branch in our Gemfile.

this prevents `bundle update` because master of molinillo is now 0.7.0 and it cannot be updated.

for 1-10-stable we are now updating the gemfile requirement and lock it to the 0.6.6 tag release.