### PR TITLE
Update analyzer.rb

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -865,7 +865,7 @@ module Pod
           Version.new(library_spec.deployment_target(platform_name) || default)
         end.max
         if platform_name == :ios && build_type.framework?
-          minimum = Version.new('8.0')
+          minimum = Version.new('12.0')
           deployment_target = [deployment_target, minimum].max
         end
         Platform.new(platform_name, deployment_target)


### PR DESCRIPTION
fix validation fail when Publishing pods to private specs repo using Xcode 14.3. or upper
- validation check on iOS 12 or upper because Xcode 14.3. or upper doesn't support iOS 11 or lower
- Related Issues: https://github.com/CocoaPods/CocoaPods/issues/11895