### PR TITLE
Use URI.open instead of open for uri type paths.

### DIFF
--- a/lib/cocoapods/external_sources/podspec_source.rb
+++ b/lib/cocoapods/external_sources/podspec_source.rb
@@ -16,7 +16,7 @@ module Pod
           else
             require 'cocoapods/open-uri'
             begin
-              open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
+              URI.open(podspec_uri) { |io| store_podspec(sandbox, io.read, is_json) }
             rescue OpenURI::HTTPError => e
               status = e.io.status.join(' ')
               raise Informative, "Failed to fetch podspec for `#{name}` at `#{podspec_uri}`.\n Error: #{status}"


### PR DESCRIPTION
This allows code to be compatible with newer versions of ruby.

`open-uri` has removed override in `Kernel#open`, so the following code :
```
pod 'Bootstrap', podspec: 'https://raw.githubusercontent.com/tnantoka/podspecs/master/Specs/Bootstrap/Bootstrap.podspec'
```
leads to error like:
```
Errno::ENOENT - No such file or directory @ rb_sysopen - https://raw.githubusercontent.com/tnantoka/podspecs/master/Specs/Bootstrap/Bootstrap.podspec
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/external_sources/podspec_source.rb:19:in `initialize'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/external_sources/podspec_source.rb:19:in `open'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/external_sources/podspec_source.rb:19:in `block in fetch'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/user_interface.rb:86:in `titled_section'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/external_sources/podspec_source.rb:11:in `fetch'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer/analyzer.rb:989:in `fetch_external_source'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer/analyzer.rb:968:in `block (2 levels) in fetch_external_sources'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer/analyzer.rb:967:in `each'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer/analyzer.rb:967:in `block in fetch_external_sources'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/user_interface.rb:64:in `section'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer/analyzer.rb:966:in `fetch_external_sources'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer/analyzer.rb:117:in `analyze'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:414:in `analyze'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:239:in `block in resolve_dependencies'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/user_interface.rb:64:in `section'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:238:in `resolve_dependencies'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:160:in `install!'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/command/update.rb:63:in `run'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/lib/cocoapods/command.rb:52:in `run'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/gems/cocoapods-1.10.1/bin/pod:55:in `<top (required)>'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/bin/pod:23:in `load'
/opt/homebrew/Cellar/cocoapods/1.10.1_1/libexec/bin/pod:23:in `<main>'
```.
