### PR TITLE
fix: fix AppHost infoplist integration #11692

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -459,10 +459,11 @@ module Pod
             end
 
             target.test_spec_consumers.select(&:requires_app_host?).reject(&:app_host_name).group_by { |consumer| target.app_host_target_label(consumer.spec) }.
-              map do |(_, target_name), _|
-                AppHostInstaller.new(sandbox, project, target.platform, target_name, target.pod_name, target_name).install!
-              end
-          end
+              map do |(_, target_name), consumer| # expose consumer to the block 
+              info_plist_entries = consumer.map(&:info_plist).reduce
+              # integrate `info_plist_entries` to AppHost for Photos\Location API testing
+              AppHostInstaller.new(sandbox, project, target.platform, target_name, target.pod_name, target_name, :info_plist_entries => info_plist_entries).install!
+            end
 
           # Adds the app targets for the library to the Pods project with the
           # appropriate build configurations.


### PR DESCRIPTION
Fixes #11692 : I am trying to fix the AppHost infoplist integration by passing the `info_plist_entries` to `AppHostInstaller`.

This patch works well in my own project.