### PR TITLE
[Pods_project_generator] Added support for specifying build configurations for schemes

### DIFF
--- a/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/multi_pods_project_generator_spec.rb
@@ -709,7 +709,9 @@ module Pod
               @coconut_test_spec.scheme = { :launch_arguments => ['TestArg1'],
                                             :environment_variables => { 'Key1' => 'Val1' },
                                             :code_coverage => true,
-                                            :parallelizable => true }
+                                            :parallelizable => true,
+                                            :build_configurations => { 'Run' => 'Debug', 'Archive' => 'App Store', 'Test' => 'Test'} 
+                                          }
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
                   returns(true)
@@ -739,6 +741,9 @@ module Pod
               test_scheme.launch_action.environment_variables.all_variables.map(&:to_h).should == [
                 { :key => 'Key1', :value => 'Val1', :enabled => true },
               ]
+              test_scheme.launch_action.build_configuration.should == 'Debug'
+              test_scheme.test_action.build_configuration.should == 'Test'
+              test_scheme.archive_action.build_configuration.should == 'App Store'
               test_scheme.test_action.code_coverage_enabled?.should.be.true
               test_scheme.test_action.testables.each { |testable| testable.parallelizable?.should.be.true }
               test_scheme.launch_action.macro_expansions.empty?.should.be.false

--- a/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
+++ b/spec/unit/installer/xcode/single_pods_project_generator_spec.rb
@@ -492,7 +492,9 @@ module Pod
               @coconut_test_spec.scheme = { :launch_arguments => ['TestArg1'],
                                             :environment_variables => { 'Key1' => 'Val1' },
                                             :code_coverage => true,
-                                            :parallelizable => true }
+                                            :parallelizable => true,
+                                            :build_configurations => { 'Run' => 'Debug', 'Archive' => 'App Store', 'Test' => 'Test'} 
+                                          }
               @generator.installation_options.
                   stubs(:share_schemes_for_development_pods).
                   returns(true)
@@ -519,6 +521,9 @@ module Pod
               test_scheme.launch_action.environment_variables.all_variables.map(&:to_h).should == [
                 { :key => 'Key1', :value => 'Val1', :enabled => true },
               ]
+              test_scheme.launch_action.build_configuration.should == 'Debug'
+              test_scheme.test_action.build_configuration.should == 'Test'
+              test_scheme.archive_action.build_configuration.should == 'App Store'
               test_scheme.test_action.code_coverage_enabled?.should.be.true
               test_scheme.test_action.testables.each { |testable| testable.parallelizable?.should.be.true }
             end


### PR DESCRIPTION
Hi! 

In our team we are using CocoaPods in a highly-modularized project and we recently came across a need to specify custom build configurations for autogenerated XCSchemes, especially we want to use custom debug config for some of the schemes and a custom test build config for our unit-tests. 

We were surprised when found that this option is not supported, however [Xcodeproj](https://www.rubydoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/XCScheme/AbstractSchemeAction) seems to support this. 

Further investigation turns out, this is quite a simple feature, so here we are! 

If you have any questions, feel free to ask!

<img width="791" alt="image" src="https://user-images.githubusercontent.com/43686146/196726316-d3f82fcf-ac7c-47d5-b48f-9add102e6435.png">
