### PR TITLE
Do not consider `podspec_repo` when analying sandbox for changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Do not consider podspec_repo when analying sandbox for changes.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#10985](https://github.com/CocoaPods/CocoaPods/pull/10985)
+
 * Rewrite XCFramework slice selection using plist metadata.  
   [Igor Makarov](https://github.com/igor-makarov)
   [#11229](https://github.com/CocoaPods/CocoaPods/pull/11229)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -125,7 +125,7 @@ module Pod
         validate_platforms(resolver_specs_by_target)
         specifications = generate_specifications(resolver_specs_by_target)
         aggregate_targets, pod_targets = generate_targets(resolver_specs_by_target, target_inspections)
-        sandbox_state   = generate_sandbox_state(specifications)
+        sandbox_state = generate_sandbox_state(specifications)
         specs_by_target = resolver_specs_by_target.each_with_object({}) do |rspecs_by_target, hash|
           hash[rspecs_by_target[0]] = rspecs_by_target[1].map(&:spec)
         end

--- a/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
+++ b/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
@@ -145,7 +145,8 @@ module Pod
           return true if spec.version != sandbox_version(pod)
           return true if spec.checksum != sandbox_checksum(pod)
           return true if resolved_spec_names(pod) != sandbox_spec_names(pod)
-          return true if podfile_dependency(pod) != sandbox_dependency(pod)
+          podfile_dep = podfile_dependency(pod)&.tap { |dep| dep.podspec_repo = nil }
+          return true if podfile_dep != sandbox_dependency(pod)
           return true if sandbox.predownloaded?(pod)
           return true if folder_empty?(pod)
           false

--- a/spec/unit/installer/analyzer/sandbox_analyzer_spec.rb
+++ b/spec/unit/installer/analyzer/sandbox_analyzer_spec.rb
@@ -92,6 +92,15 @@ module Pod
         @analyzer.stubs(:podfile_dependency).returns(dep2)
         @analyzer.send(:pod_changed?, 'BananaLib').should == true
       end
+
+      it 'does not consider the podspec repo on whether a dependency has changed' do
+        dep1 = Dependency.new('BananaLib')
+        dep2 = Dependency.new('BananaLib')
+        dep2.podspec_repo = 'https://some/repo/my_repo.git'
+        @analyzer.stubs(:sandbox_dependency).returns(dep1)
+        @analyzer.stubs(:podfile_dependency).returns(dep2)
+        @analyzer.send(:pod_changed?, 'BananaLib').should == false
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
This PR landed for 1.11.x release https://github.com/CocoaPods/CocoaPods/pull/10825 which caused a side-effect in which pods inside the Podfile with explicit `source` set are not matching the sandbox manifest.

It seems the sandbox manifest does not load the spec repo when parsing dependencies from the `Manifest.lock` file.