### PR TITLE
Fix validation when subspec name starts with the name of the root spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix lint subspec error when the name of subspec start with the pod name.  
+  [XianpuMeng](https://github.com/XianpuMeng)
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#9906](https://github.com/CocoaPods/CocoaPods/issues/9906)
+
 * Respect `--configuration` option when analyzing via `pod lib lint --analyze`. 
   [Jenn Magder](https://github.com/jmagman)
   [#10476](https://github.com/CocoaPods/CocoaPods/issues/10476)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -118,7 +118,7 @@ module Pod
       # Replace default spec with a subspec if asked for
       a_spec = spec
       if spec && @only_subspec
-        subspec_name = @only_subspec.start_with?(spec.root.name) ? @only_subspec : "#{spec.root.name}/#{@only_subspec}"
+        subspec_name = @only_subspec.start_with?("#{spec.root.name}/") ? @only_subspec : "#{spec.root.name}/#{@only_subspec}"
         a_spec = spec.subspec_by_name(subspec_name, true, true)
         @subspec_name = a_spec.name
       end


### PR DESCRIPTION
closes #9906 

supersedes https://github.com/CocoaPods/CocoaPods/pull/9914