### PR TITLE
Fix AppHost infoplist integration #11692

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [MagnificentMiles](https://github.com/MagnificentMiles)
   [#12159](https://github.com/CocoaPods/CocoaPods/pull/12159)
 
+* Fix AppHost infoplist integration, inject `info_plist_entries` into AppHost application.
+  [blastmann](https://github.com/blastmann)
+  [#11692](https://github.com/CocoaPods/CocoaPods/issues/11692)
+
 ## 1.14.3 (2023-11-19)
 
 ##### Enhancements

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -459,9 +459,11 @@ module Pod
             end
 
             target.test_spec_consumers.select(&:requires_app_host?).reject(&:app_host_name).group_by { |consumer| target.app_host_target_label(consumer.spec) }.
-              map do |(_, target_name), _|
-                AppHostInstaller.new(sandbox, project, target.platform, target_name, target.pod_name, target_name).install!
-              end
+              map do |(_, target_name), consumer| # expose consumer to the block
+              info_plist_entries = consumer.map(&:info_plist).reduce({}, &:merge)
+              # integrate `info_plist_entries` to AppHost for Photos\Location API testing
+              AppHostInstaller.new(sandbox, project, target.platform, target_name, target.pod_name, target_name, :info_plist_entries => info_plist_entries).install!
+            end
           end
 
           # Adds the app targets for the library to the Pods project with the

--- a/spec/fixtures/watermelon-lib/WatermelonLib.podspec
+++ b/spec/fixtures/watermelon-lib/WatermelonLib.podspec
@@ -31,6 +31,9 @@ Pod::Spec.new do |s|
 
   s.test_spec 'SnapshotTests' do |test_spec|
     test_spec.requires_app_host = true
+    test_spec.info_plist = {
+      'NSPhotoLibraryUsageDescription' => 'Photo Library Access Warning.'
+    }
     test_spec.source_files = 'SnapshotTests/*.{h,m}'
     test_spec.dependency 'iOSSnapshotTestCase/Core'
   end

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -385,6 +385,16 @@ module Pod
                 installation_result.app_native_targets.count.should == 1
               end
 
+              it 'snapshot tests must contains info_plist_entries' do
+                @ios_installer.install!
+                apphost_target = @project.targets[5]
+                info_plist_config_path = apphost_target.build_configurations[0].build_settings['INFOPLIST_FILE']
+                info_plist_path = temporary_sandbox.root.join(info_plist_config_path)
+                info_plist = info_plist_path.read
+                info_plist.should =~ %r{<key>NSPhotoLibraryUsageDescription<\/key>}
+                info_plist.should =~ %r{<string>Photo Library Access Warning.<\/string>}
+              end
+
               it 'raises when a test spec has no source files' do
                 @watermelon_ios_pod_target.test_spec_consumers.first.stubs(:source_files).returns([])
                 e = ->() { @ios_installer.install! }.should.raise Informative


### PR DESCRIPTION
Try to fix this issue by adding `additional_entries` into `AppHostInstaller` installation process.

Add another test case to check the plist result.