### PR TITLE
Fix incremental installation when dependent pod resources change

### DIFF
--- a/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
+++ b/lib/cocoapods/installer/project_cache/project_cache_analyzer.rb
@@ -139,10 +139,10 @@ module Pod
             when PodTarget
               local = sandbox.local?(target.pod_name)
               checkout_options = sandbox.checkout_sources[target.pod_name]
-              [label, TargetCacheKey.from_pod_target(sandbox, target, :is_local_pod => local,
-                                                                      :checkout_options => checkout_options)]
+              [label, TargetCacheKey.from_pod_target(sandbox, target_by_label, target,
+                                                     :is_local_pod => local, :checkout_options => checkout_options)]
             when AggregateTarget
-              [label, TargetCacheKey.from_aggregate_target(sandbox, target)]
+              [label, TargetCacheKey.from_aggregate_target(sandbox, target_by_label, target)]
             else
               raise "[BUG] Unknown target type #{target}"
             end

--- a/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
+++ b/spec/unit/installer/project_cache/project_cache_analyzer_spec.rb
@@ -19,6 +19,7 @@ module Pod
                                                                  Pod::Target::DEFAULT_BUILD_CONFIGURATIONS, [],
                                                                  Pod::Platform.new(:ios, '6.0'),
                                                                  secondary_target_definition)
+          @targets_by_label = Hash[(@pod_targets + [@main_aggregate_target] + [@secondary_aggregate_target]).map { |target| [target.label, target] }]
           @sandbox.project_path.mkpath
           @main_aggregate_target.support_files_dir.mkpath
           @secondary_aggregate_target.support_files_dir.mkpath
@@ -39,8 +40,8 @@ module Pod
           end
 
           it 'returns an empty result if no targets have changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
@@ -50,8 +51,8 @@ module Pod
           end
 
           it 'returns the list of pod targets that have changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             @banana_lib.root_spec.stubs(:checksum).returns('Blah')
@@ -62,8 +63,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if the build configurations have changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations.merge('Production' => :release), @project_object_version, {}, @pod_targets, [@main_aggregate_target], {})
@@ -73,8 +74,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if the list of podfile plugins changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, {})
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins' => {} }, @pod_targets, [@main_aggregate_target], {})
@@ -84,8 +85,8 @@ module Pod
           end
 
           it 'returns empty list when comparing plugins with different ordering of arguments' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, 'my-plugins' => %w[B A])
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins' => %w[A B] }, @pod_targets, [@main_aggregate_target], {})
@@ -95,8 +96,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if the list of podfile plugins params changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, 'my-plugins-1' => {}, 'my-plugins-2' => {})
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins-2' => { 'input' => 1 }, 'my-plugins-1' => {} }, @pod_targets, [@main_aggregate_target], {})
@@ -106,8 +107,8 @@ module Pod
           end
 
           it 'returns empty list if the list of podfile plugins is not different' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, 'my-plugins-1' => {}, 'my-plugins-2' => {})
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, { 'my-plugins-2' => {}, 'my-plugins-1' => {} }, @pod_targets, [@main_aggregate_target], {})
@@ -117,8 +118,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if the project object version configurations has changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, 2, {}, @pod_targets, [@main_aggregate_target], {})
@@ -128,8 +129,8 @@ module Pod
           end
 
           it 'returns all pod targets and aggregate targets if a project name has changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             @banana_lib.stubs(:project_name).returns('SomeProject')
@@ -140,9 +141,9 @@ module Pod
           end
 
           it 'returns all aggregate targets if one has changed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
             cache_key_by_aggregate_target_labels = {
-              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target),
+              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target),
               @secondary_aggregate_target.label => TargetCacheKey.from_cache_hash(@sandbox, 'BUILD_SETTINGS_CHECKSUM' => 'Blah'),
             }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
@@ -155,10 +156,10 @@ module Pod
           end
 
           it 'returns all aggregate targets if one has been removed' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
             cache_key_by_aggregate_target_labels = {
-              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target),
-              @secondary_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @secondary_aggregate_target),
+              @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target),
+              @secondary_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @secondary_aggregate_target),
             }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
