### PR TITLE
Set `PRODUCT_BUNDLE_IDENTIFIER` for generated app during lint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Set `PRODUCT_BUNDLE_IDENTIFIER` for generated app during lint.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10933](https://github.com/CocoaPods/CocoaPods/issues/10933)
 
 
 ## 1.11.0 (2021-09-01)

--- a/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/app_host_installer.rb
@@ -62,7 +62,8 @@ module Pod
           # @param [Hash] info_plist_entries see #info_plist_entries
           # @param [String] product_basename see #product_basename
           #
-          def initialize(sandbox, project, platform, subgroup_name, group_name, app_target_label, add_main: true, add_launchscreen_storyboard: platform == :ios, info_plist_entries: {}, product_basename: nil)
+          def initialize(sandbox, project, platform, subgroup_name, group_name, app_target_label, add_main: true,
+                         add_launchscreen_storyboard: platform == :ios, info_plist_entries: {}, product_basename: nil)
             @sandbox = sandbox
             @project = project
             @platform = platform

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -585,10 +585,13 @@ module Pod
       info_plist_path = app_project.path.dirname.+('App/App-Info.plist')
       Pod::Installer::Xcode::PodsProjectGenerator::TargetInstallerHelper.create_info_plist_file_with_sandbox(sandbox, info_plist_path, app_target, '1.0.0', Platform.new(consumer.platform_name), :appl)
       Pod::Generator::AppTargetHelper.add_swift_version(app_target, derived_swift_version)
-      # Lint will fail if a AppIcon is set but no image is found with such name
-      # Happens only with Static Frameworks enabled but shouldn't be set anyway
       app_target.build_configurations.each do |config|
+        # Lint will fail if a AppIcon is set but no image is found with such name
+        # Happens only with Static Frameworks enabled but shouldn't be set anyway
         config.build_settings.delete('ASSETCATALOG_COMPILER_APPICON_NAME')
+        # Ensure this is set generally but we have seen an issue with ODRs:
+        # see: https://github.com/CocoaPods/CocoaPods/issues/10933
+        config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
       end
       app_project.save
       app_project.recreate_user_schemes

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -1792,7 +1792,7 @@ module Pod
         project.native_targets.find { |t| t.name == 'App' }
       end
 
-      describe 'check appicon key deleted' do
+      describe 'sets various configuration settings' do
         before do
           @validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
           @validator.stubs(:validate_url)
@@ -1802,39 +1802,79 @@ module Pod
           @validator.send(:tear_down_validation_environment)
         end
 
-        it 'ios platform deletes AppIcon key' do
-          consumer = Specification.from_file(podspec_path).consumer(:ios)
-          target = create_target_with_validator_consumer(@validator, consumer)
+        describe 'sets the product bundle identifier' do
+          it 'ios platform sets product bundle identifier' do
+            consumer = Specification.from_file(podspec_path).consumer(:ios)
+            target = create_target_with_validator_consumer(@validator, consumer)
 
-          target.build_configurations.each do |config|
-            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            target.build_configurations.each do |config|
+              config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+            end
+          end
+
+          it 'tvos platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:tvos)
+            target = create_target_with_validator_consumer(@validator, consumer)
+
+            target.build_configurations.each do |config|
+              config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+            end
+          end
+
+          it 'osx platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:osx)
+            target = create_target_with_validator_consumer(@validator, consumer)
+
+            target.build_configurations.each do |config|
+              config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+            end
+          end
+
+          it 'watchos platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:watchos)
+            target = create_target_with_validator_consumer(@validator, consumer)
+
+            target.build_configurations.each do |config|
+              config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'].should == 'org.cocoapods.${PRODUCT_NAME:rfc1034identifier}'
+            end
           end
         end
 
-        it 'tvos platform deletes AppIcon key' do
-          consumer = Specification.from_file(podspec_path).consumer(:tvos)
-          target = create_target_with_validator_consumer(@validator, consumer)
+        describe 'check appicon key deleted' do
+          it 'ios platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:ios)
+            target = create_target_with_validator_consumer(@validator, consumer)
 
-          target.build_configurations.each do |config|
-            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            target.build_configurations.each do |config|
+              config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            end
           end
-        end
 
-        it 'osx platform deletes AppIcon key' do
-          consumer = Specification.from_file(podspec_path).consumer(:osx)
-          target = create_target_with_validator_consumer(@validator, consumer)
+          it 'tvos platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:tvos)
+            target = create_target_with_validator_consumer(@validator, consumer)
 
-          target.build_configurations.each do |config|
-            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            target.build_configurations.each do |config|
+              config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            end
           end
-        end
 
-        it 'watchos platform deletes AppIcon key' do
-          consumer = Specification.from_file(podspec_path).consumer(:watchos)
-          target = create_target_with_validator_consumer(@validator, consumer)
+          it 'osx platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:osx)
+            target = create_target_with_validator_consumer(@validator, consumer)
 
-          target.build_configurations.each do |config|
-            config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            target.build_configurations.each do |config|
+              config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            end
+          end
+
+          it 'watchos platform deletes AppIcon key' do
+            consumer = Specification.from_file(podspec_path).consumer(:watchos)
+            target = create_target_with_validator_consumer(@validator, consumer)
+
+            target.build_configurations.each do |config|
+              config.build_settings.key?('ASSETCATALOG_COMPILER_APPICON_NAME').should.be.false
+            end
           end
         end
       end


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/10933

cc @penelopearaujo