### PR TITLE
Optimize performance during uncached pod installation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Optimize performance during uncached pod installation.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#12154](https://github.com/CocoaPods/CocoaPods/pull/12154)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -51,8 +51,7 @@ module Pod
       if target && result.location && target != result.location
         UI.message "Copying #{request.name} from `#{result.location}` to #{UI.path target}", '> ' do
           Cache.read_lock(result.location) do
-            FileUtils.rm_rf target
-            FileUtils.cp_r(result.location, target)
+            FileUtils.cp_r(result.location, target, :remove_destination => true)
           end
         end
       end

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -235,13 +235,38 @@ module Pod
       #         was not found in the download cache.
       #
       def uncached_pod(request)
-        in_tmpdir do |target|
-          result, podspecs = download(request, target)
+        in_tmpdir do |tmp_dir|
+          result, podspecs = download(request, tmp_dir)
           result.location = nil
 
-          podspecs.each do |name, spec|
+          # Split by pods that require a prepare command or not to speed up installation.
+          no_prep_cmd_specs, prep_cmd_specs = podspecs.partition { |_, spec| spec.prepare_command.nil? }.map(&:to_h)
+
+          # Pods with a prepare command currently copy the entire repo, run the prepare command against the whole
+          # repo and then clean it up. We configure those first to ensure the repo is pristine.
+          prep_cmd_specs.each do |name, spec|
             destination = path_for_pod(request, :name => name, :params => result.checkout_options)
-            copy_and_clean(target, destination, spec)
+            copy_source_and_clean(tmp_dir, destination, spec)
+            write_spec(spec, path_for_spec(request, :name => name, :params => result.checkout_options))
+            if request.name == name
+              result.location = destination
+            end
+          end
+
+          specs_by_platform = group_subspecs_by_platform(no_prep_cmd_specs.values)
+
+          # Remaining pods without a prepare command can be optimized by cleaning the repo first
+          # and then copying only the files needed.
+          pod_dir_cleaner = Sandbox::PodDirCleaner.new(tmp_dir, specs_by_platform)
+          Cache.write_lock(tmp_dir) do
+            pod_dir_cleaner.clean!
+          end
+
+          no_prep_cmd_specs.each do |name, spec|
+            destination = path_for_pod(request, :name => name, :params => result.checkout_options)
+            file_accessors = pod_dir_cleaner.file_accessors.select { |fa| fa.spec.root.name == spec.name }
+            files = Pod::Sandbox::FileAccessor.all_files(file_accessors).map(&:to_s)
+            copy_files(files, tmp_dir, destination)
             write_spec(spec, path_for_spec(request, :name => name, :params => result.checkout_options))
             if request.name == name
               result.location = destination
@@ -279,23 +304,55 @@ module Pod
       #
       # @return [Void]
       #
-      def copy_and_clean(source, destination, spec)
-        specs_by_platform = group_subspecs_by_platform(spec)
+      def copy_source_and_clean(source, destination, spec)
+        specs_by_platform = group_subspecs_by_platform([spec])
         destination.parent.mkpath
         Cache.write_lock(destination) do
-          FileUtils.rm_rf(destination)
-          FileUtils.cp_r(source, destination)
+          FileUtils.cp_r(source, destination, :remove_destination => true)
           Pod::Installer::PodSourcePreparer.new(spec, destination).prepare!
           Sandbox::PodDirCleaner.new(destination, specs_by_platform).clean!
         end
       end
 
-      def group_subspecs_by_platform(spec)
+      # Copies the `files` from the `source` directory to `destination` _without_ cleaning the
+      # `destination` directory of any files unused by `spec`. This is a faster version used when
+      # installing pods without a prepare command which has already happened prior.
+      #
+      # @param  [Array<Pathname>] files
+      #
+      # @param  [Pathname] source
+      #
+      # @param  [Pathname] destination
+      #
+      # @return [Void]
+      #
+      def copy_files(files, source, destination)
+        files = files.select { |f| File.exist?(f) }
+        destination.parent.mkpath
+        Cache.write_lock(destination) do
+          FileUtils.rm_rf(destination)
+          destination.mkpath
+          files_by_dir = files.group_by do |file|
+            relative_path = Pathname(file).relative_path_from(Pathname(source)).to_s
+            destination_path = File.join(destination, relative_path)
+            File.dirname(destination_path)
+          end
+
+          files_by_dir.each do |dir, files_to_copy|
+            FileUtils.mkdir_p(dir)
+            FileUtils.cp_r(files_to_copy, dir)
+          end
+        end
+      end
+
+      def group_subspecs_by_platform(specs)
         specs_by_platform = {}
-        [spec, *spec.recursive_subspecs].each do |ss|
-          ss.available_platforms.each do |platform|
-            specs_by_platform[platform] ||= []
-            specs_by_platform[platform] << ss
+        specs.each do |spec|
+          [spec, *spec.recursive_subspecs].each do |ss|
+            ss.available_platforms.each do |platform|
+              specs_by_platform[platform] ||= []
+              specs_by_platform[platform] << ss
+            end
           end
         end
         specs_by_platform

--- a/lib/cocoapods/sandbox/pod_dir_cleaner.rb
+++ b/lib/cocoapods/sandbox/pod_dir_cleaner.rb
@@ -15,10 +15,8 @@ module Pod
       # @return [void]
       #
       def clean!
-        clean_paths.each { |path| FileUtils.rm_rf(path) } if root.exist?
+        FileUtils.rm_rf(clean_paths) if root.exist?
       end
-
-      private
 
       # @return [Array<Sandbox::FileAccessor>] the file accessors for all the
       #         specifications on their respective platform.
@@ -28,6 +26,8 @@ module Pod
           specs.flat_map { |spec| Sandbox::FileAccessor.new(path_list, spec.consumer(platform)) }
         end
       end
+
+      private
 
       # @return [Sandbox::PathList] The path list for this Pod.
       #

--- a/spec/unit/downloader/cache_spec.rb
+++ b/spec/unit/downloader/cache_spec.rb
@@ -49,7 +49,7 @@ module Pod
         end
       end
 
-      @cache.send(:group_subspecs_by_platform, @spec).should == {
+      @cache.send(:group_subspecs_by_platform, [@spec]).should == {
         Platform.new(:ios, '8.0') => [@spec.subspecs.first],
         Platform.new(:ios, '6.0') => [@spec],
         Platform.new(:osx, '10.7') => [@spec],
@@ -81,7 +81,7 @@ module Pod
         end
 
         it 'downloads the source' do
-          @cache.expects(:copy_and_clean).twice
+          @cache.expects(:copy_files).twice
           response = @cache.download_pod(@unreleased_request)
           response.should == Downloader::Response.new(@cache.root + @unreleased_request.slug, @spec, @spec.source)
         end


### PR DESCRIPTION
When installing pods from a given repo, we are currently over-doing a bunch of unnecessary work by copying the original repo from within a temp dir N times as many pods we are installing from that repo. We then trim (clean) the copied repo to the files that are only relevant to the pod we are installing.

This can be very slow if a repo is large and offers multiple podspecs.

We also need to do this work _only_ if there is a prepare command to run which currently operates or can operate against the initial cloned repo. 

The PR here optimizes by splitting pods that require a `prepare_command` and ones that do not. For the ones that need one we execute the existing behavior but for the ones that do not, we trim the cloned repo and then copy exactly the files we need.

This can speed up installation dramatically for repos that publish multiple podspecs.

