### PR TITLE
Require active_support/core_ext in cocoapods.rb to fix #12089

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Fix a crash when running with activesupport 7.1.0.  
   [MCanhisares](https://github.com/MCanhisares)
   [#12081](https://github.com/CocoaPods/CocoaPods/issues/12081)
+* Fix another crash when running with activesupport 7.1.0.
+  [movila](https://github.com/movila)
+  [#12089](https://github.com/CocoaPods/CocoaPods/issues/12089)
 
 
 ## 1.13.0 (2023-09-22)

--- a/lib/cocoapods.rb
+++ b/lib/cocoapods.rb
@@ -5,6 +5,7 @@ require 'xcodeproj'
 # result in a I18n deprecation warning, we load those here now so that we can
 # get rid of that warning.
 require 'active_support'
+require 'active_support/core_ext'
 require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/array/conversions'


### PR DESCRIPTION
A follow-up to #12082.

Shout out to @movila for [this suggestion comment].

[this suggestion comment]: https://github.com/CocoaPods/CocoaPods/issues/12089#issuecomment-1757863439