@@ -170,7 +171,7 @@ module Pod
           end
 
           it 'returns all aggregate targets if one has been added' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
             cache_key_by_aggregate_target_labels = {}
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
@@ -191,7 +192,7 @@ module Pod
 
           it 'returns a pod if its target support dir is dirty' do
             FileUtils.rm_rf @orange_lib.support_files_dir
-            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [], {})
             result = analyzer.analyze
@@ -201,7 +202,7 @@ module Pod
 
           it 'returns a pod if its project file is dirty' do
             FileUtils.rm_rf @sandbox.pod_target_project_path(@orange_lib.pod_name)
-            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
+            cache_key_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
             analyzer = ProjectCacheAnalyzer.new(@sandbox, cache, @build_configurations, @project_object_version, {}, @pod_targets, [], {})
             result = analyzer.analyze
@@ -213,8 +214,8 @@ module Pod
             cache_pod_targets = [@banana_lib, @orange_lib]
             FileUtils.rm_rf @sandbox.pod_target_project_path(@monkey_lib.pod_name)
 
-            cache_key_by_pod_target_labels = Hash[cache_pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[cache_pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version)
 
@@ -236,7 +237,7 @@ module Pod
             end
 
             cache_key_by_aggregate_target_labels = {
-              subspec_target_1.label => TargetCacheKey.from_pod_target(@sandbox, subspec_target_1),
+              subspec_target_1.label => TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, subspec_target_1),
               subspec_target_2.label => TargetCacheKey.from_cache_hash(@sandbox, 'BUILD_SETTINGS_CHECKSUM' => 'Blah'),
             }
             cache = ProjectInstallationCache.new(cache_key_by_aggregate_target_labels, @build_configurations, @project_object_version)
@@ -260,7 +261,7 @@ module Pod
             end
 
             cache_key_by_aggregate_target_labels = {
-              subspec_target_1.label => TargetCacheKey.from_pod_target(@sandbox, original_subspec),
+              subspec_target_1.label => TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, original_subspec),
             }
 
             cache = ProjectInstallationCache.new(cache_key_by_aggregate_target_labels, @build_configurations, @project_object_version)
@@ -271,8 +272,8 @@ module Pod
           end
 
           it 'returns all pod targets when installation options change' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, {}, 'share_schemes_for_development_pods' => false, 'lock_pod_sources' => true)
             installation_options = { 'share_schemes_for_development_pods' => false }
@@ -283,8 +284,8 @@ module Pod
           end
 
           it 'returns empty list when installation options do not change' do
-            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, pod_target)] }]
-            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @main_aggregate_target) }
+            cache_key_by_pod_target_labels = Hash[@pod_targets.map { |pod_target| [pod_target.label, TargetCacheKey.from_pod_target(@sandbox, @targets_by_label, pod_target)] }]
+            cache_key_by_aggregate_target_labels = { @main_aggregate_target.label => TargetCacheKey.from_aggregate_target(@sandbox, @targets_by_label, @main_aggregate_target) }
             cache_key_target_labels = cache_key_by_pod_target_labels.merge(cache_key_by_aggregate_target_labels)
             cache = ProjectInstallationCache.new(cache_key_target_labels, @build_configurations, @project_object_version, {}, 'share_schemes_for_development_pods' => false, 'lock_pod_sources' => true)
             installation_options = { 'lock_pod_sources' => true, 'share_schemes_for_development_pods' => false }

--- a/spec/unit/installer/project_cache/target_cache_key_spec.rb
+++ b/spec/unit/installer/project_cache/target_cache_key_spec.rb
@@ -8,9 +8,10 @@ module Pod
         before do
           @banana_spec = fixture_spec('banana-lib/BananaLib.podspec')
           @banana_pod_target = fixture_pod_target(@banana_spec)
-          @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target)
           @aggregate_target = fixture_aggregate_target
-          @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, @aggregate_target)
+          @targets_by_label = Hash[[@banana_pod_target, @aggregate_target].map { |target| [target.label, target] }]
+          @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @targets_by_label, @banana_pod_target)
+          @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, @targets_by_label, @aggregate_target)
         end
 
         describe 'cache key structure' do
@@ -20,7 +21,8 @@ module Pod
             subspec2 = Pod::Specification.new(root_spec, 'Module')
 
             pod_target = fixture_pod_target_with_specs([root_spec, subspec1, subspec2], BuildType.dynamic_framework)
