### PR TITLE
Replace [Bool] with [Boolean] in method comments  according to the YARD convention.

### DIFF
--- a/lib/cocoapods/config.rb
+++ b/lib/cocoapods/config.rb
@@ -49,23 +49,23 @@ module Pod
 
     # @!group UI
 
-    # @return [Bool] Whether CocoaPods should provide detailed output about the
+    # @return [Boolean] Whether CocoaPods should provide detailed output about the
     #         performed actions.
     #
     attr_accessor :verbose
     alias_method :verbose?, :verbose
 
-    # @return [Bool] Whether CocoaPods should produce not output.
+    # @return [Boolean] Whether CocoaPods should produce not output.
     #
     attr_accessor :silent
     alias_method :silent?, :silent
 
-    # @return [Bool] Whether CocoaPods is allowed to run as root.
+    # @return [Boolean] Whether CocoaPods is allowed to run as root.
     #
     attr_accessor :allow_root
     alias_method :allow_root?, :allow_root
 
-    # @return [Bool] Whether a message should be printed when a new version of
+    # @return [Boolean] Whether a message should be printed when a new version of
     #         CocoaPods is available.
     #
     attr_accessor :new_version_message
@@ -75,7 +75,7 @@ module Pod
 
     # @!group Installation
 
-    # @return [Bool] Whether the installer should skip the download cache.
+    # @return [Boolean] Whether the installer should skip the download cache.
     #
     attr_accessor :skip_download_cache
     alias_method :skip_download_cache?, :skip_download_cache

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -36,7 +36,7 @@ module Pod
     # @param  [Array<#to_s>] command
     #         The command to send to the binary.
     #
-    # @param  [Bool] raise_on_failure
+    # @param  [Boolean] raise_on_failure
     #         Whether it should raise if the command fails.
     #
     # @raise  If the executable could not be located.

--- a/lib/cocoapods/external_sources/abstract_external_source.rb
+++ b/lib/cocoapods/external_sources/abstract_external_source.rb
@@ -36,7 +36,7 @@ module Pod
         @can_cache = can_cache
       end
 
-      # @return [Bool] whether an external source source is equal to another
+      # @return [Boolean] whether an external source source is equal to another
       #         according to the {#name} and to the {#params}.
       #
       def ==(other)

--- a/lib/cocoapods/external_sources/path_source.rb
+++ b/lib/cocoapods/external_sources/path_source.rb
@@ -45,7 +45,7 @@ module Pod
         path.exist? ? path : Pathname("#{path}.json")
       end
 
-      # @return [Bool]
+      # @return [Boolean]
       #
       def absolute?(path)
         Pathname(path).absolute? || path.to_s.start_with?('~')

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -59,7 +59,7 @@ module Pod
         :tvos => Version.new('9.0'),
       }
 
-      # @return [Bool] Whether the external strings file is supported by the
+      # @return [Boolean] Whether the external strings file is supported by the
       #         `ibtool` according to the deployment target of the platform.
       #
       def use_external_strings_file?

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -43,7 +43,7 @@ module Pod
       #
       attr_reader :plugin_sources
 
-      # @return [Bool] Whether the analysis has dependencies and thus sources must be configured.
+      # @return [Boolean] Whether the analysis has dependencies and thus sources must be configured.
       #
       # @note   This is used by the `pod lib lint` command to prevent update of specs when not needed.
       #
@@ -93,7 +93,7 @@ module Pod
       # compute which specification should be installed. The manifest of the
       # sandbox returns which specifications are installed.
       #
-      # @param  [Bool] allow_fetches
+      # @param  [Boolean] allow_fetches
       #         whether external sources may be fetched
       #
       # @return [AnalysisResult]
@@ -193,7 +193,7 @@ module Pod
 
       # @!group Configuration
 
-      # @return [Bool] Whether the version of the dependencies which did not
+      # @return [Boolean] Whether the version of the dependencies which did not
       #         change in the Podfile should be locked.
       #
       def update_mode?

