### PR TITLE
Add `visionos` as a new platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add `visionOS` as a new platform. 
+  [Gabriel Donadel](https://github.com/gabrieldonadel)
+  [#11965](https://github.com/CocoaPods/CocoaPods/pull/11965)
 
 ##### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 01226592d7a295cb5567d346f996af5b3bfed2f6
+  revision: 9320bf557741d7ae80eda4415bc6fb2b0b3a8b9c
   branch: master
   specs:
     cocoapods-core (1.12.1)
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: 2fe65ce43a244370c245bcbf4176f16ff0f442cf
+  revision: 2ce68b60856c4680c2b3cd7aa5b221529120c7c4
   branch: master
   specs:
     xcodeproj (1.22.0)
@@ -143,7 +143,7 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.7.3)
+    activesupport (6.1.7.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -224,7 +224,7 @@ GEM
       rchardet (~> 1.8)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     inch (0.8.0)
       pry
@@ -245,7 +245,7 @@ GEM
       rb-kqueue (>= 0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
-    minitest (5.18.0)
+    minitest (5.18.1)
     mocha (1.4.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.3)
@@ -321,7 +321,7 @@ GEM
     webrick (1.7.0)
     yard (0.9.27)
       webrick (~> 1.7.0)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby

--- a/examples/AppCenter Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/examples/AppCenter Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/Headers Example/Headers Example.xcodeproj/xcshareddata/xcschemes/Headers Example.xcscheme
+++ b/examples/Headers Example/Headers Example.xcodeproj/xcshareddata/xcschemes/Headers Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/cocoapods/command/spec/create.rb
+++ b/lib/cocoapods/command/spec/create.rb
@@ -181,6 +181,7 @@ Pod::Spec.new do |spec|
   # spec.osx.deployment_target = "10.7"
   # spec.watchos.deployment_target = "2.0"
   # spec.tvos.deployment_target = "9.0"
+  # spec.visionos.deployment_target = "1.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/lib/cocoapods/generator/copy_resources_script.rb
+++ b/lib/cocoapods/generator/copy_resources_script.rb
@@ -57,6 +57,7 @@ module Pod
         :osx => Version.new('10.8'),
         :watchos => Version.new('2.0'),
         :tvos => Version.new('9.0'),
+        :visionos => Version.new('1.0'),
       }
 
       # @return [Boolean] Whether the external strings file is supported by the

--- a/lib/cocoapods/installer/base_install_hooks_context.rb
+++ b/lib/cocoapods/installer/base_install_hooks_context.rb
@@ -97,7 +97,7 @@ module Pod
         #
         attr_reader :specs
 
-        # @return [Symbol] The platform (either `:ios`, `:watchos`, `:tvos`, or `:osx`).
+        # @return [Symbol] The platform (either `:ios`, `:watchos`, `:tvos`, `:visionos`, or `:osx`).
         #
         attr_reader :platform_name
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -894,6 +894,7 @@ module Pod
             :osx => Version.new('10.8'),
             :watchos => Version.new('2.0'),
             :tvos => Version.new('9.0'),
+            :visionos => Version.new('1.0'),
           }.freeze
 
           # Returns the compiler flags for the source files of the given specification.

--- a/lib/cocoapods/installer/xcode/pods_project_generator/project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/project_generator.rb
@@ -103,11 +103,13 @@ module Pod
             ios_deployment_target = platforms.select { |p| p.name == :ios }.map(&:deployment_target).min
             watchos_deployment_target = platforms.select { |p| p.name == :watchos }.map(&:deployment_target).min
             tvos_deployment_target = platforms.select { |p| p.name == :tvos }.map(&:deployment_target).min
+            visionos_deployment_target = platforms.select { |p| p.name == :visionos }.map(&:deployment_target).min
             project.build_configurations.each do |build_configuration|
               build_configuration.build_settings['MACOSX_DEPLOYMENT_TARGET'] = osx_deployment_target.to_s if osx_deployment_target
               build_configuration.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = ios_deployment_target.to_s if ios_deployment_target
               build_configuration.build_settings['WATCHOS_DEPLOYMENT_TARGET'] = watchos_deployment_target.to_s if watchos_deployment_target
               build_configuration.build_settings['TVOS_DEPLOYMENT_TARGET'] = tvos_deployment_target.to_s if tvos_deployment_target
+              build_configuration.build_settings['XROS_DEPLOYMENT_TARGET'] = visionos_deployment_target.to_s if visionos_deployment_target
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
               build_configuration.build_settings['CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED'] = 'YES'

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -152,6 +152,8 @@ module Pod
           platform_message = '[watchOS] '
         elsif result.platforms == [:tvos]
           platform_message = '[tvOS] '
+        elsif result.platforms == [:visionos]
+          platform_message = '[visionOS] '
         end
 
         subspecs_message = ''
@@ -1104,6 +1106,9 @@ module Pod
       when :tvos
         command += %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator)
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)
+      when :visionos
+        command += %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator)
+        command += Fourflusher::SimControl.new.destination(:oldest, 'visionOS', deployment_target)
       end
 
       if analyze

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -218,6 +218,7 @@ module Pod
       Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, true, [], false, nil).twice.returns(stub('Podfile'))
       Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, true, [], false, nil).twice.returns(stub('Podfile'))
       Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, true, [], false, nil).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:visionos, nil, true, [], false, nil).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
