### PR TITLE
Use `${DEVELOPMENT_LANGUAGE}` as the default `CFBundleDevelopmentRegion` value in any generated `Info.plist`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Use `${DEVELOPMENT_LANGUAGE}` as the default `CFBundleDevelopmentRegion` value in any generated `Info.plist`.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10950](https://github.com/CocoaPods/CocoaPods/pull/10950)
 
 ##### Bug Fixes
 

--- a/Rakefile
+++ b/Rakefile
@@ -219,7 +219,7 @@ begin
         exit 1
       end
       title 'Running Integration tests'
-      rm_rf 'tmp'
+      FileUtils.rm_rf 'tmp'
       title 'Building all the fixtures'
       sh('bundle exec bacon spec/integration.rb') {}
       title 'Storing fixtures'
@@ -228,8 +228,8 @@ begin
         name = source.match(%r{^tmp/(.+)/transformed$})[1]
         destination = "spec/cocoapods-integration-specs/#{name}/after"
         if File.exist?(destination)
-          rm_rf destination
-          mv source, destination
+          FileUtils.rm_rf destination
+          FileUtils.mv source, destination
         end
       end
 

--- a/lib/cocoapods/generator/info_plist_file.rb
+++ b/lib/cocoapods/generator/info_plist_file.rb
@@ -112,7 +112,7 @@ module Pod
           'CFBundleSignature' => '????',
           'CFBundleVersion' => '${CURRENT_PROJECT_VERSION}',
           'NSPrincipalClass' => '',
-          'CFBundleDevelopmentRegion' => 'en',
+          'CFBundleDevelopmentRegion' => '${PODS_DEVELOPMENT_LANGUAGE}',
         }
 
         info['CFBundleExecutable'] = '${EXECUTABLE_NAME}' if bundle_package_type != :bndl

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -602,6 +602,11 @@ module Pod
           target.pod_target_srcroot
         end
 
+        # @return [String]
+        define_build_settings_method :pods_development_language, :build_setting => true do
+          '${DEVELOPMENT_LANGUAGE}'
+        end
+
         #-------------------------------------------------------------------------#
 
         # @!group Frameworks

--- a/spec/unit/generator/info_plist_file_spec.rb
+++ b/spec/unit/generator/info_plist_file_spec.rb
@@ -20,7 +20,7 @@ module Pod
       file = temporary_directory + 'Info.plist'
       generator.save_as(file)
       Xcodeproj::Plist.read_from_path(file).should == {
-        'CFBundleDevelopmentRegion' => 'en',
+        'CFBundleDevelopmentRegion' => '${PODS_DEVELOPMENT_LANGUAGE}',
         'CFBundleExecutable' => '${EXECUTABLE_NAME}',
         'CFBundleIdentifier' => '${PRODUCT_BUNDLE_IDENTIFIER}',
         'CFBundleInfoDictionaryVersion' => '6.0',
@@ -38,7 +38,7 @@ module Pod
       file = temporary_directory + 'Info.plist'
       generator.save_as(file)
       Xcodeproj::Plist.read_from_path(file).should == {
-        'CFBundleDevelopmentRegion' => 'en',
+        'CFBundleDevelopmentRegion' => '${PODS_DEVELOPMENT_LANGUAGE}',
         'CFBundleExecutable' => '${EXECUTABLE_NAME}',
         'CFBundleIdentifier' => '${PRODUCT_BUNDLE_IDENTIFIER}',
         'CFBundleInfoDictionaryVersion' => '6.0',
@@ -56,7 +56,7 @@ module Pod
       file = temporary_directory + 'Info.plist'
       generator.save_as(file)
       Xcodeproj::Plist.read_from_path(file).should == {
-        'CFBundleDevelopmentRegion' => 'en',
+        'CFBundleDevelopmentRegion' => '${PODS_DEVELOPMENT_LANGUAGE}',
         'CFBundleExecutable' => '${EXECUTABLE_NAME}',
         'CFBundleIdentifier' => '${PRODUCT_BUNDLE_IDENTIFIER}',
         'CFBundleInfoDictionaryVersion' => '6.0',
@@ -74,7 +74,7 @@ module Pod
       file = temporary_directory + 'Info.plist'
       generator.save_as(file)
       Xcodeproj::Plist.read_from_path(file).should == {
-        'CFBundleDevelopmentRegion' => 'en',
+        'CFBundleDevelopmentRegion' => '${PODS_DEVELOPMENT_LANGUAGE}',
         'CFBundleExecutable' => '${EXECUTABLE_NAME}',
         'CFBundleIdentifier' => '${PRODUCT_BUNDLE_IDENTIFIER}',
         'CFBundleInfoDictionaryVersion' => '6.0',


### PR DESCRIPTION
Xcode by default uses `${DEVELOPMENT_LANGUAGE}` for this value, however, there is no UI to update it. I put it behind `PODS_DEVELOPMENT_LANGUAGE` so folks can go to build settings to change it.

<img width="1103" alt="Screen Shot 2021-09-16 at 3 44 27 PM" src="https://user-images.githubusercontent.com/310370/133702781-a0686350-68f6-4029-a520-27b03e597f94.png">

Integration specs https://github.com/CocoaPods/cocoapods-integration-specs/pull/327