-            cache_key = TargetCacheKey.from_pod_target(config.sandbox, pod_target)
+            targets_by_label = Hash[[pod_target].map { |target| [target.label, target] }]
+            cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, pod_target)
             cache_key.to_h['SPECS'].should.equal(['BananaLib (1.0)', 'BananaLib/Module (1.0)', 'BananaLib/MUS (1.0)'])
           end
 
@@ -28,7 +30,8 @@ module Pod
             aggregate_target = AggregateTarget.new(config.sandbox, BuildType.static_library, { 'Debug' => :debug }, [], Platform.ios,
                                                    fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
                                                    nil, 'Debug' => [@banana_pod_target])
-            aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, aggregate_target)
+            targets_by_label = Hash[[aggregate_target].map { |target| [target.label, target] }]
+            aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, targets_by_label, aggregate_target)
             library_resources = @banana_pod_target.resource_paths.values.flatten.sort_by(&:downcase)
             aggregate_target_cache_key.to_h['FILES'].should.equal(library_resources)
           end
@@ -37,10 +40,11 @@ module Pod
             aggregate_target = AggregateTarget.new(config.sandbox, BuildType.static_library, { 'Debug' => :debug }, [], Platform.ios,
                                                    fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
                                                    nil, 'Debug' => [@banana_pod_target])
+            targets_by_label = Hash[[aggregate_target].map { |target| [target.label, target] }]
             @banana_pod_target.stubs(:resource_paths).returns({})
             on_demand_resources = { 'tag1' => { :paths => [Pathname('/path/to/resource')], :category => :download_on_demand } }
             @banana_pod_target.file_accessors.first.stubs(:on_demand_resources).returns(on_demand_resources)
-            aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, aggregate_target)
+            aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, targets_by_label, aggregate_target)
             library_on_demand_resources = @banana_pod_target.file_accessors.first.on_demand_resources_files.map do |p|
               p.relative_path_from(config.sandbox.root).to_s.downcase
             end
@@ -51,9 +55,10 @@ module Pod
             aggregate_target = AggregateTarget.new(config.sandbox, BuildType.static_library, { 'Debug' => :debug }, [], Platform.ios,
                                                    fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
                                                    nil, 'Debug' => [@banana_pod_target])
+            targets_by_label = Hash[[aggregate_target].map { |target| [target.label, target] }]
             on_demand_resources = { 'tag1' => { :paths => [Pathname('/path/to/resource')], :category => :download_on_demand } }
             @banana_pod_target.file_accessors.first.stubs(:on_demand_resources).returns(on_demand_resources)
-            aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, aggregate_target)
+            aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, targets_by_label, aggregate_target)
             library_resources = @banana_pod_target.resource_paths.values.flatten.sort_by(&:downcase)
             library_on_demand_resources = @banana_pod_target.file_accessors.first.on_demand_resources_files.map do |p|
               p.relative_path_from(config.sandbox.root).to_s.downcase
@@ -70,7 +75,8 @@ module Pod
           it 'should return inequality for different checksums' do
             diff_banana_checksum = fixture_pod_target('banana-lib/BananaLib.podspec')
             diff_banana_checksum.root_spec.stubs(:checksum).returns('blah')
-            diff_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, diff_banana_checksum)
+            targets_by_label = Hash[[diff_banana_checksum].map { |target| [target.label, target] }]
+            diff_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, diff_banana_checksum)
             difference = @banana_cache_key.key_difference(diff_banana_cache_key)
             inverse_difference = diff_banana_cache_key.key_difference(@banana_cache_key)
             difference.should.equal(:project)
@@ -79,7 +85,8 @@ module Pod
 
           it 'should return inequality for external pod turned local' do
             local_banana = fixture_pod_target('banana-lib/BananaLib.podspec')
-            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, local_banana, :is_local_pod => true)
+            targets_by_label = Hash[[local_banana].map { |target| [target.label, target] }]
+            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, local_banana, :is_local_pod => true)
             difference = @banana_cache_key.key_difference(local_banana_cache_key)
             inverse_difference = local_banana_cache_key.key_difference(@banana_cache_key)
             difference.should.equal(:project)
@@ -101,7 +108,9 @@ module Pod
             added_dependency_aggregate_target = AggregateTarget.new(config.sandbox, BuildType.static_library, { 'Debug' => :debug }, [], Platform.ios,
                                                                     fixture_target_definition('MyApp'), config.sandbox.root.dirname, nil,
                                                                     nil, 'Debug' => [@banana_pod_target])
