### PR TITLE
Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflusher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Don't use the `remove_destination` parameter in FileUtils.cp_r  
   [Justin Martin](https://github.com/justinseanmartin)
   [#12165](https://github.com/CocoaPods/CocoaPods/pull/12165)
+
 * Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflusher`  
   [MagnificentMiles](https://github.com/MagnificentMiles)
-  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
+  [#12159](https://github.com/CocoaPods/CocoaPods/pull/12159)
 
 ## 1.14.3 (2023-11-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#12122](https://github.com/CocoaPods/CocoaPods/issues/12122)
 
-* Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflush`  
+* Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflusher`  
   [MagnificentMiles](https://github.com/MagnificentMiles)
   [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Don't use the `remove_destination` parameter in FileUtils.cp_r  
   [Justin Martin](https://github.com/justinseanmartin)
   [#12165](https://github.com/CocoaPods/CocoaPods/pull/12165)
+* Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflusher`  
+  [MagnificentMiles](https://github.com/MagnificentMiles)
+  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
 
 ## 1.14.3 (2023-11-19)
 
@@ -33,10 +36,6 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Revert minimum required Ruby version to 2.6 to support macOS system Ruby  
   [Eric Amorde](https://github.com/amorde)
   [#12122](https://github.com/CocoaPods/CocoaPods/issues/12122)
-
-* Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflusher`  
-  [MagnificentMiles](https://github.com/MagnificentMiles)
-  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
 
 ## 1.14.2 (2023-10-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
   [Eric Amorde](https://github.com/amorde)
   [#12122](https://github.com/CocoaPods/CocoaPods/issues/12122)
 
+* Support `visionos` in `pod lib lint --platforms=` and use `xros` for `Fourflush`  
+  [MagnificentMiles](https://github.com/MagnificentMiles)
+  [#issue_number](https://github.com/CocoaPods/CocoaPods/issues/issue_number)
 
 ## 1.14.2 (2023-10-27)
 

--- a/lib/cocoapods/command/lib/lint.rb
+++ b/lib/cocoapods/command/lib/lint.rb
@@ -25,7 +25,7 @@ module Pod
             ['--use-static-frameworks', 'Lint uses static frameworks during installation'],
             ["--sources=#{Pod::TrunkSource::TRUNK_REPO_URL}", 'The sources from which to pull dependent pods ' \
               "(defaults to #{Pod::TrunkSource::TRUNK_REPO_URL}). Multiple sources must be comma-delimited"],
-            ['--platforms=ios,macos', 'Lint against specific platforms (defaults to all platforms supported by the ' \
+            ['--platforms=ios,macos,visionos', 'Lint against specific platforms (defaults to all platforms supported by the ' \
               'podspec). Multiple platforms must be comma-delimited'],
             ['--private', 'Lint skips checks that apply only to public specs'],
             ['--swift-version=VERSION', 'The `SWIFT_VERSION` that should be used to lint the spec. ' \

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -1108,7 +1108,7 @@ module Pod
         command += Fourflusher::SimControl.new.destination(:oldest, 'tvOS', deployment_target)
       when :visionos
         command += %w(CODE_SIGN_IDENTITY=- -sdk xrsimulator)
-        command += Fourflusher::SimControl.new.destination(:oldest, 'visionOS', deployment_target)
+        command += Fourflusher::SimControl.new.destination(:oldest, 'xrOS', deployment_target)
       end
 
       if analyze


### PR DESCRIPTION
## Motivation

Fixes https://github.com/CocoaPods/CocoaPods/pull/11965#issuecomment-1808472679

And possibly Firebase and [RevenueCat](https://github.com/RevenueCat/purchases-ios/pull/3262#issuecomment-1743880127)

## Description

- Added `visionos` to `--platforms` in `pod lib lint`
- Changed the validator to use `xros` when passing into `Fourflusher`
  - Prevents `ERROR | [visionOS] unknown: Encountered an unknown error (Could not find a `xsos` simulator (valid values: ios, tvos, watchos, xros). Ensure that Xcode -> Window -> Devices has at least one `xsos` simulator listed or otherwise add one.`  


And this is my first CocoaPods pull request so let me know if there is anything else I can do make this PR easier to merge!