### PR TITLE
Validate vendored library names after they have been expanded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Validate vendored library names after they have been expanded.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10832](https://github.com/CocoaPods/CocoaPods/pull/10832)
+
 * Place frameworks from xcframeworks into a unique folder name to avoid duplicate outputs.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10106](https://github.com/CocoaPods/CocoaPods/issues/10106)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 397fa25c069afc7c75666b74ffc39b2d61e8130c
+  revision: f7cf05720eab935d7d50e35224d263952176fb53
   branch: master
   specs:
     cocoapods-core (1.10.2)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -814,6 +814,17 @@ module Pod
       add_result(message_type, 'file patterns', "The `#{attr_name}` pattern did not match any file.")
     end
 
+    def _validate_vendored_libraries
+      file_accessor.vendored_libraries.each do |lib|
+        basename = File.basename(lib)
+        lib_name = basename.downcase
+        unless lib_name.end_with?('.a') && lib_name.start_with?('lib')
+          warning('vendored_libraries', "`#{basename}` does not match the expected static library name format `lib[name].a`")
+        end
+      end
+      validate_nonempty_patterns(:vendored_libraries, :warning)
+    end
+
     def _validate_private_header_files
       _validate_header_files(:private_header_files)
       validate_nonempty_patterns(:private_header_files, :warning)


### PR DESCRIPTION
Requires https://github.com/CocoaPods/Core/pull/693 to land.