### PR TITLE
Make xcframework's slices order stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#11224](https://github.com/CocoaPods/CocoaPods/pull/11224)
 
+* Ensure the order of slices passed to the `install_xcframework` script (in the "Copy XCFrameworks" script build phase) is stable.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#11707](https://github.com/CocoaPods/CocoaPods/pull/11707)
+
 ##### Bug Fixes
 
 * Fix incremental installation when a development pod is deleted.  

--- a/lib/cocoapods/xcode/xcframework.rb
+++ b/lib/cocoapods/xcode/xcframework.rb
@@ -91,7 +91,7 @@ module Pod
           slice_path = slice_root.join(relative_path)
           headers = slice_root.join(headers) unless headers.nil?
           XCFramework::Slice.new(slice_path, identifier, archs, platform_name, :platform_variant => platform_variant, :headers => headers)
-        end
+        end.sort_by(&:identifier)
         raise Informative, "XCFramework at #{path} does not contain any frameworks or libraries." if slices.empty?
       end
     end

--- a/spec/unit/generator/copy_xcframeworks_script_spec.rb
+++ b/spec/unit/generator/copy_xcframeworks_script_spec.rb
@@ -22,11 +22,11 @@ module Pod
       SH
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.watchos)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "watchos-i386-simulator" "watchos-armv7k_arm64_32"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "watchos-armv7k_arm64_32" "watchos-i386-simulator"
       SH
       generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.tvos)
       generator.send(:script).should.include <<-SH.strip_heredoc
-        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "tvos-x86_64-simulator" "tvos-arm64"
+        install_xcframework "${PODS_ROOT}/../../spec/fixtures/CoconutLib.xcframework" "CoconutLib" "framework" "tvos-arm64" "tvos-x86_64-simulator"
       SH
     end
 


### PR DESCRIPTION
## What?

Sort the order of the slices parsed from the `.xcframework`'s `Info.plist`'s `AvailableLibraries` array, so that the order of the extracted slices is consistent across multiple runs.

## Why?

This is especially useful when [generating the `install_xcframeworks` script invocation](https://github.com/CocoaPods/CocoaPods/blob/4a3159879a29d076d16a20b763f61eb96406a6c1/lib/cocoapods/generator/copy_xcframework_script.rb#L166-L176) (used in the `[CP] Copy XCFrameworks` build phase), to make sure this generated shell script is consistent and stable across runs.

Without this fix, every time you re-generate a `xcframework` (using `create_xcframework` fastlane action, for example), the order of the slices generated in the `Info.plist` being arbitrary (even if you pass the arguments to `xcodebuild` in the same order every time), they might change order (and they do in practice) in the final `*.xcframework/Info.plist` generated by Xcode; so when you then run `pod install` again (which will parse the newly-regenerated `.xcframework/Info.plist` and update the script accordingly), the call site of the script might have the order of its args switched, and the order of the `switch case` statements in the script might be shuffled around too.

While changing the order of the slices in the script doesn't change the final outcome—as that order doesn't matter to the command using those list of slices—it is still annoying to have a non-empty `git diff` every time we regenerate a `.xcframework` again to recompile our library. Having the order of the slices parsed from the `Info.plist` (for which Xcode doesn't offer any guarantee regarding the order in which the slices are listed in) be consistent allows the generation of the `install_xcframeworks` scripts to be idempotent and avoid a needless `diff` when the re-generated framework still contains the same list of slices between multiple compilations / re-generations but the arbitrary order in which Xcode generated them (between runs, or depending on the machine used, maybe?) changed.

## Integration Specs submodule

To update the integration specs to match the new `switch case` order, I had to create https://github.com/CocoaPods/cocoapods-integration-specs/pull/337 in the integration specs repo.

This CocoaPods PR points to the head commit of that integration specs' PR. I'm not sure what's the best next steps to land this in order. 🌈

I'd assume one will want https://github.com/CocoaPods/cocoapods-integration-specs/pull/337 to be merged first, then this current PR to be updated to have the submodule point to the resulting merge commit in `cocoapods-integration-specs` before landing it? Or is it ok to keep the submodule in this PR pointing to the PR's head commit? Please let me know! 🙂 