### PR TITLE
Add the ability to download pods in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Raihaan Shouhell](https://github.com/res0nance)
   [#10940](https://github.com/CocoaPods/CocoaPods/pull/10940)
 
+* Add the ability to download pods in parallel  
+  [Seth Friedman](https://github.com/sethfri)
+  [#11232](https://github.com/CocoaPods/CocoaPods/pull/11232)
+
 ##### Bug Fixes
 
 * Clean sandbox when a pod switches from remote to local.  

--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -513,7 +513,8 @@ module Pod
       # Download pods in parallel before installing if the option is set
       if installation_options.parallel_pod_downloads
         require 'concurrent/executor/fixed_thread_pool'
-        thread_pool = Concurrent::FixedThreadPool.new(40, :idletime => 300)
+        thread_pool_size = installation_options.parallel_pod_download_thread_pool_size
+        thread_pool = Concurrent::FixedThreadPool.new(thread_pool_size, :idletime => 300)
 
         sorted_root_specs.each do |spec|
           if pods_to_install.include?(spec.name)

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -190,6 +190,10 @@ module Pod
       # Whether to skip generating the `Pods.xcodeproj` and perform only dependency resolution and downloading.
       #
       option :skip_pods_project_generation, false
+
+      # Whether to download pods in parallel before beginning the installation process
+      #
+      option :parallel_pod_downloads, false
     end
   end
 end

--- a/lib/cocoapods/installer/installation_options.rb
+++ b/lib/cocoapods/installer/installation_options.rb
@@ -194,6 +194,13 @@ module Pod
       # Whether to download pods in parallel before beginning the installation process
       #
       option :parallel_pod_downloads, false
+
+      # The size of the thread pool to use when downloading pods in parallel. Only takes effect when
+      # `parallel_pod_downloads` is `true`.
+      #
+      # Default: 40
+      #
+      option(:parallel_pod_download_thread_pool_size, 40, :boolean => false)
     end
   end
 end

--- a/lib/cocoapods/installer/pod_source_downloader.rb
+++ b/lib/cocoapods/installer/pod_source_downloader.rb
@@ -1,0 +1,145 @@
+
+module Pod
+  class Installer
+    # Controller class responsible for downloading the activated specifications
+    # of a single Pod.
+    #
+    # @note This class needs to consider all the activated specs of a Pod.
+    #
+    class PodSourceDownloader
+      UNENCRYPTED_PROTOCOLS = %w(http git).freeze
+
+      # @return [Sandbox] The installation target.
+      #
+      attr_reader :sandbox
+
+      # @return [Podfile] the podfile that should be integrated with the user
+      #         projects.
+      #
+      attr_reader :podfile
+
+      # @return [Hash{Symbol=>Array}] The specifications that need to be
+      #         installed grouped by platform.
+      #
+      attr_reader :specs_by_platform
+
+      # @return [Boolean] Whether the installer is allowed to touch the cache.
+      #
+      attr_reader :can_cache
+      alias can_cache? can_cache
+
+      # Initialize a new instance
+      #
+      # @param [Sandbox] sandbox @see #sandbox
+      # @param [Podfile] podfile @see #podfile
+      # @param [Hash{Symbol=>Array}] specs_by_platform @see #specs_by_platform
+      # @param [Boolean] can_cache @see #can_cache
+      #
+      def initialize(sandbox, podfile, specs_by_platform, can_cache: true)
+        @sandbox = sandbox
+        @podfile = podfile
+        @specs_by_platform = specs_by_platform
+        @can_cache = can_cache
+      end
+
+      # @return [String] A string suitable for debugging.
+      #
+      def inspect
+        "<#{self.class} sandbox=#{sandbox.root} pod=#{root_spec.name}"
+      end
+
+      # @return [String] The name of the pod this downloader is downloading.
+      #
+      def name
+        root_spec.name
+      end
+
+      #-----------------------------------------------------------------------#
+
+      public
+
+      # @!group Downloading
+
+      # Creates the target in the Pods project and the relative support files.
+      #
+      # @return [void]
+      #
+      def download!
+        verify_source_is_secure(root_spec)
+        download_result = Downloader.download(download_request, root, :can_cache => can_cache?)
+
+        if (specific_source = download_result.checkout_options) && specific_source != root_spec.source
+          sandbox.store_checkout_source(root_spec.name, specific_source)
+        end
+
+        sandbox.store_downloaded_pod(root_spec.name)
+      end
+
+      #-----------------------------------------------------------------------#
+
+      private
+
+      # @!group Download Steps
+
+      # Verify the source of the spec is secure, which is used to show a warning to the user if that isn't the case
+      # This method doesn't verify all protocols, but currently only prohibits unencrypted 'http://' and 'git://''
+      # connections.
+      #
+      # @return [void]
+      #
+      def verify_source_is_secure(root_spec)
+        return if root_spec.source.nil? || (root_spec.source[:http].nil? && root_spec.source[:git].nil?)
+        source = if !root_spec.source[:http].nil?
+                   URI(root_spec.source[:http].to_s)
+                 elsif !root_spec.source[:git].nil?
+                   git_source = root_spec.source[:git].to_s
+                   return unless git_source =~ /^#{URI::DEFAULT_PARSER.make_regexp}$/
+                   URI(git_source)
+                 end
+        if UNENCRYPTED_PROTOCOLS.include?(source.scheme) && source.host != 'localhost'
+          UI.warn "'#{root_spec.name}' uses the unencrypted '#{source.scheme}' protocol to transfer the Pod. " \
+                'Please be sure you\'re in a safe network with only trusted hosts. ' \
+                'Otherwise, please reach out to the library author to notify them of this security issue.'
+        end
+      end
+
+      def download_request
+        Downloader::Request.new(
+          :spec => root_spec,
+          :released => released?,
+          )
+      end
+
+      #-----------------------------------------------------------------------#
+
+      private
+
+      # @!group Convenience methods.
+
+      # @return [Array<Specifications>] the specification of the Pod used in
+      #         this installation.
+      #
+      def specs
+        specs_by_platform.values.flatten
+      end
+
+      # @return [Specification] the root specification of the Pod.
+      #
+      def root_spec
+        specs.first.root
+      end
+
+      # @return [Pathname] the folder where the source of the Pod is located.
+      #
+      def root
+        sandbox.pod_dir(root_spec.name)
+      end
+
+      def released?
+        sandbox.specification(root_spec.name) != root_spec
+      end
+
+      #-----------------------------------------------------------------------#
+    end
+  end
+end

--- a/lib/cocoapods/installer/pod_source_downloader.rb
+++ b/lib/cocoapods/installer/pod_source_downloader.rb
@@ -107,7 +107,7 @@ module Pod
         Downloader::Request.new(
           :spec => root_spec,
           :released => released?,
-          )
+        )
       end
 
       #-----------------------------------------------------------------------#
@@ -133,6 +133,20 @@ module Pod
       #
       def root
         sandbox.pod_dir(root_spec.name)
+      end
+
+      # @return [Boolean] whether the source has been pre downloaded in the
+      #         resolution process to retrieve its podspec.
+      #
+      def predownloaded?
+        sandbox.predownloaded_pods.include?(root_spec.name)
+      end
+
+      # @return [Boolean] whether the pod uses the local option and thus
+      #         CocoaPods should not interfere with the files of the user.
+      #
+      def local?
+        sandbox.local?(root_spec.name)
       end
 
       def released?

--- a/lib/cocoapods/sandbox.rb
+++ b/lib/cocoapods/sandbox.rb
@@ -67,6 +67,7 @@ module Pod
       @root = Pathname.new(root).realpath
       @public_headers = HeadersStore.new(self, 'Public', :public)
       @predownloaded_pods = []
+      @downloaded_pods = []
       @checkout_sources = {}
       @development_pods = {}
       @pods_with_absolute_path = []
@@ -347,6 +348,42 @@ module Pod
       root_name = Specification.root_name(name)
       predownloaded_pods.include?(root_name)
     end
+
+    #--------------------------------------#
+
+    # Marks a Pod as downloaded
+    #
+    # @param  [String] name
+    #         The name of the Pod.
+    #
+    # @return [void]
+    #
+    def store_downloaded_pod(name)
+      root_name = Specification.root_name(name)
+      downloaded_pods << root_name
+    end
+
+    # Checks if a Pod has been downloaded before the installation
+    # process.
+    #
+    # @param  [String] name
+    #         The name of the Pod.
+    #
+    # @return [Boolean] Whether the Pod has been downloaded.
+    #
+    def downloaded?(name)
+      root_name = Specification.root_name(name)
+      downloaded_pods.include?(root_name)
+    end
+
+    # @return [Array<String>] The names of the pods that have been
+    #         downloaded before the installation process begins.
+    #         These are distinct from the pre-downloaded pods in
+    #         that these do not necessarily come from external
+    #         sources, and are only downloaded right before
+    #         installation if the parallel_pod_downloads option is on.
+    #
+    attr_reader :downloaded_pods
 
     #--------------------------------------#
 

--- a/spec/unit/installer/installation_options_spec.rb
+++ b/spec/unit/installer/installation_options_spec.rb
@@ -72,6 +72,8 @@ module Pod
           'generate_multiple_pod_projects' => false,
           'incremental_installation' => false,
           'skip_pods_project_generation' => false,
+          'parallel_pod_downloads' => false,
+          'parallel_pod_download_thread_pool_size' => 40,
         }
       end
 

--- a/spec/unit/installer/pod_source_downloader_spec.rb
+++ b/spec/unit/installer/pod_source_downloader_spec.rb
@@ -1,0 +1,83 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  describe Installer::PodSourceDownloader do
+    FIXTURE_HEAD = Dir.chdir(SpecHelper.fixture('banana-lib')) { `git rev-parse HEAD`.chomp }
+
+    before do
+      @podfile = Podfile.new
+      @spec = fixture_spec('banana-lib/BananaLib.podspec')
+      @spec.source = { :git => SpecHelper.fixture('banana-lib') }
+      specs_by_platform = { :ios => [@spec] }
+      @downloader = Installer::PodSourceDownloader.new(config.sandbox, @podfile, specs_by_platform)
+    end
+
+    #-------------------------------------------------------------------------#
+
+    describe 'Download' do
+      it 'does not show warning if the source is encrypted using https' do
+        @spec.source = { :http => 'https://orta.io/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.length.should.equal(0)
+      end
+
+      it 'does not show warning if the source uses file:///' do
+        @spec.source = { :http => 'file:///orta.io/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.length.should.equal(0)
+      end
+
+      it 'shows a warning if the source is unencrypted with http://' do
+        @spec.source = { :http => 'http://orta.io/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.should.include 'uses the unencrypted \'http\' protocol'
+      end
+
+      it 'does not show a warning if the source is http://localhost' do
+        @spec.source = { :http => 'http://localhost:123/sdk.zip' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.length.should.equal(0)
+      end
+
+      it 'shows a warning if the source is unencrypted with git://' do
+        @spec.source = { :git => 'git://git.orta.io/orta.git' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.should.include 'uses the unencrypted \'git\' protocol'
+      end
+
+      it 'does not warn for local repositories with spaces' do
+        @spec.source = { :git => '/Users/kylef/Projects X', :tag => '1.0' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.length.should.equal(0)
+      end
+
+      it 'does not warn for SSH repositories' do
+        @spec.source = { :git => 'git@bitbucket.org:kylef/test.git', :tag => '1.0' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.length.should.equal(0)
+      end
+
+      it 'does not warn for SSH repositories on Github' do
+        @spec.source = { :git => 'git@github.com:kylef/test.git', :tag => '1.0' }
+        dummy_response = Pod::Downloader::Response.new
+        Downloader.stubs(:download).returns(dummy_response)
+        @downloader.download!
+        UI.warnings.length.should.equal(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, when CocoaPods installs a pod, it first downloads the pod if it's not local or already cached, and then it does the installation for the pod. It does this combined download/installation step serially for each pod that needs to be installed.

While parallelizing the pod installation process itself might be a larger effort given the potential assumptions built in throughout the codebase that installation is performed serially, we can still improve `pod install` times significantly by parallelizing the downloads.

To do this, we first need to separate the download step from the installation step, instead of doing downloading and installing at the same time for each pod. Using the opt-in `:parallel_pod_downloads` option, CocoaPods now downloads all pods in parallel, and then moves on to serially install each pod. By default, this is done with 40 threads, which is the sweet spot I found in my testing. However, the number of threads is configurable via the `:parallel_pod_download_thread_pool_size` option.

The PR is likely easiest to review commit-by-commit:
* Add `parallel_pod_downloads` option
* Extract `PodSourceDownloader` out of `PodSourceInstaller`
* Implement parallel downloads
* Add `parallel_pod_download_thread_pool_size` option
* Extract `section_title` method

In my testing of a proprietary project on a 2020 M1 MacBook Pro, I got the following results for a completely clean `pod install` (after running `rm -rf Pods && rm -rf ~/Library/Caches/CocoaPods`):

```
No parallelization
pod install  82.63s user 33.51s system 25% cpu 7:35.21 total

10 threads
pod install  93.61s user 38.64s system 78% cpu 2:47.81 total

20 threads
pod install  94.86s user 40.38s system 89% cpu 2:31.75 total

30 threads
pod install  92.38s user 39.68s system 92% cpu 2:22.82 total

40 threads
pod install  94.31s user 43.23s system 99% cpu 2:18.13 total

50 threads
pod install  97.80s user 42.16s system 68% cpu 2:28.04 total
```

This means that using 40 threads to parallelize downloads instead of no parallelization results in a 70% speedup for clean pod install times, saving 5 min 17 sec for this particular project.