### PR TITLE
Setting ruby 2.7 to lint job

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6]
+        ruby: [2.7]
         os: [ubuntu-20.04]
 
     name: Lint


### PR DESCRIPTION
Since [479e711](https://github.com/CocoaPods/CocoaPods/commit/479e71131962e3e560e4cc0601d39860c2a590ce) upgraded ruby to 2.7 as minimum version, lint tests are failing, as they were running on Ruby 2.6
This PR solves the current issue 