### PR TITLE
Add support for always_out_of_date flag in script phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Gabriel Donadel](https://github.com/gabrieldonadel)
   [#11965](https://github.com/CocoaPods/CocoaPods/pull/11965)
 
+* Extend `script_phase` DSL to support `always_out_of_date` attribute.  
+  [Alvar Hansen](https://github.com/alvarhansen)
+  [#12055](https://github.com/CocoaPods/CocoaPods/pull/12055)
+
 ##### Bug Fixes
 
 * Use safe_load during custom YAML config loading.  

--- a/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
+++ b/lib/cocoapods/installer/user_project_integrator/target_integrator.rb
@@ -314,6 +314,7 @@ module Pod
               phase.input_file_list_paths = script_phase[:input_file_lists]
               phase.output_file_list_paths = script_phase[:output_file_lists]
               phase.dependency_file = script_phase[:dependency_file]
+              phase.always_out_of_date = script_phase[:always_out_of_date]
               # At least with Xcode 10 `showEnvVarsInLog` is *NOT* set to any value even if it's checked and it only
               # gets set to '0' if the user has explicitly disabled this.
               if (show_env_vars_in_log = script_phase.fetch(:show_env_vars_in_log, '1')) == '0'

--- a/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
+++ b/spec/unit/installer/user_project_integrator/target_integrator_spec.rb
@@ -546,6 +546,7 @@ module Pod
           phase.output_file_list_paths.should.be.nil
           phase.show_env_vars_in_log.should.be.nil
           phase.dependency_file.should.be.nil
+          phase.always_out_of_date.should.be.nil
         end
 
         it 'adds a custom shell script phase with input/output paths' do
@@ -567,6 +568,7 @@ module Pod
           phase.output_file_list_paths.should == ['/path/to/output_file.xcfilelist']
           phase.show_env_vars_in_log.should.be.nil
           phase.dependency_file.should.be.nil
+          phase.always_out_of_date.should.be.nil
         end
 
         it 'adds a custom shell script phase with dependency file' do
@@ -586,6 +588,7 @@ module Pod
           phase.output_file_list_paths.should.be.nil
           phase.show_env_vars_in_log.should.be.nil
           phase.dependency_file.should == '/path/to/depfile.d'
+          phase.always_out_of_date.should.be.nil
         end
 
         it 'sets the show_env_vars_in_log value to 0 if its explicitly set' do
@@ -751,6 +754,28 @@ module Pod
             '[CP] Copy Pods Resources',
           ]
         end
+      end
+
+      it 'sets the always_out_of_date value to 1 if its explicitly set' do
+        @pod_bundle.target_definition.stubs(:script_phases).returns([:name => 'Custom Script',
+                                                                     :script => 'echo "Hello World"',
+                                                                     :always_out_of_date => '1'])
+        @target_integrator.integrate!
+        target = @target_integrator.send(:native_targets).first
+        phase = target.shell_script_build_phases.find { |bp| bp.name == @user_script_phase_name }
+        phase.should.not.be.nil?
+        phase.always_out_of_date.should == '1'
+      end
+
+      it 'sets the always_out_of_date value to 1 if its explicitly set' do
+        @pod_bundle.target_definition.stubs(:script_phases).returns([:name => 'Custom Script',
+                                                                     :script => 'echo "Hello World"',
+                                                                     :always_out_of_date => '1'])
+        @target_integrator.integrate!
+        target = @target_integrator.send(:native_targets).first
+        phase = target.shell_script_build_phases.find { |bp| bp.name == @user_script_phase_name }
+        phase.should.not.be.nil?
+        phase.always_out_of_date.should == '1'
       end
 
       it 'adds and remove on demand resources to the user target resources build phase' do


### PR DESCRIPTION
Exposes existing `PBXShellScriptBuildPhase` attribute for enabling it in cases where it input & output file(s) are not possible to be defined.
Without it, Xcode will always give build time warning about missing inputs & outputs.

Related to: https://github.com/CocoaPods/Core/pull/750