### PR TITLE
Fix post install hooks from Podfile not ran if skip_pods_project_generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#11213](https://github.com/CocoaPods/CocoaPods/pull/11213)
 
+* Run post install hooks when "skip Pods.xcodeproj generation" option is set
+  [Elton Gao](https://github.com/gyfelton)
+  [#11073](https://github.com/CocoaPods/CocoaPods/pull/11073)
 
 ## 1.11.2 (2021-09-13)
 

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -163,6 +163,7 @@ module Pod
       validate_targets
       if installation_options.skip_pods_project_generation?
         show_skip_pods_project_generation_message
+        run_podfile_post_install_hooks
       else
         integrate
       end

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -138,7 +138,6 @@ module Pod
 
         hooks = sequence('hooks')
         @installer.expects(:run_podfile_post_install_hooks).once.in_sequence(hooks)
-        Installer::Xcode::PodsProjectWriter.any_instance.expects(:save_projects).once.in_sequence(hooks)
 
         @installer.install!
       end


### PR DESCRIPTION
Right now `run_podfile_post_install_hooks ` is only ran when `skip_pods_project_generation` option is set to false
I have a use case where I want to set skip_pods_project_generation to false and still run some post install hooks.

Unless there is explicit reason not to call it when skip_pods_project_generation is false, I see this as a bug? Just that few ppl ever run into my combo. (want skip_pods_project_generation + run post install hook)

TODO:
- [x] Change log
- [x]  Write/fix specs
- [x] Have an integration test case?