### PR TITLE
Fix typo in validation for `--validation-dir` help message  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Chris Vasselli](https://github.com/chrisvasselli)
   [#11828](https://github.com/CocoaPods/CocoaPods/pull/11828)
   [#11808](https://github.com/CocoaPods/CocoaPods/issues/11808)
+* Fix typo in validation for `--validation-dir` help message  
+  [Austin Evans](https://github.com/ajevans99)
+  [#11857](https://github.com/CocoaPods/CocoaPods/issues/11857)
 
 # Xcode 14.3 fix: `pod lib lint` warning generation from main.m.  
   [Paul Beusterien](https://github.com/paulb777)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Chris Vasselli](https://github.com/chrisvasselli)
   [#11828](https://github.com/CocoaPods/CocoaPods/pull/11828)
   [#11808](https://github.com/CocoaPods/CocoaPods/issues/11808)
+
 * Fix typo in validation for `--validation-dir` help message  
   [Austin Evans](https://github.com/ajevans99)
   [#11857](https://github.com/CocoaPods/CocoaPods/issues/11857)

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -38,7 +38,7 @@ module Pod
             ['--test-specs=test-spec1,test-spec2,etc', 'List of test specs to run'],
             ['--analyze', 'Validate with the Xcode Static Analysis tool'],
             ['--configuration=CONFIGURATION', 'Build using the given configuration (defaults to Release)'],
-            ['--validaton-dir', 'The directory to use for validation. If none is specified a temporary directory will be used.'],
+            ['--validation-dir', 'The directory to use for validation. If none is specified a temporary directory will be used.'],
           ].concat(super)
         end
 

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -38,7 +38,7 @@ module Pod
              'This takes precedence over the Swift versions specified by the spec or a `.swift-version` file'],
             ['--no-overwrite', 'Disallow pushing that would overwrite an existing spec'],
             ['--update-sources', 'Make sure sources are up-to-date before a push'],
-            ['--validaton-dir', 'The directory to use for validation. If none is specified a temporary directory will be used.'],
+            ['--validation-dir', 'The directory to use for validation. If none is specified a temporary directory will be used.'],
           ].concat(super)
         end
 

--- a/lib/cocoapods/command/spec/lint.rb
+++ b/lib/cocoapods/command/spec/lint.rb
@@ -37,7 +37,7 @@ module Pod
             ['--test-specs=test-spec1,test-spec2,etc', 'List of test specs to run'],
             ['--analyze', 'Validate with the Xcode Static Analysis tool'],
             ['--configuration=CONFIGURATION', 'Build using the given configuration (defaults to Release)'],
-            ['--validaton-dir', 'The directory to use for validation. If none is specified a temporary directory will be used.'],
+            ['--validation-dir', 'The directory to use for validation. If none is specified a temporary directory will be used.'],
           ].concat(super)
         end
 


### PR DESCRIPTION
Fixes typo in a couple command options that listed `--validaton-dir` instead of `--validation-dir` in the help messages.

Resolves #11857 