--- a/lib/cocoapods/installer/analyzer/analysis_result.rb
+++ b/lib/cocoapods/installer/analyzer/analysis_result.rb
@@ -59,14 +59,14 @@ module Pod
           end
         end
 
-        # @return [Bool] Whether an installation should be performed or this
+        # @return [Boolean] Whether an installation should be performed or this
         #         CocoaPods project is already up to date.
         #
         def needs_install?
           podfile_needs_install? || sandbox_needs_install?
         end
 
-        # @return [Bool] Whether the podfile has changes respect to the lockfile.
+        # @return [Boolean] Whether the podfile has changes respect to the lockfile.
         #
         def podfile_needs_install?
           state = podfile_state
@@ -74,7 +74,7 @@ module Pod
           needing_install > 0
         end
 
-        # @return [Bool] Whether the sandbox is in synch with the lockfile.
+        # @return [Boolean] Whether the sandbox is in synch with the lockfile.
         #
         def sandbox_needs_install?
           state = sandbox_state

--- a/lib/cocoapods/installer/analyzer/pod_variant.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant.rb
@@ -56,7 +56,7 @@ module Pod
         # @note Non library specs are intentionally not included as part of the equality for pod variants since a pod
         #       variant should not be affected by the number of test nor app specs included.
         #
-        # @return [Bool] whether the {PodVariant} is equal to another taking all all their attributes into account
+        # @return [Boolean] whether the {PodVariant} is equal to another taking all all their attributes into account
         #
         def ==(other)
           self.class == other.class &&

--- a/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
+++ b/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
@@ -40,7 +40,7 @@ module Pod
         #
         attr_reader :specs
 
-        # @return [Bool] Whether the installation is performed in update mode.
+        # @return [Boolean] Whether the installation is performed in update mode.
         #
         attr_reader :update_mode
 
@@ -51,7 +51,7 @@ module Pod
         # @param [Sandbox] sandbox @see sandbox
         # @param [Podfile] podfile @see podfile
         # @param [Array<Specifications>] specs @see specs
-        # @param [Bool] update_mode @see update_mode
+        # @param [Boolean] update_mode @see update_mode
         #
         def initialize(sandbox, podfile, specs, update_mode)
           @sandbox = sandbox
@@ -105,7 +105,7 @@ module Pod
         # @param  [String] pod
         #         the name of the Pod.
         #
-        # @return [Bool] Whether the Pod is added.
+        # @return [Boolean] Whether the Pod is added.
         #
         def pod_added?(pod)
           return true if resolved_pods.include?(pod) && !sandbox_pods.include?(pod)
@@ -119,7 +119,7 @@ module Pod
         # @param  [String] pod
         #         the name of the Pod.
         #
-        # @return [Bool] Whether the Pod is deleted.
+        # @return [Boolean] Whether the Pod is deleted.
         #
         def pod_deleted?(pod)
           return true if !resolved_pods.include?(pod) && sandbox_pods.include?(pod)
@@ -138,7 +138,7 @@ module Pod
         # @param  [String] pod
         #         the name of the Pod.
         #
-        # @return [Bool] Whether the Pod is changed.
+        # @return [Boolean] Whether the Pod is changed.
         #
         def pod_changed?(pod)
           spec = root_spec(pod)

--- a/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
@@ -38,7 +38,7 @@ module Pod
         #
         attr_reader :installation_options
 
-        # @return [Bool] Flag indicating if we want to ignore the cache and force a clean installation.
+        # @return [Boolean] Flag indicating if we want to ignore the cache and force a clean installation.
         #
         attr_reader :clean_install
 
@@ -52,7 +52,7 @@ module Pod
         # @param [Array<PodTarget>] pod_targets @see #pod_targets
         # @param [Array<AggregateTarget>] aggregate_targets @see #aggregate_targets
         # @param [Hash<Symbol, Object>] installation_options @see #installation_options
