### PR TITLE
Do not validate modular header dependencies for pre-built Swift pods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Do not validate modular header dependencies for pre-built Swift pods.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10912](https://github.com/CocoaPods/CocoaPods/issues/10912)
 
 
 ## 1.11.0 (2021-09-01)

--- a/lib/cocoapods/installer/xcode/target_validator.rb
+++ b/lib/cocoapods/installer/xcode/target_validator.rb
@@ -129,7 +129,7 @@ module Pod
         def verify_swift_pods_have_module_dependencies
           error_messages = []
           pod_targets.each do |pod_target|
-            next unless pod_target.uses_swift?
+            next unless pod_target.uses_swift? && pod_target.should_build?
 
             non_module_dependencies = []
             pod_target.dependent_targets.each do |dependent_target|


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/10912