### PR TITLE
Bump minimum Xcodeproj version to 1.21.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,10 +37,10 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: eeccae7275645753cbaf45d96fc4b23e4b8b3b9f
+  revision: 878c6464b593287ee907d755f812306384b4cca6
   branch: master
   specs:
-    xcodeproj (1.20.0)
+    xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -127,7 +127,7 @@ PATH
       molinillo (~> 0.7.0)
       nap (~> 1.0)
       ruby-macho (>= 1.0, < 3.0)
-      xcodeproj (>= 1.20.0, < 2.0)
+      xcodeproj (>= 1.21.0, < 2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.4.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-try',         '>= 1.1.0', '< 2.0'
   s.add_runtime_dependency 'molinillo',             '~> 0.7.0'
-  s.add_runtime_dependency 'xcodeproj',             '>= 1.20.0', '< 2.0'
+  s.add_runtime_dependency 'xcodeproj',             '>= 1.21.0', '< 2.0'
 
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'escape',        '~> 0.0.4'


### PR DESCRIPTION
1.21.0 of Xcodeproj is required for the 1.11.0 release of cocoapods as it includes support for on demand resources.