+            targets_by_label = Hash[[added_dependency_aggregate_target].map { |target| [target.label, target] }]
             added_dependency_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox,
+                                                                              targets_by_label,
                                                                               added_dependency_aggregate_target)
             diff = @aggregate_target_cache_key.key_difference(added_dependency_cache_key)
             inverse_diff = added_dependency_cache_key.key_difference(@aggregate_target_cache_key)
@@ -113,27 +122,30 @@ module Pod
             old_checkout_options = { 'BananaLib' => { :git => 'https://git.com', :sha => '1' } }
             new_checkout_options = { 'BananaLib' => { :git => 'https://git.com', :sha => '2' } }
 
-            banana_sha1_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+            targets_by_label = Hash[[@banana_pod_target].map { |target| [target.label, target] }]
+
+            banana_sha1_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target,
                                                                    :checkout_options => old_checkout_options)
-            banana_sha2_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+            banana_sha2_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target,
                                                                    :checkout_options => new_checkout_options)
 
             banana_sha1_cache_key.key_difference(banana_sha2_cache_key).should.equal(:project)
 
-            banana_no_checkout_options = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target)
+            banana_no_checkout_options = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target)
             banana_no_checkout_options.key_difference(banana_sha1_cache_key).should.equal(:project)
             banana_sha1_cache_key.key_difference(banana_no_checkout_options).should.equal(:project)
           end
 
           it 'should return inequality if the list of tracked files has changed' do
             added_banana_files_target = fixture_pod_target('banana-lib/BananaLib.podspec')
-            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+            targets_by_label = Hash[[@banana_pod_target, added_banana_files_target].map { |target| [target.label, target] }]
+            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target,
                                                                :is_local_pod => true)
             new_file = [(Pod::Sandbox::PathList.new(@banana_spec.defined_in_file.dirname).root + 'CoolFile.h')]
             added_files_list = new_file + @banana_pod_target.all_files
             added_banana_files_target.stubs(:all_files).returns(added_files_list)
 
-            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, added_banana_files_target,
+            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, added_banana_files_target,
                                                                     :is_local_pod => true)
             diff = added_banana_cache_key.key_difference(@banana_cache_key)
             inverse_diff = @banana_cache_key.key_difference(added_banana_cache_key)
@@ -143,7 +155,8 @@ module Pod
 
           it 'should return inequality for aggregate target if the list of tracked resource files has changed' do
             @aggregate_target = fixture_aggregate_target([@banana_pod_target])
-            @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, @aggregate_target)
+            targets_by_label = Hash[[@aggregate_target].map { |target| [target.label, target] }]
+            @aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, targets_by_label, @aggregate_target)
 
             added_banana_files_target = fixture_pod_target('banana-lib/BananaLib.podspec')
             new_file = (Pod::Sandbox::PathList.new(@banana_spec.defined_in_file.dirname).root + 'Resources/CoolFile.png').to_s
@@ -153,7 +166,8 @@ module Pod
             added_banana_files_target.stubs(:resource_paths).returns(added_files_list)
 
             added_aggregate_target = fixture_aggregate_target([added_banana_files_target])
-            added_aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, added_aggregate_target)
+            added_targets_by_label = Hash[[@aggregate_target, added_aggregate_target].map { |target| [target.label, target] }]
+            added_aggregate_target_cache_key = TargetCacheKey.from_aggregate_target(config.sandbox, added_targets_by_label, added_aggregate_target)
             added_aggregate_target_cache_key.to_h['FILES'].should.include?(new_file.to_s)
             diff = added_aggregate_target_cache_key.key_difference(@aggregate_target_cache_key)
             inverse_diff = @aggregate_target_cache_key.key_difference(added_aggregate_target_cache_key)
@@ -168,7 +182,9 @@ module Pod
               'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/../../spec/fixtures/banana-lib"',
             }
             changed_build_settings_target.build_settings.each_value { |settings| settings.stubs(:xcconfig).returns(Xcodeproj::Config.new(changed_build_settings)) }
