### PR TITLE
Fixes the source path of frameworks

### DIFF
--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -71,10 +71,15 @@ BCSYMBOLMAP_DIR="BCSymbolMaps"
 # Copies and strips a vendored framework
 install_framework()
 {
+  local basename
+  basename="$(basename -s .framework "$1")"
+
   if [ -r "${BUILT_PRODUCTS_DIR}/$1" ]; then
     local source="${BUILT_PRODUCTS_DIR}/$1"
   elif [ -r "${BUILT_PRODUCTS_DIR}/$(basename "$1")" ]; then
     local source="${BUILT_PRODUCTS_DIR}/$(basename "$1")"
+  elif [ -r "${PODS_CONFIGURATION_BUILD_DIR}/${basename}/$(basename "$1")" ]; then
+    local source="${PODS_CONFIGURATION_BUILD_DIR}/${basename}/$(basename "$1")"
   elif [ -r "$1" ]; then
     local source="$1"
   fi
@@ -100,8 +105,6 @@ install_framework()
   echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${destination}\\""
   rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${destination}"
 
-  local basename
-  basename="$(basename -s .framework "$1")"
   binary="${destination}/${basename}.framework/${basename}"
 
   if ! [ -r "$binary" ]; then


### PR DESCRIPTION
This commit fixes an issue where `Pods-TARGET_NAME-frameworks.sh` could give a `source: unbound variable` error as follow.

	Showing All Messages
	PhaseScriptExecution [CP]\ Embed\ Pods\ Frameworks /Users/USERNAME/Developer/PROJECT_PATH/build/TARGET_NAME.build/Debug-iphoneos/Script-6D601675FA2FB56714C154A0.sh (in target 'TARGET_NAME' from project 'TARGET_NAME')
	    cd /Users/USERNAME/Developer/fogofworld3/src/ios
	    /bin/sh -c /Users/USERNAME/Developer/PROJECT_PATH/build/TARGET_NAME.build/Debug-iphoneos/Script-6D601675FA2FB56714C154A0.sh

	mkdir -p /Users/USERNAME/Developer/PROJECT_PATH/Debug-iphoneos/TARGET_NAME.app/Frameworks
	/Users/USERNAME/Developer/fogofworld3/src/ios/Pods/Target Support Files/Pods-TARGET_NAME/Pods-TARGET_NAME-frameworks.sh: line 42: source: unbound variable
	Command PhaseScriptExecution failed with a nonzero exit code


This error occurs in Xcode 14.3 (14E222a) on a MacBook Pro M2 Max.

PS. #11828 should also be accepted to make archiving work.