### PR TITLE
Changed behaviour of the reflect_file_system_structure flag

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -221,11 +221,10 @@ module Pod
 
               pod_name = file_accessor.spec.name
               preserve_pod_file_structure_flag = (sandbox.local?(pod_name) || preserve_pod_file_structure) && reflect_file_system_structure
-              base_path = preserve_pod_file_structure_flag ? common_path(paths) : nil
               actual_group_key = preserve_pod_file_structure_flag ? nil : group_key
               group = pods_project.group_for_spec(pod_name, actual_group_key)
               paths.map do |path|
-                pods_project.add_file_reference(path, group, preserve_pod_file_structure_flag, base_path)
+                pods_project.add_file_reference(path, group, preserve_pod_file_structure_flag, nil)
               end
             end
           end


### PR DESCRIPTION
The project structure now matches Xcodes expectations, so that it is possible move files around without creating a mismatch compared to a freshly generated project.
This (the old way) could break builds, so the change makes it much more convenient to refactor related project (moving files to different pods, or back to a non-shared product).

Hint: https://guides.cocoapods.org/contributing/contribute-to-cocoapods.html still recommends to use https://github.com/CocoaPods/Rainforest — which says that you shouldn't use it...