### PR TITLE
fix: turn a warning message to a error message

### DIFF
--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -140,7 +140,7 @@ install_xcframework() {
   select_slice "${paths[@]}"
   local target_path="$SELECT_SLICE_RETVAL"
   if [[ -z "$target_path" ]]; then
-    echo "warning: [CP] Unable to find matching .xcframework slice in '${paths[@]}' for the current build architectures ($ARCHS)."
+    echo "error: [CP] Unable to find matching .xcframework slice in '${paths[@]}' for the current build architectures ($ARCHS)."
     return
   fi
   local source="$basepath/$target_path"


### PR DESCRIPTION
if it just cause a warning,  most of us maybe ignore it, then it will cost some  errors like 
- header file cannot be found 
- symbol not found

and developer will be puzzled by these errors,because the frameworks are copy to the build space(XCFRAMEWORKS_BUILD_DIR_VARIABLE), in another way, it cause a not visual error