### PR TITLE
Fix incremental installation when development pod is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Fix incremental installation when a development pod is deleted.  
+  [John Szumski](https://github.com/jszumski)
+  [#11438](https://github.com/CocoaPods/CocoaPods/pull/11681)
+
 * Clean sandbox when a pod switches from remote to local.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#11213](https://github.com/CocoaPods/CocoaPods/pull/11213)

--- a/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
+++ b/lib/cocoapods/installer/analyzer/sandbox_analyzer.rb
@@ -92,8 +92,8 @@ module Pod
         # @return [Symbol] The state
         #
         def pod_state(pod)
-          return :added   if pod_added?(pod)
           return :deleted if pod_deleted?(pod)
+          return :added   if pod_added?(pod)
           return :changed if pod_changed?(pod)
           :unchanged
         end

--- a/spec/unit/installer/analyzer/sandbox_analyzer_spec.rb
+++ b/spec/unit/installer/analyzer/sandbox_analyzer_spec.rb
@@ -50,7 +50,7 @@ module Pod
         @analyzer.send(:pod_added?, 'BananaLib').should == true
       end
 
-      it "considers a Pod as added if it folder doesn't exits" do
+      it "considers a Pod as added if it folder doesn't exist" do
         @analyzer.stubs(:folder_exist?).returns(false)
         @analyzer.send(:pod_added?, 'BananaLib').should == true
       end
@@ -58,6 +58,16 @@ module Pod
       it 'considers a deleted Pod without any resolved specification' do
         @analyzer.stubs(:resolved_pods).returns([])
         @analyzer.send(:pod_deleted?, 'BananaLib').should == true
+      end
+
+      it 'considers a Pod as deleted if no resolved specification exists even if other metadata is present' do
+        @analyzer.stubs(:resolved_pods).returns([])
+        @analyzer.stubs(:sandbox_pods).returns(['BananaLib'])
+
+        @analyzer.stubs(:folder_exist?).returns(false)
+        @sandbox.stubs(:local?).returns(false)
+
+        @analyzer.send(:pod_state, 'BananaLib').should == :deleted
       end
 
       it 'considers a changed Pod whose versions do not match' do


### PR DESCRIPTION
Fix issue where a deleted development pod could be marked as added if its prior directory still exists during an incremental install.

This scenario can happen when a pod has locally generated code that is gitignore'd and that pod is deleted in another branch.  After that change is merged locally and installed with incremental installation enabled, the gitignore'd files still exist on disk in the deleted pod's directory.

Swapping the order to evaluate `pod_deleted` before `pod_added` results in a correct `SpecsState` with the pod marked as deleted.