### PR TITLE
Rewrite the only place dependent on `typhoeus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [dcvz](https://github.com/dcvz)
   [#9935](https://github.com/CocoaPods/CocoaPods/pull/9935)
 
+* Rewrite the only place dependent on `typhoeus`.  
+  [Jun Jiang](https://github.com/jasl), [Igor Makarov](https://github.com/igor-makarov)
+  [#10346](https://github.com/CocoaPods/CocoaPods/pull/10346)
+
 * Add a `--update-sources` option to `pod repo push` so one can ensure sources are up-to-date. 
   [Elton Gao](https://github.com/gyfelton)
   [Justin Martin](https://github.com/justinseanmartin)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,8 +155,8 @@ GEM
     concurrent-ruby (1.1.7)
     cork (0.3.0)
       colored2 (~> 3.1)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     danger (5.16.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
@@ -184,7 +184,7 @@ GEM
     gh_inspector (1.1.3)
     git (1.7.0)
       rchardet (~> 1.8)
-    hashdiff (0.3.1)
+    hashdiff (1.0.1)
     httpclient (2.8.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
@@ -254,7 +254,6 @@ GEM
     ruby-macho (1.4.0)
     ruby-prof (0.15.2)
     ruby-progressbar (1.10.1)
-    safe_yaml (1.0.4)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -276,10 +275,10 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    webmock (2.3.1)
+    webmock (3.11.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.12)
 
 PLATFORMS

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -122,7 +122,7 @@ module Pod
                 output_path = podspecs_tmp_dir + File.basename(path)
                 output_path.dirname.mkpath
                 begin
-                  open(path) do |io|
+                  OpenURI.open_uri(path) do |io|
                     output_path.open('w') { |f| f << io.read }
                   end
                 rescue => e


### PR DESCRIPTION
`typhoeus` is the only blocking that prevent CocoaPods running on M1 natively

`cdn_url?` is the only place that using `typhoeus` so I just rewrite it with Ruby's `OpenURI`

WebMock dependency was updated in the `Gemfile.lock` to support testing natively bundled `OpenURI` on newer Ruby versions.