### PR TITLE
Fix setting `LD_RUNTIME_SEARCH_PATHS` for aggregate targets that include dynamic xcframeworks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#10950](https://github.com/CocoaPods/CocoaPods/pull/10950)
 
+* Fix setting `LD_RUNTIME_SEARCH_PATHS` for aggregate targets that include dynamic xcframeworks.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#11158](https://github.com/CocoaPods/CocoaPods/pull/11158)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -179,12 +179,21 @@ module Pod
         end
       end
 
-      # @return [Array<Pathname>] The paths of the dynamic xcframework bundles
+      # @return [Array<Pathname>] The paths of the static xcframework bundles
       #         that come shipped with the Pod.
       #
       def vendored_static_xcframeworks
         vendored_xcframeworks.select do |path|
           Xcode::XCFramework.new(spec.name, path).build_type == BuildType.static_framework
+        end
+      end
+
+      # @return [Array<Pathname>] The paths of the dynamic xcframework bundles
+      #         that come shipped with the Pod.
+      #
+      def vendored_dynamic_xcframeworks
+        vendored_xcframeworks.select do |path|
+          Xcode::XCFramework.new(spec.name, path).build_type == BuildType.dynamic_framework
         end
       end
 

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -1288,7 +1288,7 @@ module Pod
         define_build_settings_method :any_vendored_dynamic_artifacts?, :memoized => true do
           pod_targets.any? do |pt|
             pt.file_accessors.any? do |fa|
-              !fa.vendored_dynamic_artifacts.empty?
+              !fa.vendored_dynamic_artifacts.empty? || !fa.vendored_dynamic_xcframeworks.empty?
             end
           end
         end

--- a/spec/fixtures/xcframeworks/xcframework-spec.podspec
+++ b/spec/fixtures/xcframeworks/xcframework-spec.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name             = 'xcframework-spec'
+  s.version          = '1.0'
+  s.author           = { 'xcframework-spec' => 'xcframework-spec@xcframework-spec.com' }
+  s.summary          = 'Use this podspec for tests to point to different xcframeworks for testing'
+  s.description      = 'Use this podspec for tests to point to different xcframeworks for testing'
+  s.homepage         = 'http://xcframework-spec.com'
+  s.source          = { :git => 'http://xcframework-spec-corp.local/xcframework-spec-lib.git', :tag => 'v1.0' }
+  s.license          = 'MIT'
+
+  s.platform     = :ios, '8.0'
+end

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -342,6 +342,24 @@ module Pod
             end
           end
 
+          describe 'with a vendored dynamic xcframework pod' do
+            before do
+              coconut_pod_target = @pod_targets.first
+              coconut_pod_target.stubs(:build_type).returns(BuildType.static_library)
+            end
+
+            def specs
+              spec = fixture_spec('xcframeworks/xcframework-spec.podspec')
+              spec.vendored_frameworks = 'DynamicFramework/CoconutLib.xcframework'
+              [spec]
+            end
+
+            it 'includes default runpath search path list when linking vendored dynamic xcframework' do
+              @target.stubs(:build_type => BuildType.dynamic_framework)
+              @generator.generate.to_hash['LD_RUNPATH_SEARCH_PATHS'].should == "$(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'"
+            end
+          end
+
           describe 'with a scoped pod target' do
             def specs
               [


### PR DESCRIPTION
If an app (and its aggregate target) only consume pre-built dynamic xcframeworks (xcframeworks with slices that are dynamically linked) then we never set the `LD_RUNTIME_SEARCH_PATHS` because we only do it if any of our dependencies are dynamic or whether vendored *frameworks* are dynamic.

This PR fixes this.