### PR TITLE
Handle spec repo urls with user info when determining if they are CDN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Handle spec repo urls with user info when determining if they are CDN.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10941](https://github.com/CocoaPods/CocoaPods/issues/10941)
+
 * Set `INFOPLIST_FILE` build setting to `$(SRCROOT)/App/App-Info.plist` during lint.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10927](https://github.com/CocoaPods/CocoaPods/issues/10927)

--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -71,12 +71,15 @@ module Pod
       #         The URL of the source.
       #
       def cdn_url?(url)
-        return unless url =~ %r{^https?:\/\/}
+        return false unless url =~ %r{^https?:\/\/}
 
         uri_options = {}
 
         netrc_info = Netrc.read
-        netrc_host = URI.parse(url).host
+        uri = URI.parse(url)
+        return false unless uri.userinfo.nil?
+
+        netrc_host = uri.host
         credentials = netrc_info[netrc_host]
         uri_options[:http_basic_authentication] = credentials if credentials
 

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -154,6 +154,10 @@ module Pod
           @sources_manager.cdn_url?('http://cdn.cocoapods.org').should == true
         end
 
+        it 'spec repo with userinfo' do
+          @sources_manager.cdn_url?('https://foo:bar@bitbucket.org/foobar/Specs.git').should == false
+        end
+
         it 'git master spec repo' do
           stub_as_404('https://github.com/cocoapods/specs.git')
           stub_as_404('https://github.com/cocoapods/specs')


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/10941