### PR TITLE
Fix compatibility error with Ruby 3.x

### DIFF
--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -52,7 +52,7 @@ module Pod
         UI.message "Copying #{request.name} from `#{result.location}` to #{UI.path target}", '> ' do
           Cache.read_lock(result.location) do
             FileUtils.rm_rf target
-            FileUtils.cp_r(result.location, target)
+            FileUtils.cp_r(result.location.force_encoding('UTF-8'), target.force_encoding('UTF-8'))
           end
         end
       end


### PR DESCRIPTION
When using CocoaPods with Ruby 3.x, and the path has non-ascii characters in it, then we may encounter the following error: 

```
Encoding::CompatibilityError - incompatible character encodings: UTF-8 and ASCII-8BIT
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1564:in `join'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1564:in `join'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1224:in `path'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:500:in `block in copy_entry'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1513:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1516:in `block in wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `each'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1516:in `block in wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `each'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1516:in `block in wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `each'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1516:in `block in wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `each'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1516:in `block in wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `each'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1516:in `block in wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `each'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1515:in `wrap_traverse'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:497:in `copy_entry'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:471:in `block in cp_r'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1597:in `block in fu_each_src_dest'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1613:in `fu_each_src_dest0'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:1595:in `fu_each_src_dest'
/Users/uddmobile-2019/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/fileutils.rb:470:in `cp_r'
/Users/uddmobile-2019/.rvm/gems/ruby-3.0.0/gems/cocoapods-1.12.1/lib/cocoapods/downloader.rb:55:in `block (2 levels) in download'
```

This merge request aims to fix this so that users don't have to change their path to accommodate a software limitation.