### PR TITLE
Change minimal required version of ruby-macho to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10950](https://github.com/CocoaPods/CocoaPods/pull/10950)
 
+* Change `ruby-macho` minimal required version 2.0 to upgrade ruby-macho when users update CocoaPods.
+  [Jeroen Bobbeldijk](https://github.com/jerbob92)
+  [#10390](https://github.com/CocoaPods/CocoaPods/issues/10390)
+
 ##### Bug Fixes
 
 * None.  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
+      ruby-macho (>= 2.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
 
 GEM

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '>= 2.3.0', '< 3.0'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '>= 1.0', '< 3.0'
+  s.add_runtime_dependency 'ruby-macho',    '>= 2.0', '< 3.0'
 
   s.add_runtime_dependency 'addressable', '~> 2.8'
 


### PR DESCRIPTION
:rainbow: 
In response to #10390

This is needed because gem does not automatically upgrade ruby-macho to a 2+ version when upgrading CocoaPods.
Since more and more people will upgrade their macOS to Big Sur, this issue will be more common. 