### PR TITLE
Fix pod install issue when git's `core.fsmonitor` feature is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Fix pod install issue when git's `core.fsmonitor` feature is enabled
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#11640](https://github.com/CocoaPods/CocoaPods/issues/11640)
 
 ## 1.14.3 (2023-11-19)
 

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -308,7 +308,7 @@ module Pod
         specs_by_platform = group_subspecs_by_platform([spec])
         destination.parent.mkpath
         Cache.write_lock(destination) do
-          FileUtils.cp_r(source, destination, :remove_destination => true)
+          Pod::Executable.execute_command('rsync', ['-a', '--exclude=.git/fsmonitor--daemon.ipc', '--delete', "#{source}/", destination])
           Pod::Installer::PodSourcePreparer.new(spec, destination).prepare!
           Sandbox::PodDirCleaner.new(destination, specs_by_platform).clean!
         end


### PR DESCRIPTION
This prevents a copy error where the system is unable to copy the ipc file due to being a socket. This would otherwise manifest as errors during pod install with the message "too long unix socket path" if git's `core.fsmonitor` feature is enabled.

Resolves #11640

🌈 