### PR TITLE
Xcode 14.3 fix: Pass the -f option when resolving the path to the symlinked source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Xcode 14.3 fix: Pass the -f option when resolving the path to the symlinked source.  
+  [Chris Vasselli](https://github.com/chrisvasselli)
+  [#11828](https://github.com/CocoaPods/CocoaPods/pull/11828)
+  [#11808](https://github.com/CocoaPods/CocoaPods/issues/11808)
 
 
 ## 1.12.0 (2023-02-27)

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -83,7 +83,7 @@ install_framework()
 
   if [ -L "${source}" ]; then
     echo "Symlinked..."
-    source="$(readlink "${source}")"
+    source="$(readlink -f "${source}")"
   fi
 
   if [ -d "${source}/${BCSYMBOLMAP_DIR}" ]; then


### PR DESCRIPTION
🌈

Fixes the issue where archives fail when using Xcode 14.3. https://github.com/CocoaPods/CocoaPods/issues/11808

Xcode 14.3 is now using a relative path in its symlink for frameworks. Without the -f flag, this relative path would be evaluated relative to the working directory of the script being executed, instead of relative to the framework symlink itself. With the -f flag, it resolves that relative path and returns the full path to the source.

`bundle exec rake spec` failed, but it looks like maybe just because there were changes? Snapshot testing maybe? Also, it might make sense to add a test case to handle this scenario, but I don't know CocoaPods well enough to know what to add or where.

[rake.txt](https://github.com/CocoaPods/CocoaPods/files/11048739/rake.txt)
