### PR TITLE
Integrate test specs and app specs of pre-built pods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10793](https://github.com/CocoaPods/CocoaPods/pull/10793)
 
+* Integrate test specs and app specs of pre-built pods.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10795](https://github.com/CocoaPods/CocoaPods/pull/10795)
+
 * Add support for `before_headers` and `after_headers` script phase DSL.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10770](https://github.com/CocoaPods/CocoaPods/issues/10770)

--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -137,6 +137,10 @@ module Pod
       #        The indentation level relative to the current,
       #        when the message is printed.
       #
+      # @yield  The action, this block is always executed.
+      #
+      # @return [void]
+      #
       def message(message, verbose_prefix = '', relative_indentation = 2)
         message = verbose_prefix + message if config.verbose?
         puts_indented message if config.verbose?


### PR DESCRIPTION
Previously, CocoaPods would not integrate test specs or app specs of pre-built targets. We used to return early. This updates the logic to still integrate test specs and app specs even if the target has no sources to compile.