### PR TITLE
Change URL validation failure to a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * None.  
 
+## 1.10.2
+
+##### Enhancements
+
+* None.  
+
+##### Bug Fixes
+
+* Change URL validation failure to a note  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#10291](https://github.com/CocoaPods/CocoaPods/issues/10291)
 
 ## 1.10.1 (2021-01-07)
 

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -443,7 +443,7 @@ module Pod
       if !resp
         warning('url', "There was a problem validating the URL #{url}.", true)
       elsif !resp.success?
-        warning('url', "The URL (#{url}) is not reachable.", true)
+        note('url', "The URL (#{url}) is not reachable.", true)
       end
 
       resp


### PR DESCRIPTION
Fix #10291

Because on the recent Twitter changes, this change allows podspecs to still validate with Twitter URLs without needing to add `--allow-warnings`.