-        # @param [Bool] clean_install @see #clean_install
+        # @param [Boolean] clean_install @see #clean_install
         #
         def initialize(sandbox, cache, build_configurations, project_object_version, podfile_plugins, pod_targets, aggregate_targets, installation_options,
                        clean_install: false)

--- a/lib/cocoapods/installer/project_cache/target_cache_key.rb
+++ b/lib/cocoapods/installer/project_cache/target_cache_key.rb
@@ -109,7 +109,7 @@ module Pod
         # @param [PodTarget] pod_target
         #        The pod target used to construct a TargetCacheKey object.
         #
-        # @param [Bool] is_local_pod
+        # @param [Boolean] is_local_pod
         #        Used to also include its local files in the cache key.
         #
         # @param [Hash] checkout_options

--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -195,7 +195,7 @@ module Pod
 
         # @param  [String] pod The root name of the development pod.
         #
-        # @return [Bool] whether the scheme for the given development pod should be
+        # @return [Boolean] whether the scheme for the given development pod should be
         #         shared.
         #
         def share_scheme_for_development_pod?(pod)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/file_references_installer.rb
@@ -21,7 +21,7 @@ module Pod
           #
           attr_reader :pods_project
 
-          # @return [Bool] add support for preserving the file structure of externally sourced pods, in addition to local pods.
+          # @return [Boolean] add support for preserving the file structure of externally sourced pods, in addition to local pods.
           #
           attr_reader :preserve_pod_file_structure
 
@@ -30,7 +30,7 @@ module Pod
           # @param [Sandbox] sandbox @see #sandbox
           # @param [Array<PodTarget>] pod_targets @see #pod_targets
           # @param [Project] pods_project @see #pods_project
-          # @param [Bool] preserve_pod_file_structure @see #preserve_pod_file_structure
+          # @param [Boolean] preserve_pod_file_structure @see #preserve_pod_file_structure
           #
           def initialize(sandbox, pod_targets, pods_project, preserve_pod_file_structure = false)
             @sandbox = sandbox
@@ -207,7 +207,7 @@ module Pod
           # @param  [Symbol] group_key
           #         The key of the group of the Pods project.
           #
-          # @param  [Bool] reflect_file_system_structure
+          # @param  [Boolean] reflect_file_system_structure
           #         Whether organizing a local pod's files in subgroups inside
           #         the pod's group is allowed.
           #

--- a/lib/cocoapods/installer/xcode/pods_project_generator/project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/project_generator.rb
@@ -38,7 +38,7 @@ module Pod
         #
         attr_reader :podfile_path
 
-        # @return [Bool] Bool indicating if this project is a pod target subproject.
+        # @return [Boolean] Bool indicating if this project is a pod target subproject.
         # Used by `generate_multiple_pod_projects` installation option.
         #
         attr_reader :pod_target_subproject

--- a/lib/cocoapods/native_target_extension.rb
+++ b/lib/cocoapods/native_target_extension.rb
@@ -43,7 +43,7 @@ module Pod
     # @param  [TargetMetadata] cached_target
     #         the target to search for.
     #
-    # @return [Bool]
+    # @return [Boolean]
     #
     def self.dependency_for_cached_target?(sandbox, target, cached_target)
       target.dependencies.find do |dep|

--- a/lib/cocoapods/open-uri.rb
+++ b/lib/cocoapods/open-uri.rb
@@ -24,7 +24,7 @@ module OpenURI
   # @param [URI::Generic] uri2
   #        the target uri where to where the redirect points to
   #
-  # @return [Bool]
+  # @return [Boolean]
   #
   def self.redirectable?(uri1, uri2)
     uri1.scheme.downcase == uri2.scheme.downcase ||

--- a/lib/cocoapods/project.rb
+++ b/lib/cocoapods/project.rb
@@ -26,7 +26,7 @@ module Pod
     #
     attr_reader :dependencies_group
 
