### PR TITLE
[pod_variant_set] install pods with default_subspecs set to :none

### DIFF
--- a/lib/cocoapods/installer/analyzer/pod_variant_set.rb
+++ b/lib/cocoapods/installer/analyzer/pod_variant_set.rb
@@ -116,13 +116,15 @@ module Pod
         def scope_by_specs
           root_spec = variants.first.root_spec
           specs = [root_spec]
-          specs += if root_spec.default_subspecs.empty?
-                     root_spec.subspecs.compact
-                   else
-                     root_spec.default_subspecs.map do |subspec_name|
-                       root_spec.subspec_by_name("#{root_spec.name}/#{subspec_name}")
+          if root_spec.default_subspecs != :none
+            specs += if root_spec.default_subspecs.empty?
+                       root_spec.subspecs.compact
+                     else
+                       root_spec.default_subspecs.map do |subspec_name|
+                         root_spec.subspec_by_name("#{root_spec.name}/#{subspec_name}")
+                       end
                      end
-                   end
+          end
           default_specs = Set.new(specs)
           grouped_variants = group_by(&:specs)
           all_spec_variants = grouped_variants.map { |set| set.variants.first.specs }


### PR DESCRIPTION
Fixes #10264 

Fixes error being thrown when trying to run `pod install` in a project with pods that set `spec.default_subspecs = :none`. This should be supported, as is stated in the [documentation](https://guides.cocoapods.org/syntax/podspec.html#default_subspecs).