### PR TITLE
Fix missing -ObjC for xcframeworks - take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix missing `-ObjC` for static XCFrameworks - take 2  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#10459](https://github.com/CocoaPods/CocoaPods/issuess/10459)
+
 * Change URL validation failure to a note  
   [Paul Beusterien](https://github.com/paulb777)
   [#10291](https://github.com/CocoaPods/CocoaPods/issues/10291)

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -177,9 +177,7 @@ module Pod
       #
       def vendored_static_xcframeworks
         vendored_xcframeworks.select do |path|
-          if Xcode::XCFramework.new(path).build_type == BuildType.static_framework
-            path
-          end
+          Xcode::XCFramework.new(path).build_type == BuildType.static_framework
         end
       end
 

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -167,8 +167,19 @@ module Pod
       #         that come shipped with the Pod.
       #
       def vendored_dynamic_frameworks
-        vendored_frameworks.select do |framework|
+        (vendored_frameworks - vendored_xcframeworks).select do |framework|
           Xcode::LinkageAnalyzer.dynamic_binary?(framework + framework.basename('.*'))
+        end
+      end
+
+      # @return [Array<Pathname>] The paths of the dynamic xcframework bundles
+      #         that come shipped with the Pod.
+      #
+      def vendored_static_xcframeworks
+        vendored_xcframeworks.select do |path|
+          if Xcode::XCFramework.new(path).build_type == BuildType.static_framework
+            path
+          end
         end
       end
 
@@ -176,7 +187,7 @@ module Pod
       #         bundles that come shipped with the Pod.
       #
       def vendored_static_frameworks
-        vendored_frameworks - vendored_dynamic_frameworks
+        vendored_frameworks - vendored_dynamic_frameworks - vendored_xcframeworks
       end
 
       # @return [Array<Pathname>] The paths of vendored .xcframework bundles
@@ -289,7 +300,7 @@ module Pod
       #         that come shipped with the Pod.
       #
       def vendored_static_artifacts
-        vendored_static_libraries + vendored_static_frameworks
+        vendored_static_libraries + vendored_static_frameworks + vendored_static_xcframeworks
       end
 
       # @return [Hash{String => Array<Pathname>}] A hash that describes the

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -167,7 +167,7 @@ module Pod
       #         that come shipped with the Pod.
       #
       def vendored_dynamic_frameworks
-        (vendored_frameworks - vendored_xcframeworks).select do |framework|
+        vendored_frameworks.select do |framework|
           Xcode::LinkageAnalyzer.dynamic_binary?(framework + framework.basename('.*'))
         end
       end
@@ -176,7 +176,7 @@ module Pod
       #         bundles that come shipped with the Pod.
       #
       def vendored_static_frameworks
-        vendored_frameworks - vendored_dynamic_frameworks - vendored_xcframeworks
+        vendored_frameworks - vendored_dynamic_frameworks
       end
 
       # @return [Array<Pathname>] The paths of vendored .xcframework bundles

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -1264,23 +1264,7 @@ module Pod
         end
 
         # @return [Boolean]
-        define_build_settings_method :any_vendored_static_xcframeworks?, :memoized => true do
-          pod_targets.any? do |pt|
-            pt.build_settings.any? do |bs|
-              if bs.respond_to?(:vendored_xcframeworks)
-                bs.vendored_xcframeworks.any? do |xcf|
-                  xcf.build_type == BuildType.static_framework
-                end
-              end
-            end
-          end
-        end
-
-        # @return [Boolean]
         define_build_settings_method :any_vendored_static_artifacts?, :memoized => true do
-          if any_vendored_static_xcframeworks?
-            return true
-          end
           pod_targets.any? do |pt|
             pt.file_accessors.any? do |fa|
               !fa.vendored_static_artifacts.empty?

--- a/spec/unit/target/build_settings_spec.rb
+++ b/spec/unit/target/build_settings_spec.rb
@@ -352,18 +352,12 @@ module Pod
           file_accessor = stub('file_accessor',
                                :spec => spec,
                                :spec_consumer => consumer,
-                               :vendored_static_artifacts => [],
+                               :vendored_static_artifacts => [1, 2, 3],
                                :vendored_static_libraries => [],
                                :vendored_dynamic_libraries => [],
                                :vendored_static_frameworks => [],
                                :vendored_dynamic_frameworks => [],
                                :vendored_xcframeworks => [],
-                              )
-          vendored_xcframework = stub('vendored_xcframework',
-                                      :build_type => BuildType.static_framework,
-                                     )
-          build_setting = stub('build_setting',
-                               :vendored_xcframeworks => [vendored_xcframework],
                               )
           pod_target = stub('pod_target',
                             :any_vendored_static_artifacts? => true,
@@ -377,7 +371,6 @@ module Pod
                             :spec_consumers => [consumer],
                             :build_as_static? => false,
                             :build_as_dynamic? => false,
-                            :build_settings => [build_setting],
                             :product_basename => 'PodTarget',
                             :target_definitions => [target_definition],
                             :root_spec => spec,
@@ -407,12 +400,6 @@ module Pod
                                :vendored_dynamic_frameworks => [],
                                :vendored_xcframeworks => [],
                               )
-          vendored_xcframework = stub('vendored_xcframework',
-                                      :build_type => BuildType.dynamic_framework,
-                                     )
-          build_setting = stub('build_setting',
-                               :vendored_xcframeworks => [vendored_xcframework],
-                              )
           pod_target = stub('pod_target',
                             :any_vendored_static_artifacts? => true,
                             :file_accessors => [file_accessor],
@@ -425,7 +412,6 @@ module Pod
                             :spec_consumers => [consumer],
                             :build_as_static? => false,
                             :build_as_dynamic? => false,
-                            :build_settings => [build_setting],
                             :product_basename => 'PodTarget',
                             :target_definitions => [target_definition],
                             :root_spec => spec,


### PR DESCRIPTION
Fix #10459 - a better file_accessor solution that undoes the build_settings.rb changes from #10234

Integration test companion is https://github.com/CocoaPods/cocoapods-integration-specs/pull/312