### PR TITLE
Re-use the same path lists for pods that share the same root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
+* Re-use the same path lists for pods that share the same root.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#11417](https://github.com/CocoaPods/CocoaPods/pull/11417)
+
 * Integrate `parallelizable` scheme DSL option.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#11399](https://github.com/CocoaPods/CocoaPods/pull/11399)

--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -84,6 +84,7 @@ module Pod
         @installation_options = podfile.installation_options
         @podfile_dependency_cache = PodfileDependencyCache.from_podfile(podfile)
         @sources_manager = sources_manager
+        @path_lists = {}
         @result = nil
       end
 
@@ -830,7 +831,10 @@ module Pod
       def create_file_accessors(specs, platform)
         name = specs.first.name
         pod_root = sandbox.pod_dir(name)
-        path_list = Sandbox::PathList.new(pod_root)
+        path_list = @path_lists.fetch(pod_root) do |root|
+          path_list = Sandbox::PathList.new(root)
+          @path_lists[root] = path_list
+        end
         specs.map do |spec|
           Sandbox::FileAccessor.new(path_list, spec.consumer(platform))
         end


### PR DESCRIPTION
Given a repo that has multiple podspecs at the root, it seems all podspecs retrieve a separate instance of `PathList` which in turn calls `read_file_system` which constantly globs the entire repository.

For large repositories this can be very slow.