### PR TITLE
Add method for formatting licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 * None.  
 * Add method for formatting licenses for acknowledgements generation.    
+* Add method for formatting licenses for acknowledgements generation.  
   [Raihaan Shouhell](https://github.com/res0nance)
+  [#10940](https://github.com/CocoaPods/CocoaPods/pull/10940)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 ##### Enhancements
 
 * None.  
+* Add method for formatting licenses for acknowledgements generation.    
+  [Raihaan Shouhell](https://github.com/res0nance)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#11158](https://github.com/CocoaPods/CocoaPods/pull/11158)
 
+* Add method for formatting licenses for acknowledgements generation.  
+  [Raihaan Shouhell](https://github.com/res0nance)
+  [#10940](https://github.com/CocoaPods/CocoaPods/pull/10940)
+
 ##### Bug Fixes
 
 * Clean sandbox when a pod switches from remote to local.  
@@ -35,10 +39,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 ##### Enhancements
 
 * None.  
-* Add method for formatting licenses for acknowledgements generation.    
-* Add method for formatting licenses for acknowledgements generation.  
-  [Raihaan Shouhell](https://github.com/res0nance)
-  [#10940](https://github.com/CocoaPods/CocoaPods/pull/10940)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/acknowledgements.rb
+++ b/lib/cocoapods/generator/acknowledgements.rb
@@ -84,7 +84,19 @@ module Pod
           elsif license_file = file_accessor(spec).license
             text = IO.read(license_file)
           end
+          text = format_license(text)
         end
+        text
+      end
+
+      # Convenience method for users to format licenses
+      #
+      # @param  [String] text
+      #         Unformatted license text
+      #
+      # @return [String] Formatted license text
+      #
+      def format_license(text)
         text
       end
 


### PR DESCRIPTION
We can change the footer / header as per https://blog.cocoapods.org/Acknowledgements/

But we can't touch the license itself besides copy pasting the entire private method.
Add a method such that we can format license texts without having to copy the entire private method