### PR TITLE
Fix issue with repo push to empty repo

### DIFF
--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -166,7 +166,7 @@ module Pod
         # @return [void]
         #
         def check_repo_status
-          porcelain_status, = Executable.capture_command('git', %w(status --porcelain), :capture => :merge, :chdir => repo_dir)
+          porcelain_status, = Executable.capture_command('git', %w(status --untracked-files=all --porcelain), :capture => :merge, :chdir => repo_dir)
           clean = porcelain_status == ''
           raise Informative, "The repo `#{@repo}` at #{UI.path repo_dir} is not clean" unless clean
         end
@@ -231,7 +231,7 @@ module Pod
             end
 
             # only commit if modified
-            if repo_git('status', '--porcelain').include?(spec.name)
+            if repo_git('status', '--untracked-files=all', '--porcelain').include?(spec.name)
               UI.puts " - #{message}"
               repo_git('add', spec.name)
               repo_git('commit', '--no-verify', '-m', message)


### PR DESCRIPTION
After execution of:
`pod repo push TEST <SPEC_NAME>.podspec --allow-warnings --use-json`

I have a message then nothing changed
`/usr/bin/git -C <PATH>/Specs status --porcelain
  ?? Specs/2/
 - [No change] CAClient-debug (1.0.0)`

so only after adding `--untracked-files=all` or `-uall`
`git status --untracked-files=all --porcelain`
git status retruns full path of untracked changes
`?? Specs/2/0/a/<POD_NAME>/1.0.0/<POD_NAME>.podspec.json`
 
this fix could solve the problem with untracked files which was added 
