### PR TITLE
Add --use-static-frameworks repo push option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Add --use-static-frameworks repo push option  
+  [lxj9457](https://github.com/lxj9457)
+  [#10575](https://github.com/CocoaPods/CocoaPods/pull/10575)
+
 * Improve compatibility with ActiveSupport 6  
   [Jun Jiang](https://github.com/jasl)
   [#10364](https://github.com/CocoaPods/CocoaPods/pull/10364)

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -25,6 +25,7 @@ module Pod
             ['--allow-warnings', 'Allows pushing even if there are warnings'],
             ['--use-libraries', 'Linter uses static libraries to install the spec'],
             ['--use-modular-headers', 'Lint uses modular headers during installation'],
+            ['--use-static-frameworks', 'Lint uses static frameworks during installation'],
             ["--sources=#{Pod::TrunkSource::TRUNK_REPO_URL}", 'The sources from which to pull dependent pods ' \
              '(defaults to all available repos). Multiple sources must be comma-delimited'],
             ['--local-only', 'Does not perform the step of pushing REPO to its remote'],
@@ -51,6 +52,7 @@ module Pod
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
           @use_modular_headers = argv.flag?('use-modular-headers', false)
+          @use_static_frameworks = argv.flag?('use-static-frameworks', false)
           @private = argv.flag?('private', true)
           @message = argv.option('commit-message')
           @commit_message = argv.flag?('commit-message', false)
@@ -140,6 +142,7 @@ module Pod
             validator.allow_warnings = @allow_warnings
             validator.use_frameworks = @use_frameworks
             validator.use_modular_headers = @use_modular_headers
+            validator.use_static_frameworks = @use_static_frameworks
             validator.ignore_public_only_results = @private
             validator.swift_version = @swift_version
             validator.skip_import_validation = @skip_import_validation


### PR DESCRIPTION
Add --use-statice-frameworks option for repo push command.
We can use `use_frameworks!:linkage=>:statice` when pod. and We can use `--use-statice-frameworks ` when lib lint. It will cause push failure if unsupport ` --use-statice-frameworks` when repo push.