### PR TITLE
Add version option to pod spec cat and pod spec which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [cltnschlosser](https://github.com/cltnschlosser)
   [#9916](https://github.com/CocoaPods/CocoaPods/pull/9916)
 
+* Add a `--version` option to `pod spec cat` for listing the podspec of a specific version  
+  [pietbrauer](https://github.com/pietbrauer)
+  [#10609](https://github.com/CocoaPods/CocoaPods/pull/10609)
+
 ##### Bug Fixes
 
 * Respect `--configuration` option when analyzing via `pod lib lint --analyze`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [cltnschlosser](https://github.com/cltnschlosser)
   [#9916](https://github.com/CocoaPods/CocoaPods/pull/9916)
 
-* Add a `--version` option to `pod spec cat` for listing the podspec of a specific version  
+* Add a `--version` option to `pod spec cat` and `pod spec which` for listing the podspec of a specific version  
   [pietbrauer](https://github.com/pietbrauer)
   [#10609](https://github.com/CocoaPods/CocoaPods/pull/10609)
 

--- a/lib/cocoapods/command/spec/cat.rb
+++ b/lib/cocoapods/command/spec/cat.rb
@@ -16,6 +16,7 @@ module Pod
           [
             ['--regex', 'Interpret the `QUERY` as a regular expression'],
             ['--show-all', 'Pick from all versions of the given podspec'],
+            ['--version', 'Print a specific version of the given podspec'],
           ].concat(super)
         end
 
@@ -24,6 +25,7 @@ module Pod
           @show_all = argv.flag?('show-all')
           @query = argv.shift_argument
           @query = @query.gsub('.podspec', '') unless @query.nil?
+          @version = argv.option('version')
           super
         end
 
@@ -40,7 +42,7 @@ module Pod
                        index = UI.choose_from_array(specs, "Which spec would you like to print [1-#{specs.count}]? ")
                        specs[index]
                      else
-                       get_path_of_spec(query)
+                       get_path_of_spec(query, @version)
                      end
 
           UI.puts File.read(filepath)

--- a/lib/cocoapods/command/spec/which.rb
+++ b/lib/cocoapods/command/spec/which.rb
@@ -16,12 +16,14 @@ module Pod
           [
             ['--regex', 'Interpret the `QUERY` as a regular expression'],
             ['--show-all', 'Print all versions of the given podspec'],
+            ['--version', 'Print a specific version of the given podspec'],
           ].concat(super)
         end
 
         def initialize(argv)
           @use_regex = argv.flag?('regex')
           @show_all = argv.flag?('show-all')
+          @version = argv.option('version')
           @query = argv.shift_argument
           @query = @query.gsub('.podspec', '') unless @query.nil?
           super
@@ -35,7 +37,7 @@ module Pod
 
         def run
           query = @use_regex ? @query : Regexp.escape(@query)
-          UI.puts get_path_of_spec(query, @show_all)
+          UI.puts get_path_of_spec(query, @show_all || @version)
         end
       end
     end

--- a/spec/functional/command/spec_spec.rb
+++ b/spec/functional/command/spec_spec.rb
@@ -336,6 +336,12 @@ module Pod
         UI.output.should.include text.gsub(/\n/, '')
       end
 
+      it 'prints the path of a given podspec respecting the version' do
+        lambda { command('spec', 'which', '--version=3.1.0', 'AFNetworking').run }.should.not.raise
+        text = '3.1.0/AFNetworking.podspec'
+        UI.output.should.include text.gsub(/\n/, '')
+      end
+
       describe_regex_support('which')
     end
 

--- a/spec/functional/command/spec_spec.rb
+++ b/spec/functional/command/spec_spec.rb
@@ -358,6 +358,11 @@ module Pod
         UI.output.should.include Pathname.new(first_spec_path).read
       end
 
+      it 'cats the first podspec from all podspecs matching the version' do
+        lambda { command('spec', 'cat', '--version=3.1.0', 'AFNetworking').run }.should.not.raise
+        UI.output.should.include fixture('spec-repos/trunk/Specs/a/7/5/AFNetworking/3.1.0/AFNetworking.podspec.json').read
+      end
+
       describe_regex_support('cat')
     end
 


### PR DESCRIPTION
This PR adds a new option to `pod spec cat` and `pod spec which` if someone might not need the latest pod spec but the one for a specific version.