+            targets_by_label = Hash[[changed_build_settings_target].map { |target| [target.label, target] }]
             changed_build_settings_cache_key = TargetCacheKey.from_pod_target(config.sandbox,
+                                                                              targets_by_label,
                                                                               changed_build_settings_target)
             @banana_cache_key.key_difference(changed_build_settings_cache_key).should.equal(:project)
             changed_build_settings_cache_key.key_difference(@banana_cache_key).should.equal(:project)
@@ -176,10 +192,11 @@ module Pod
 
           it 'should return inequality if the project name changed' do
             banana_project_target = fixture_pod_target('banana-lib/BananaLib.podspec')
-            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target)
+            targets_by_label = Hash[[banana_project_target].map { |target| [target.label, target] }]
+            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target)
             banana_project_target.stubs(:project_name).returns('SomeProject')
 
-            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, banana_project_target)
+            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, banana_project_target)
             diff = added_banana_cache_key.key_difference(@banana_cache_key)
             inverse_diff = @banana_cache_key.key_difference(added_banana_cache_key)
             diff.should.equal(:project)
@@ -195,7 +212,7 @@ module Pod
           end
 
           it 'should return equality for same local pod target and hash' do
-            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @targets_by_label, @banana_pod_target,
                                                                     :is_local_pod => true)
             hash_cache_key = TargetCacheKey.from_cache_hash(config.sandbox, local_banana_cache_key.to_h)
             local_banana_cache_key.key_difference(hash_cache_key).should.equal(:none)
@@ -203,7 +220,7 @@ module Pod
           end
 
           it 'should return inequality for modified pod target' do
-            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @banana_pod_target,
+            local_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, @targets_by_label, @banana_pod_target,
                                                                     :is_local_pod => true)
             cache_hash = local_banana_cache_key.to_h.dup
             cache_hash['FILES'] = cache_hash['FILES'].dup << 'Blah.h'

--- a/spec/unit/installer/project_cache/target_cache_key_spec.rb
+++ b/spec/unit/installer/project_cache/target_cache_key_spec.rb
@@ -202,6 +202,25 @@ module Pod
             diff.should.equal(:project)
             inverse_diff.should.equal(:project)
           end
+
+          it 'should return inequality if an upstream pod changes resources' do
+            monkey_target = fixture_pod_target('monkey/monkey.podspec')
+            targets_by_label = Hash[[@banana_pod_target, monkey_target].map { |target| [target.label, target] }]
+            @banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target,
+                                                               :is_local_pod => true)
+
+            # make up a new object to avoid the memoization of a target's resource_paths
+            monkey_target = fixture_pod_target('monkey/monkey.podspec')
+            monkey_target.file_accessors.first.stubs(:resource_bundles).returns('monkey_bundle' => ['Resources/**/*'])
+
+            targets_by_label = Hash[[@banana_pod_target, monkey_target].map { |target| [target.label, target] }]
+            added_banana_cache_key = TargetCacheKey.from_pod_target(config.sandbox, targets_by_label, @banana_pod_target,
+                                                                    :is_local_pod => true)
+            diff = added_banana_cache_key.key_difference(@banana_cache_key)
+            inverse_diff = @banana_cache_key.key_difference(added_banana_cache_key)
+            diff.should.equal(:project)
+            inverse_diff.should.equal(:project)
+          end
         end
 
         describe 'key_difference with hash objects' do


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/CocoaPods/issues/11567: for projects using `incremental_installation: true`, consuming pods were not updated when their dependencies add/rename/remove `resource_bundle`s.  When `SomePodWithResources` updates a resource bundle in its podspec, there should be a corresponding update to `ConsumingPod` in the `ConsumingPod-resources.sh` build script:

```
if [[ "$CONFIGURATION" == "Debug" ]]; then
  install_resource "${PODS_CONFIGURATION_BUILD_DIR}/SamplePodWithResources/SomeBundleName.bundle"
fi
if [[ "$CONFIGURATION" == "Release" ]]; then
  install_resource "${PODS_CONFIGURATION_BUILD_DIR}/SamplePodWithResources/SomeBundleName.bundle"
fi
```

-----

Notable changes:
- The cache calculation now receives a copy of the pod list so it can examine dependent pod attributes.  This caused a lot of diff noise because each call site changed.
- The cache key dictionary now lists `RESOURCES` for dependencies (if applicable).  This ensures the `{name}-resource.sh` script is regenerated when dependencies change bundled resources.