### PR TITLE
Requiring base active_support before definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix a crash when running with activesupport 7.1.0.  
+  [MCanhisares](https://github.com/MCanhisares)
+  [#12081](https://github.com/CocoaPods/CocoaPods/issues/12081)
 
 
 ## 1.13.0 (2023-09-22)

--- a/lib/cocoapods.rb
+++ b/lib/cocoapods.rb
@@ -4,6 +4,7 @@ require 'xcodeproj'
 # It is very likely that we'll need these and as some of those paths will atm
 # result in a I18n deprecation warning, we load those here now so that we can
 # get rid of that warning.
+require 'active_support'
 require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/array/conversions'


### PR DESCRIPTION
As per the official [active_support documentation](https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support), we should import the base library before the specific definitions on files.

This fixes #12081 