### PR TITLE
Update `ruby-macho` gem version to support 1.x and 2.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* Use relative paths in copy dsyms script
+* Use relative paths in copy dsyms script.  
   [Mickey Knox](https://github.com/knox)
   [#10583](https://github.com/CocoaPods/CocoaPods/pull/10583)
 
@@ -61,6 +61,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [XianpuMeng](https://github.com/XianpuMeng)
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9906](https://github.com/CocoaPods/CocoaPods/issues/9906)
+
+* Update `ruby-macho` gem version to support 1.x and 2.x.  
+  [Eric Chamberlain](https://github.com/PeqNP)
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10390](https://github.com/CocoaPods/CocoaPods/issues/10390)
 
 * Respect `--configuration` option when analyzing via `pod lib lint --analyze`. 
   [Jenn Magder](https://github.com/jmagman)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.7.0)
       nap (~> 1.0)
-      ruby-macho (~> 1.4)
+      ruby-macho (>= 1.0, < 3.0)
       xcodeproj (>= 1.19.0, < 2.0)
 
 GEM
@@ -251,7 +251,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.2)
-    ruby-macho (1.4.0)
+    ruby-macho (2.5.1)
     ruby-prof (0.15.2)
     ruby-progressbar (1.10.1)
     sawyer (0.8.2)
@@ -289,7 +289,7 @@ DEPENDENCIES
   awesome_print
   bacon!
   bigdecimal (~> 1.3.0)
-  bundler (~> 1.3)
+  bundler (~> 2.0)
   claide!
   clintegracon
   cocoapods!

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -44,12 +44,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '>= 2.3.0', '< 3.0'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '~> 1.4'
+  s.add_runtime_dependency 'ruby-macho',    '>= 1.0', '< 3.0'
 
   s.add_runtime_dependency 'addressable', '~> 2.6'
 
   s.add_development_dependency 'bacon', '~> 1.1'
-  s.add_development_dependency 'bundler', '~> 1.3'
+  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.0'
 
   s.required_ruby_version = '>= 2.6'


### PR DESCRIPTION
closes: https://github.com/CocoaPods/CocoaPods/issues/10390

supersedes https://github.com/CocoaPods/CocoaPods/pull/10396
