### PR TITLE
[Installer] use relative paths in copy dsyms script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Use relative paths in copy dsyms script
+  [Mickey Knox](https://github.com/knox)
+  [#10583](https://github.com/CocoaPods/CocoaPods/pull/10583)
+
 * Use `OpenURI.open_uri` instead.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10597](https://github.com/CocoaPods/CocoaPods/issues/10597)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -1185,7 +1185,11 @@ module Pod
             def dsym_paths(target)
               dsym_paths = target.framework_paths.values.flatten.reject { |fmwk_path| fmwk_path.dsym_path.nil? }.map(&:dsym_path)
               dsym_paths.concat(target.xcframeworks.values.flatten.flat_map { |xcframework| xcframework_dsyms(xcframework.path) })
-              dsym_paths
+              dsym_paths.map do |dsym_path|
+                dsym_pathname = Pathname(dsym_path)
+                dsym_path = "${PODS_ROOT}/#{dsym_pathname.relative_path_from(target.sandbox.root)}" unless dsym_pathname.relative?
+                dsym_path
+              end
             end
 
             # @param [PodTarget] target the target to be installed


### PR DESCRIPTION
🌈

This writes relative paths into copy dsyms script which i find very useful for projects where Pods folder is part of the repo and no `pod install` is executed on ci machine