### PR TITLE
Fix static Swift XCFramework import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Kanstantsin Shautsou](https://github.com/KostyaSha)
   [#11010](https://github.com/CocoaPods/CocoaPods/issues/11010)
 
+* Fix static Swift XCFramework import paths.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#11058](https://github.com/CocoaPods/CocoaPods/issues/10058)
+  [#11093](https://github.com/CocoaPods/CocoaPods/pull/11093)
+
 ## 1.11.2 (2021-09-13)
 
 ##### Enhancements

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -938,6 +938,8 @@ module Pod
         define_build_settings_method :swift_include_paths, :build_setting => true, :memoized => true, :sorted => true, :uniqued => true do
           paths = dependent_targets.flat_map { |pt| pt.build_settings[@configuration].swift_include_paths_to_import }
           paths.concat swift_include_paths_to_import if non_library_xcconfig?
+          vendored_static_library_search_paths = dependent_targets.flat_map { |pt| pt.build_settings[@configuration].vendored_static_library_search_paths }
+          paths.concat vendored_static_library_search_paths
           paths.concat ['$(PLATFORM_DIR)/Developer/usr/lib'] if should_apply_xctunwrap_fix?
           paths
         end

--- a/spec/unit/target/build_settings/pod_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/pod_target_settings_spec.rb
@@ -211,7 +211,7 @@ module Pod
             hash = generator.generate.to_hash
             hash['SYSTEM_FRAMEWORK_SEARCH_PATHS'].should.be.nil
             hash['LIBRARY_SEARCH_PATHS'].should.not.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
-            hash['SWIFT_INCLUDE_PATHS'].should.be.nil
+            hash['SWIFT_INCLUDE_PATHS'].should.not.include '"$(PLATFORM_DIR)/Developer/usr/lib"'
           end
 
           it 'saves the xcconfig' do


### PR DESCRIPTION
Resolves #10058

Has an integration fixture update here: https://github.com/CocoaPods/cocoapods-integration-specs/pull/329