### PR TITLE
cdn_url? check shouldn't crash operations. Catch YAML.load failure

### DIFF
--- a/lib/cocoapods/sources_manager.rb
+++ b/lib/cocoapods/sources_manager.rb
@@ -86,7 +86,7 @@ module Pod
         response = OpenURI.open_uri(url.chomp('/') + '/CocoaPods-version.yml', uri_options)
         response_hash = YAML.load(response.read) # rubocop:disable Security/YAMLLoad
         response_hash.is_a?(Hash) && !Source::Metadata.new(response_hash).latest_cocoapods_version.nil?
-      rescue ::OpenURI::HTTPError, SocketError
+      rescue Psych::SyntaxError, ::OpenURI::HTTPError, SocketError
         return false
       rescue => e
         raise Informative, "Couldn't determine repo type for URL: `#{url}`: #{e}"

--- a/spec/unit/sources_manager_spec.rb
+++ b/spec/unit/sources_manager_spec.rb
@@ -179,16 +179,12 @@ module Pod
         end
 
         it 'fake 200 response' do
-          HTML_RESPONSE = '<!doctype html>
-          <html>
-           <head>
-            <title>Some page</title>\n\n <meta charset=\"utf-8\" />
-           <body>
-            <div>
-             <h1>Some page</h1>
-            </div>
-           </body>
-           </html>"'.freeze
+          # really broken (not compatible with YAML) html that may return any endpoint
+          # i.e. login page after request redirect
+          HTML_RESPONSE = '<!DOCTYPE html>
+            <html class="devise-layout-html">
+            <head prefix="og: http://ogp.me/ns#">
+            <meta charset="utf-8">'.freeze
           WebMock.stub_request(:get, 'https://some_host.com/something/CocoaPods-version.yml').
             to_return(:status => 200, :body => HTML_RESPONSE)
           @sources_manager.cdn_url?('https://some_host.com/something').should == false


### PR DESCRIPTION
Some services (i.e. gitlab) on `https://url/repo.git/CocoaPods-version.yml` request will redirect to a login page with http status 200.
Such response body will not be a valid YAML and throw exception.
HTML in a test case was YAML compatible, now it's a real garbage.

fixes #11010 