### PR TITLE
Don't copy `.mom` files because `.momd` directory includes them

### DIFF
--- a/lib/cocoapods/target.rb
+++ b/lib/cocoapods/target.rb
@@ -341,7 +341,6 @@ module Pod
       case input_extension
       when '.storyboard'        then '.storyboardc'
       when '.xib'               then '.nib'
-      when '.xcdatamodel'       then '.mom'
       when '.xcdatamodeld'      then '.momd'
       when '.xcmappingmodel'    then '.cdm'
       when '.xcassets'          then '.car'


### PR DESCRIPTION
Fix #10202.

Paths of `.mom`files is wrong because `.mom` files are child of `.momd` directory.

xcode output:

> Showing All Messages
> /Users/kumabook/Library/Developer/Xcode/DerivedData/RSR-cxsuruklbrludaahethyoeaaveyt/Build/Products/Debug-iphoneos/FESPLIKit/FESPLIKit.framework/Model.momd

> Resource "/Users/kumabook/Library/Developer/Xcode/DerivedData/RSR-cxsuruklbrludaahethyoeaaveyt/Build/Products> /Debug-iphoneos/FESPLIKit/FESPLIKit.framework/Model.mom" not found. Run 'pod install' to update the copy resources script.

`.../Model.momd/Model.mom` is correct


If you copy the parent `.mod` directory, the child `.mom` will be copied with it.
So, We need not copy `.mom` files explicitly. 

