### PR TITLE
Generate default `Info.plist` for consumer app during validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Generate default `Info.plist` for consumer app during validation.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#8570](https://github.com/CocoaPods/CocoaPods/issues/8570)
+
 * Fix lint subspec error when the name of subspec start with the pod name.  
   [XianpuMeng](https://github.com/XianpuMeng)
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -581,6 +581,9 @@ module Pod
     def create_app_project
       app_project = Xcodeproj::Project.new(validation_dir + 'App.xcodeproj')
       app_target = Pod::Generator::AppTargetHelper.add_app_target(app_project, consumer.platform_name, deployment_target)
+      sandbox = Sandbox.new(config.sandbox_root)
+      info_plist_path = app_project.path.dirname.+('App/App-Info.plist')
+      Pod::Installer::Xcode::PodsProjectGenerator::TargetInstallerHelper.create_info_plist_file_with_sandbox(sandbox, info_plist_path, app_target, '1.0.0', Platform.new(consumer.platform_name), :appl)
       Pod::Generator::AppTargetHelper.add_swift_version(app_target, derived_swift_version)
       # Lint will fail if a AppIcon is set but no image is found with such name
       # Happens only with Static Frameworks enabled but shouldn't be set anyway

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -997,7 +997,9 @@ module Pod
           target.symbol_type.should == :application
           target.deployment_target.should.be.nil
           target.platform_name.should == :ios
-
+          target.build_configurations.each do |c|
+            File.basename(c.build_settings['INFOPLIST_FILE']).should == 'App-Info.plist'
+          end
           Xcodeproj::Project.schemes(project.path).should == %w(App)
         end
 


### PR DESCRIPTION
This prevents Xcode from printing a warning message that an info plist file is missing on the generated app.

closes https://github.com/CocoaPods/CocoaPods/issues/8570