-    # @return [Bool] Bool indicating if this project is a pod target subproject.
+    # @return [Boolean] Bool indicating if this project is a pod target subproject.
     # Used by `generate_multiple_pod_projects` installation option.
     #
     attr_reader :pod_target_subproject
@@ -39,7 +39,7 @@ module Pod
     # Initialize a new instance
     #
     # @param  [Pathname, String] path @see Xcodeproj::Project#path
-    # @param  [Bool] skip_initialization Whether the project should be initialized from scratch.
+    # @param  [Boolean] skip_initialization Whether the project should be initialized from scratch.
     # @param  [Int] object_version Object version to use for serialization, defaults to Xcode 3.2 compatible.
     #
     def initialize(path, skip_initialization = false,
@@ -107,10 +107,10 @@ module Pod
     # @param  [#to_s] path
     #         The path to the root of the Pod.
     #
-    # @param  [Bool] development
+    # @param  [Boolean] development
     #         Whether the group should be added to the Development Pods group.
     #
-    # @param  [Bool] absolute
+    # @param  [Boolean] absolute
     #         Whether the path of the group should be set as absolute.
     #
     # @return [PBXGroup] The new group.
@@ -136,7 +136,7 @@ module Pod
     # @param [Project] project
     #        The subproject to be added.
     #
-    # @param [Bool] development
+    # @param [Boolean] development
     #        Whether the project should be added to the Development Pods group.
     #        For projects where `pod_target_subproject` is enabled, all subprojects are added into the Dependencies group.
     #
@@ -156,7 +156,7 @@ module Pod
     # @param [TargetMetadata] metadata
     #        The project metadata to be added.
     #
-    # @param [Bool] development
+    # @param [Boolean] development
     #        Whether the project should be added to the Development Pods group.
     #        For projects where `pod_target_subproject` is enabled, all subprojects are added into the Dependencies group.
     #
@@ -253,7 +253,7 @@ module Pod
     # @param  [PBXGroup] group
     #         The group for the new file reference.
     #
-    # @param  [Bool] reflect_file_system_structure
+    # @param  [Boolean] reflect_file_system_structure
     #         Whether group structure should reflect the file system structure.
     #         If yes, where needed, intermediate groups are created, similar to
     #         how mkdir -p operates.
@@ -430,7 +430,7 @@ module Pod
     # @param  [PBXGroup] group
     #         The parent group used as the base of the relative path.
     #
-    # @param  [Bool] reflect_file_system_structure
+    # @param  [Boolean] reflect_file_system_structure
     #         Whether group structure should reflect the file system structure.
     #         If yes, where needed, intermediate groups are created, similar to
     #         how mkdir -p operates.

--- a/lib/cocoapods/resolver.rb
+++ b/lib/cocoapods/resolver.rb
@@ -34,7 +34,7 @@ module Pod
     #
     attr_reader :sources
 
-    # @return [Bool] Whether the resolver has sources repositories up-to-date.
+    # @return [Boolean] Whether the resolver has sources repositories up-to-date.
     #
     attr_reader :specs_updated
     alias specs_updated? specs_updated
@@ -531,7 +531,7 @@ You have either:#{specs_update_message}
     #
     # @param  [Specification] spec
     #
-    # @return [Bool]
+    # @return [Boolean]
     #
     def spec_is_platform_compatible?(dependency_graph, dependency, spec)
       # This is safe since a pod will only be in locked dependencies if we're
@@ -575,7 +575,7 @@ You have either:#{specs_update_message}
     # Whether the given `edge` should be followed to find dependencies for the
     # given `target_platform`.
     #
-    # @return [Bool]
+    # @return [Boolean]
     #
     def edge_is_valid_for_target_platform?(edge, target_platform)
       @edge_validity ||= Hash.new do |hash, edge_and_platform|

--- a/lib/cocoapods/resolver/resolver_specification.rb
+++ b/lib/cocoapods/resolver/resolver_specification.rb
@@ -12,7 +12,7 @@ module Pod
       #
       attr_reader :source
 
-      # @return [Bool] whether this resolved specification is used by non-library targets.
+      # @return [Boolean] whether this resolved specification is used by non-library targets.
       #
       attr_reader :used_by_non_library_targets_only
       alias used_by_non_library_targets_only? used_by_non_library_targets_only

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -192,7 +192,7 @@ module Pod
     #
     # @param  [String] name
     #
-    # @return [Bool] true if originally absolute
+    # @return [Boolean] true if originally absolute
     #
     def local_path_was_absolute?(name)
       @pods_with_absolute_path.include? name
@@ -342,7 +342,7 @@ module Pod
     # @param  [String] name
     #         The name of the Pod.
     #
-    # @return [Bool] Whether the Pod has been pre-downloaded.
+    # @return [Boolean] Whether the Pod has been pre-downloaded.
     #
     def predownloaded?(name)
       root_name = Specification.root_name(name)
@@ -406,7 +406,7 @@ module Pod
     # @param  [Pathname, String] path
     #         The path to the local Podspec
     #
-    # @param  [Bool] was_absolute
+    # @param  [Boolean] was_absolute
     #         True if the specified local path was absolute.
     #
     # @return [void]
@@ -428,7 +428,7 @@ module Pod
     # @param  [String] name
     #         The name of the Pod.
     #
-    # @return [Bool] Whether the Pod is locally sourced.
+    # @return [Boolean] Whether the Pod is locally sourced.
     #
     def local?(name)
       !local_podspec(name).nil?

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -504,7 +504,7 @@ module Pod
       # @option options [Array<String>] :exclude_patterns
       #         The exclude patterns to pass to the PathList.
       #
-      # @option options [Bool] :include_dirs
+      # @option options [Boolean] :include_dirs
       #         Whether directories should be also included or just plain
       #         files.
       #

--- a/lib/cocoapods/sandbox/path_list.rb
+++ b/lib/cocoapods/sandbox/path_list.rb
@@ -164,7 +164,7 @@ module Pod
 
       # @!group Private helpers
 
-      # @return [Bool] Wether a path is a directory. The result of this method
+      # @return [Boolean] Wether a path is a directory. The result of this method
       #         computed without accessing the file system and is case
       #         insensitive.
       #

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -116,7 +116,7 @@ module Pod
       #
       # @param  [String] source_name
       #
-      # @param  [Bool] show_output
+      # @param  [Boolean] show_output
       #
       # @return [void]
       #

--- a/lib/cocoapods/target/pod_target.rb
+++ b/lib/cocoapods/target/pod_target.rb
@@ -285,7 +285,7 @@ module Pod
       end
     end
 
-    # @return [Bool] Whether or not this target should be built.
+    # @return [Boolean] Whether or not this target should be built.
     #
     # A target should not be built if it has no source files.
     #
@@ -947,7 +947,7 @@ module Pod
 
     # Checks if warnings should be inhibited for this pod.
     #
-    # @return [Bool]
+    # @return [Boolean]
     #
     def inhibit_warnings?
       return @inhibit_warnings if defined? @inhibit_warnings

--- a/lib/cocoapods/user_interface.rb
+++ b/lib/cocoapods/user_interface.rb
@@ -25,7 +25,7 @@ module Pod
       #
       attr_accessor :output_io
 
-      # @return [Bool] Whether the wrapping of the strings to the width of the
+      # @return [Boolean] Whether the wrapping of the strings to the width of the
       #         terminal should be disabled.
       #
       attr_accessor :disable_wrap
@@ -370,7 +370,7 @@ module Pod
       #
       # @param [String]  message The message to print.
       # @param [Array]   actions The actions that the user should take.
-      # @param [Bool]    verbose_only
+      # @param [Boolean]    verbose_only
       #        Restrict the appearance of the warning to verbose mode only
       #
       # return [void]

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -110,7 +110,7 @@ module Pod
     # @note   This method shows immediately which pod is being processed and
     #         overrides the printed line once the result is known.
     #
-    # @return [Bool] whether the specification passed validation.
+    # @return [Boolean] whether the specification passed validation.
     #
     def validate
       @results = []
@@ -201,23 +201,23 @@ module Pod
 
     #  @!group Configuration
 
-    # @return [Bool] whether the validation should skip the checks that
+    # @return [Boolean] whether the validation should skip the checks that
     #         requires the download of the library.
     #
     attr_accessor :quick
 
-    # @return [Bool] whether the linter should not clean up temporary files
+    # @return [Boolean] whether the linter should not clean up temporary files
     #         for inspection.
     #
     attr_accessor :no_clean
 
-    # @return [Bool] whether the linter should fail as soon as the first build
+    # @return [Boolean] whether the linter should fail as soon as the first build
     #         variant causes an error. Helpful for i.e. multi-platforms specs,
     #         specs with subspecs.
     #
     attr_accessor :fail_fast
 
-    # @return [Bool] whether the validation should be performed against the root of
+    # @return [Boolean] whether the validation should be performed against the root of
     #         the podspec instead to its original source.
     #
     # @note   Uses the `:path` option of the Podfile.
@@ -225,7 +225,7 @@ module Pod
     attr_accessor :local
     alias_method :local?, :local
 
-    # @return [Bool] Whether the validator should fail on warnings, or only on errors.
+    # @return [Boolean] Whether the validator should fail on warnings, or only on errors.
     #
     attr_accessor :allow_warnings
 
@@ -233,11 +233,11 @@ module Pod
     #
     attr_accessor :only_subspec
 
-    # @return [Bool] Whether the validator should validate all subspecs.
+    # @return [Boolean] Whether the validator should validate all subspecs.
     #
     attr_accessor :no_subspecs
 
-    # @return [Bool] Whether the validator should skip building and running tests.
+    # @return [Boolean] Whether the validator should skip building and running tests.
     #
     attr_accessor :skip_tests
 
@@ -245,11 +245,11 @@ module Pod
     #
     attr_accessor :test_specs
 
-    # @return [Bool] Whether the validator should run Xcode Static Analysis.
+    # @return [Boolean] Whether the validator should run Xcode Static Analysis.
     #
     attr_accessor :analyze
 
-    # @return [Bool] Whether frameworks should be used for the installation.
+    # @return [Boolean] Whether frameworks should be used for the installation.
     #
     attr_accessor :use_frameworks
 
@@ -983,7 +983,7 @@ module Pod
     #         the deployment target, which should be declared in
     #         the Podfile.
     #
-    # @param  [Bool] use_frameworks
+    # @param  [Boolean] use_frameworks
     #         whether frameworks should be used for the installation
     #
     # @param [Array<String>] test_spec_names
@@ -1122,7 +1122,7 @@ module Pod
     # @param  [Platform] platform
     #         The platform to check
     #
-    # @return [Bool] True if the platform is valid
+    # @return [Boolean] True if the platform is valid
     #
     def valid_platform?(platform)
       VALID_PLATFORMS.any? { |p| p.name == platform.name }
@@ -1136,7 +1136,7 @@ module Pod
     # @param  [Specification] spec
     #         The specification which must support the provided platform
     #
-    # @return [Bool] Whether the platform is supported by the specification
+    # @return [Boolean] Whether the platform is supported by the specification
     #
     def supported_platform?(platform, spec)
       available_platforms = spec.available_platforms


### PR DESCRIPTION
This PR is to replace `[Bool]` with `[Boolean]` in method comments.

In the project,  `@param [Boolean]` or `@return [Boolean]` and `@param [Bool]` or `@return [Bool]` are mixed up in the method comments, so the goal is to unify them into `@param [Boolean]` or `@return [Boolean]` according to the [YARD convention](https://www.rubydoc.info/gems/yard/file/docs/Tags.md#literals).