### PR TITLE
Limit auto-detected docs in development pods to 100

### DIFF
--- a/lib/cocoapods/sandbox/file_accessor.rb
+++ b/lib/cocoapods/sandbox/file_accessor.rb
@@ -11,7 +11,8 @@ module Pod
     class FileAccessor
       HEADER_EXTENSIONS = Xcodeproj::Constants::HEADER_FILES_EXTENSIONS
       SOURCE_FILE_EXTENSIONS = (%w(.m .mm .i .c .cc .cxx .cpp .c++ .swift) + HEADER_EXTENSIONS).uniq.freeze
-
+      MAX_AUTO_DETECTED_DOCS = 100
+      
       GLOB_PATTERNS = {
         :readme              => 'readme{*,.*}'.freeze,
         :license             => 'licen{c,s}e{*,.*}'.freeze,
@@ -401,7 +402,12 @@ module Pod
       # @return [Array<Pathname>] The paths of auto-detected docs
       #
       def docs
-        path_list.glob([GLOB_PATTERNS[:docs]])
+        files = path_list.glob([GLOB_PATTERNS[:docs]])
+        if files.count > MAX_AUTO_DETECTED_DOCS
+          UI.warn "Limiting development docs for podspec `#{spec.name}` to #{MAX_AUTO_DETECTED_DOCS} files"
+        end
+
+        files.first MAX_AUTO_DETECTED_DOCS
       end
 
       # @return [Pathname] The path of the license file specified in the


### PR DESCRIPTION
See: https://github.com/CocoaPods/CocoaPods/issues/11753

TL;DR:

- In Development Pods, CP will try to auto-detect docs files, and add them to Pods/Development Pods/NAME/Pod/ group in Xcode
- This might be helpful if there's a few files, but trying to add an unlimited number of files (that are just there for a convenience and not required to build the app) to an Xcode project is not a good idea. In my case, I had a `docs-website` folder, containing 30k files in its node_modules.
- Besides bloating Xcodeproj, a very large number of files can cause Xcodeproj's UUID generator to exhaust all system resources and cause a kernel panic ;) Surely that could be improved, but I don't think we should be adding an arbitrary number of docs files to Xcodeproj anyway.