### PR TITLE
Respect `--configuration` option when analyzing via `pod lib lint --analyze`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Respect `--configuration` option when analyzing via `pod lib lint --analyze`. 
+  [Jenn Magder](https://github.com/jmagman)
+  [#10476](https://github.com/CocoaPods/CocoaPods/issues/10476)
+
 * Do not add dependencies to 'Link Binary With Libraries' phase.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10133](https://github.com/CocoaPods/CocoaPods/pull/10133)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -712,8 +712,9 @@ module Pod
           if scheme.nil?
             UI.warn "Skipping compilation with `xcodebuild` because target contains no sources.\n".yellow
           else
+            requested_configuration = configuration ? configuration : 'Release'
             if analyze
-              output = xcodebuild('analyze', scheme, 'Release', :deployment_target => deployment_target)
+              output = xcodebuild('analyze', scheme, requested_configuration, :deployment_target => deployment_target)
               find_output = Executable.execute_command('find', [validation_dir, '-name', '*.html'], false)
               if find_output != ''
                 message = 'Static Analysis failed.'
@@ -722,7 +723,7 @@ module Pod
                 error('build_pod', message)
               end
             else
-              output = xcodebuild('build', scheme, configuration ? configuration : 'Release', :deployment_target => deployment_target)
+              output = xcodebuild('build', scheme, requested_configuration, :deployment_target => deployment_target)
             end
             parsed_output = parse_xcodebuild_output(output)
             translate_output_to_linter_messages(parsed_output)

--- a/spec/functional/command/lib/list_spec.rb
+++ b/spec/functional/command/lib/list_spec.rb
@@ -18,6 +18,15 @@ module Pod
       end
     end
 
+    it 'analyzes the current working directory using Debug configuration' do
+      Dir.chdir(fixture('integration/Reachability')) do
+        cmd = command('lib', 'lint', '--only-errors', '--quick', '--configuration=Debug', '--analyze')
+        cmd.run
+
+        UI.output.should.include 'passed validation'
+      end
+    end
+
     it 'lints a single spec in the current working directory' do
       Dir.chdir(fixture('integration/Reachability')) do
         cmd = command('lib', 'lint', 'Reachability.podspec', '--quick', '--only-errors')

--- a/spec/functional/command/spec_spec.rb
+++ b/spec/functional/command/spec_spec.rb
@@ -226,6 +226,14 @@ module Pod
         end
       end
 
+      it 'analyzes the current working directory using Debug configuration' do
+        Dir.chdir(fixture('spec-repos') + 'trunk/Specs/1/3/f/JSONKit/1.4/') do
+          cmd = command('spec', 'lint', '--quick', '--allow-warnings', '--configuration=Debug', '--analyze')
+          cmd.run
+          UI.output.should.include 'passed validation'
+        end
+      end
+
       it 'fails with an informative error when downloading the podspec 404s' do
         WebMock.stub_request(:get, 'https://no.such.domain/404').
           to_return(:status => 404, :body => '', :headers => {})


### PR DESCRIPTION
#9760 introduced the `--configuration` flag and used it for `xcodebuild build`.  Also adopt for `xcodebuild analyze` for `pod lib lint --analyze` and `pod spec lint --analyze`

Fixes https://github.com/CocoaPods/CocoaPods/issues/10476