### PR TITLE
Dedup bcsymbolmap paths found from multiple vendored frameworks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Dedup bcsymbolmap paths found from multiple vendored frameworks.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10373](https://github.com/CocoaPods/CocoaPods/issues/10373)
+
 * Correctly filter dependencies for pod variants across different platforms.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10777](https://github.com/CocoaPods/CocoaPods/issues/10777)

--- a/lib/cocoapods/generator/copy_dsyms_script.rb
+++ b/lib/cocoapods/generator/copy_dsyms_script.rb
@@ -1,18 +1,18 @@
 module Pod
   module Generator
     class CopydSYMsScript
-      # @return [Array<Pathname>] dsym_paths the dSYM paths to include in the script contents.
+      # @return [Array<Pathname, String>] dsym_paths the dSYM paths to include in the script contents.
       #
       attr_reader :dsym_paths
 
-      # @return [Array<Pathname>] bcsymbolmap_paths the bcsymbolmap paths to include in the script contents.
+      # @return [Array<Pathname, String>] bcsymbolmap_paths the bcsymbolmap paths to include in the script contents.
       #
       attr_reader :bcsymbolmap_paths
 
       # Initialize a new instance
       #
-      # @param  [Array<Pathname>] dsym_paths @see dsym_paths
-      # @param  [Array<Pathname>] bcsymbolmap_paths @see bcsymbolmap_paths
+      # @param  [Array<Pathname, String>] dsym_paths @see dsym_paths
+      # @param  [Array<Pathname, String>] bcsymbolmap_paths @see bcsymbolmap_paths
       #
       def initialize(dsym_paths, bcsymbolmap_paths)
         @dsym_paths = Array(dsym_paths)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -1199,7 +1199,7 @@ module Pod
             def bcsymbolmap_paths(target)
               target.framework_paths.values.flatten.reject do |fmwk_path|
                 fmwk_path.bcsymbolmap_paths.nil?
-              end.flat_map(&:bcsymbolmap_paths)
+              end.flat_map(&:bcsymbolmap_paths).uniq
             end
 
             # @param  [Pathname] xcframework_path

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -1255,6 +1255,26 @@ module Pod
 
             #--------------------------------------------------------------------------------#
 
+            describe '#bcsymbolmap_paths' do
+              it 'de dups bcsymbol map paths that are found across multiple frameworks' do
+                framework_a = Pod::Xcode::FrameworkPaths.new('/path/to/A.framework', '/path/to/A.framework.dSYM', [
+                  '${PODS_ROOT}/path/to/A9FE499F-68E9-3984-A291-CFB68F9C77EB.bcsymbolmap',
+                  '${PODS_ROOT}/path/to/48874290-E5EB-391C-A715-28CBA7F8B4B8.bcsymbolmap',
+                ])
+                framework_b = Pod::Xcode::FrameworkPaths.new('/path/to/B.framework', '/path/to/B.framework.dSYM', [
+                  '${PODS_ROOT}/path/to/A9FE499F-68E9-3984-A291-CFB68F9C77EB.bcsymbolmap',
+                  '${PODS_ROOT}/path/to/48874290-E5EB-391C-A715-28CBA7F8B4B8.bcsymbolmap',
+                ])
+                @pod_target.stubs(:framework_paths).returns('Spec' => [framework_a, framework_b])
+                Pod::Installer::Xcode::PodsProjectGenerator::PodTargetInstaller.bcsymbolmap_paths(@pod_target).should == [
+                  '${PODS_ROOT}/path/to/A9FE499F-68E9-3984-A291-CFB68F9C77EB.bcsymbolmap',
+                  '${PODS_ROOT}/path/to/48874290-E5EB-391C-A715-28CBA7F8B4B8.bcsymbolmap',
+                ]
+              end
+            end
+
+            #--------------------------------------------------------------------------------#
+
             describe 'concerning header_mappings_dirs' do
               before do
                 @project = Project.new(config.sandbox.project_path)


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/10373

when a target provides multiple vendored frameworks under the same root folder then we always scan and include all bcsymbolmap paths for all frameworks. This ensures we dedup them before we install them in the copy dSYM script phase.