### PR TITLE
Fix publishing podspecs with watchOS support on Xcode 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Seth Friedman](https://github.com/sethfri)
   [#11235](https://github.com/CocoaPods/CocoaPods/pull/11235)
 
+* Fix publishing podspecs with watchOS support on Xcode 14
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#11660](https://github.com/CocoaPods/CocoaPods/pull/11660)
+
 ## 1.11.3 (2022-03-16)
 
 ##### Enhancements

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -1098,7 +1098,6 @@ module Pod
         end
       when :watchos
         command += %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
-        command += Fourflusher::SimControl.new.destination(:oldest, 'watchOS', deployment_target)
       when :tvos
         command += %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator)
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -821,7 +821,7 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
-        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + Fourflusher::SimControl.new.destination('Apple Watch - 38mm')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate.should == true
       end
@@ -850,7 +850,7 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
-        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + Fourflusher::SimControl.new.destination('Apple Watch - 38mm')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate.should == true
       end
@@ -881,7 +881,7 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s') + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
-        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + Fourflusher::SimControl.new.destination('Apple Watch - 38mm') + analyzer_args
+        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate.should == true
       end
@@ -913,7 +913,7 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s') + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
-        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + Fourflusher::SimControl.new.destination('Apple Watch - 38mm') + analyzer_args
+        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate.should == true
       end
@@ -937,7 +937,7 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
-        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + Fourflusher::SimControl.new.destination('Apple Watch - 38mm')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate
       end


### PR DESCRIPTION
As called out in #11558, publishing podspecs that support watchOS platform is currently broken under Xcode 14. Per the `xcodebuild` man page:

> To use a watchOS Simulator device as your destination ... specify the iOS Simulator platform destination that is paired with the watchOS Simulator device you want to use.

Not specifying any `-destination id=...` value and letting Xcode decide works well enough for now, though it won't have the same semantics of always choosing the oldest version available. This at least gets CocoaPods working again for pods that support watchOS.

Resolves #11558

🌈 