### PR TITLE
Change minimal required version of ruby-macho to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Clean sandbox when a pod switches from remote to local.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#11213](https://github.com/CocoaPods/CocoaPods/pull/11213)
+* Change minimal required version of ruby-macho to 2.3.0.
+  [xuzhongping](https://github.com/xuzhongping)
+  [#10390](https://github.com/CocoaPods/CocoaPods/issues/10390)
+
+
 
 * Run post install hooks when "skip Pods.xcodeproj generation" option is set
   [Elton Gao](https://github.com/gyfelton)
@@ -668,7 +673,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Add support for integrating dependency file in user script phases.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9082](https://github.com/CocoaPods/CocoaPods/issues/9082)
- 
+
 * Add support for XCFrameworks using the `vendored_frameworks` Podspec DSL.  
   [Eric Amorde](https://github.com/amorde)
   [#9148](https://github.com/CocoaPods/CocoaPods/issues/9148)
@@ -1373,7 +1378,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Nests test specs host apps inside that Pod's directory for cleaner project 
   navigators.  
   [Derek Ostrander](https://github.com/dostrander)
-   
+  
 * mark_ruby_file_ref add indent width and tab width config  
   [dacaiguoguogmail](https://github.com/dacaiguoguogmail)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,7 +673,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Add support for integrating dependency file in user script phases.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#9082](https://github.com/CocoaPods/CocoaPods/issues/9082)
-
+ 
 * Add support for XCFrameworks using the `vendored_frameworks` Podspec DSL.  
   [Eric Amorde](https://github.com/amorde)
   [#9148](https://github.com/CocoaPods/CocoaPods/issues/9148)
@@ -1378,7 +1378,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Nests test specs host apps inside that Pod's directory for cleaner project 
   navigators.  
   [Derek Ostrander](https://github.com/dostrander)
-  
+   
 * mark_ruby_file_ref add indent width and tab width config  
   [dacaiguoguogmail](https://github.com/dacaiguoguogmail)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,14 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Clean sandbox when a pod switches from remote to local.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#11213](https://github.com/CocoaPods/CocoaPods/pull/11213)
-* Change minimal required version of ruby-macho to 2.3.0.
-  [xuzhongping](https://github.com/xuzhongping)
-  [#10390](https://github.com/CocoaPods/CocoaPods/issues/10390)
 
-
-
-* Run post install hooks when "skip Pods.xcodeproj generation" option is set
+* Run post install hooks when "skip Pods.xcodeproj generation" option is set  
   [Elton Gao](https://github.com/gyfelton)
   [#11073](https://github.com/CocoaPods/CocoaPods/pull/11073)
+
+* Change minimal required version of ruby-macho to 2.3.0.  
+  [xuzhongping](https://github.com/xuzhongping)
+  [#10390](https://github.com/CocoaPods/CocoaPods/issues/10390)
 
 ## 1.11.2 (2021-09-13)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
+      ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
 
 GEM

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '>= 2.3.0', '< 3.0'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '>= 1.0', '< 3.0'
+  s.add_runtime_dependency 'ruby-macho',    '>= 2.3.0', '< 3.0'
 
   s.add_runtime_dependency 'addressable', '~> 2.8'
 


### PR DESCRIPTION
The problem comes from #10390 
The specific repair version of ruby-macho is 2.3.0 [ruby-macho-commit](https://github.com/Homebrew/ruby-macho/commit/f17ed3780ad15db85e5079eafd10b26f5b58c489)