@@ -232,6 +233,7 @@ module Pod
       Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, [], false, nil).twice.returns(stub('Podfile'))
       Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, [], false, nil).twice.returns(stub('Podfile'))
       Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, [], false, nil).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:visionos, nil, false, [], false, nil).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master', '--use-libraries')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator
@@ -246,6 +248,7 @@ module Pod
       Validator.any_instance.expects(:podfile_from_spec).with(:osx, nil, false, [], true, nil).twice.returns(stub('Podfile'))
       Validator.any_instance.expects(:podfile_from_spec).with(:watchos, nil, false, [], true, nil).twice.returns(stub('Podfile'))
       Validator.any_instance.expects(:podfile_from_spec).with(:tvos, nil, false, [], true, nil).twice.returns(stub('Podfile'))
+      Validator.any_instance.expects(:podfile_from_spec).with(:visionos, nil, false, [], true, nil).twice.returns(stub('Podfile'))
 
       cmd = command('repo', 'push', 'master', '--use-libraries', '--use-modular-headers')
       # Git push will throw an exception here since this is a local custom git repo. All we care is the validator

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -340,10 +340,10 @@ module Pod
           file = write_podspec(stub_podspec)
           validator = Validator.new(file, config.sources_manager.master.map(&:url))
           validator.stubs(:validate_url)
-          validator.expects(:install_pod).times(4)
-          validator.expects(:build_pod).times(4)
-          validator.expects(:add_app_project_import).times(4)
-          validator.expects(:check_file_patterns).times(4)
+          validator.expects(:install_pod).times(5)
+          validator.expects(:build_pod).times(5)
+          validator.expects(:add_app_project_import).times(5)
+          validator.expects(:check_file_patterns).times(5)
           validator.validate
         end
 
@@ -608,6 +608,7 @@ module Pod
         validator.expects(:podfile_from_spec).with(:ios, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         validator.expects(:podfile_from_spec).with(:ios, '7.0', false, [], nil, nil).once.returns(stub('Podfile'))
         validator.expects(:podfile_from_spec).with(:tvos, nil, false, [], nil, nil).once.returns(stub('Podfile'))
+        validator.expects(:podfile_from_spec).with(:visionos, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         validator.expects(:podfile_from_spec).with(:watchos, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         validator.send(:perform_extensive_analysis, validator.spec)
 
@@ -821,6 +822,8 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator) + Fourflusher::SimControl.new.destination('Apple Vision Pro')
+        Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate.should == true
@@ -849,6 +852,8 @@ module Pod
         args = %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator) + Fourflusher::SimControl.new.destination('Apple TV 1080p')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')
+        Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator) + Fourflusher::SimControl.new.destination('Apple Vision Pro')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
@@ -880,6 +885,8 @@ module Pod
         args = %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator) + Fourflusher::SimControl.new.destination('Apple TV 1080p') + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s') + analyzer_args
+        Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator) + Fourflusher::SimControl.new.destination('Apple Vision Pro') + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
@@ -913,6 +920,8 @@ module Pod
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s') + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator) + Fourflusher::SimControl.new.destination('Apple Vision Pro') + analyzer_args
+        Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator) + analyzer_args
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         validator.validate.should == true
@@ -936,6 +945,8 @@ module Pod
         args = %w(CODE_SIGN_IDENTITY=- -sdk appletvsimulator) + Fourflusher::SimControl.new.destination('Apple TV 1080p')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk iphonesimulator) + Fourflusher::SimControl.new.destination('iPhone 4s')
+        Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
+        args = %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator) + Fourflusher::SimControl.new.destination('Apple Vision Pro')
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
         args = %w(CODE_SIGN_IDENTITY=- -sdk watchsimulator)
         Executable.expects(:execute_command).with('xcodebuild', command + args, true).once.returns('')
@@ -1275,6 +1286,7 @@ module Pod
         @validator.expects(:podfile_from_spec).with(:osx, nil, true, [], nil, nil).once.returns(stub('Podfile'))
         @validator.expects(:podfile_from_spec).with(:ios, '8.0', true, [], nil, nil).once.returns(stub('Podfile'))
         @validator.expects(:podfile_from_spec).with(:tvos, nil, true, [], nil, nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:visionos, nil, true, [], nil, nil).once.returns(stub('Podfile'))
         @validator.expects(:podfile_from_spec).with(:watchos, nil, true, [], nil, nil).once.returns(stub('Podfile'))
         @validator.send(:perform_extensive_analysis, @validator.spec)
 
@@ -1289,6 +1301,7 @@ module Pod
         @validator.expects(:podfile_from_spec).with(:osx, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         @validator.expects(:podfile_from_spec).with(:ios, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         @validator.expects(:podfile_from_spec).with(:tvos, nil, false, [], nil, nil).once.returns(stub('Podfile'))
+        @validator.expects(:podfile_from_spec).with(:visionos, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         @validator.expects(:podfile_from_spec).with(:watchos, nil, false, [], nil, nil).once.returns(stub('Podfile'))
         @validator.send(:perform_extensive_analysis, @validator.spec)
 


### PR DESCRIPTION
This PR introduces `visionOS` as a supported platform. This lays the groundwork for supporting visionOS as a new platform in CocoaPods.

Closes https://github.com/CocoaPods/CocoaPods/issues/11961

Related to https://github.com/CocoaPods/Core/pull/745 and https://github.com/CocoaPods/Xcodeproj/pull/913