### PR TITLE
Bump Molinillo version to 0.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,10 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo.git
-  revision: e1d565eb9dc9ca2c4f0cfb97c9c824731d97a0ba
+  revision: 9822e38f1a4908202d13af5d069800887ce3d877
   branch: master
   specs:
-    molinillo (0.7.0)
+    molinillo (0.8.0)
 
 GIT
   remote: https://github.com/CocoaPods/Nanaimo.git
@@ -124,7 +124,7 @@ PATH
       escape (~> 0.0.4)
       fourflusher (>= 2.3.0, < 3.0)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.7.0)
+      molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 1.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cocoapods-search',      '>= 1.0.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.4.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-try',         '>= 1.1.0', '< 2.0'
-  s.add_runtime_dependency 'molinillo',             '~> 0.7.0'
+  s.add_runtime_dependency 'molinillo',             '~> 0.8.0'
   s.add_runtime_dependency 'xcodeproj',             '>= 1.21.0', '< 2.0'
 
   s.add_runtime_dependency 'colored2',       '~> 3.1'


### PR DESCRIPTION
Molinilllo 0.8.0 CHANGELOG: https://github.com/CocoaPods/Molinillo/releases/0.8.0