### PR TITLE
Use Bash in scripts that set `pipefail`

### DIFF
--- a/examples/Excluded-Archs-Example/CoconutLib/build.sh
+++ b/examples/Excluded-Archs-Example/CoconutLib/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This will build and export `CoconutLib.xcframework` to `build/CoconutLib.xcframework` including all supported slices.
 #

--- a/examples/Oddly-Named-XCF-Slices-Example/CoconutLib/build.sh
+++ b/examples/Oddly-Named-XCF-Slices-Example/CoconutLib/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This will build and export `CoconutLib.xcframework` to `build/CoconutLib.xcframework` including all supported slices.
 #

--- a/examples/Vendored XCFramework Example/CoconutLib/build.sh
+++ b/examples/Vendored XCFramework Example/CoconutLib/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This will build and export `CoconutLib.xcframework` to `build/CoconutLib.xcframework` including all supported slices.
 # Use the `--static` flag to build static frameworks instead.

--- a/examples/Vendored-XCFramework12-Example/BananaLib/build.sh
+++ b/examples/Vendored-XCFramework12-Example/BananaLib/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This will build and export `BananaLib.xcframework` to `build/BananaLib.xcframework` including all supported slices.
 #

--- a/examples/Vendored-XCFramework12-Example/CoconutLib/build.sh
+++ b/examples/Vendored-XCFramework12-Example/CoconutLib/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This will build and export `CoconutLib.xcframework` to `build/CoconutLib.xcframework` including all supported slices.
 #

--- a/lib/cocoapods/generator/script_phase_constants.rb
+++ b/lib/cocoapods/generator/script_phase_constants.rb
@@ -2,7 +2,7 @@ module Pod
   module Generator
     module ScriptPhaseConstants
       DEFAULT_SCRIPT_PHASE_HEADER = <<-SH.strip_heredoc.freeze
-#!/bin/sh
+#!/bin/bash
 set -e
 set -u
 set -o pipefail


### PR DESCRIPTION
`pipefail` is a non-POSIX Bash feature, and if `sh` is symlinked to something other than Bash (e.g. Dash, `sudo ln -sf /bin/dash /private/var/select/sh`)[1], these scripts would fail to run.
