### PR TITLE
Update ubuntu to 18.04

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.6]
-        os: [ubuntu-16.04]
+        os: [ubuntu-18.04]
 
     name: Lint
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         task: [SPECS]
         ruby: [2.6, 2.7, 3.0]
-        os: [ubuntu-16.04]
+        os: [ubuntu-18.04]
         include:
           - task: SPECS
             os: macos-10.15


### PR DESCRIPTION
Pointing to `1-11-stable` because we are still actively working on that branch. It will be auto-merged to `master` after.

See https://github.com/actions/virtual-environments/issues/3287