### PR TITLE
Don't use :remove_destination option to `FileUtils.cp_r`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Fix pod install issue when git's `core.fsmonitor` feature is enabled
+* Fix pod install issue when git's `core.fsmonitor` feature is enabled  
   [Justin Martin](https://github.com/justinseanmartin)
   [#11640](https://github.com/CocoaPods/CocoaPods/issues/11640)
+
+* Don't use the `remove_destination` parameter in FileUtils.cp_r  
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#12165](https://github.com/CocoaPods/CocoaPods/pull/12165)
 
 ## 1.14.3 (2023-11-19)
 

--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -51,7 +51,8 @@ module Pod
       if target && result.location && target != result.location
         UI.message "Copying #{request.name} from `#{result.location}` to #{UI.path target}", '> ' do
           Cache.read_lock(result.location) do
-            FileUtils.cp_r(result.location, target, :remove_destination => true)
+            FileUtils.rm_rf(target)
+            FileUtils.cp_r(result.location, target)
           end
         end
       end


### PR DESCRIPTION
The docs for `FileUtils.cp_r` state:
> If `remove_destination` is true, this method removes each destination file before copy.

This isn't the behavior like `rsync --delete` provides, where it removes extraneous files. Instead, [it seems like](https://public--inbox-org.translate.goog/ruby-dev/873bi0lqc0.fsf@m17n.org/T/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp#t) this feature was added to Ruby to deal with cases where the file being copied over is potentially actively in use during the copy operation. Instead of overwriting the file, it'll [unlink](https://linux.die.net/man/2/unlink) the file first [here](https://github.com/ruby/ruby/blob/fb7add495454322ea00efa7549feb957cb1ca538/lib/fileutils.rb#L1047), which allows open file handles to continue accessing the old file contents.

In any case, the solution is to go back to the previous behavior of doing an `rm_rf` before the `cp_r`. Alternatively, we could use `rsync --delete` here as well, like we did [here](https://github.com/CocoaPods/CocoaPods/pull/12158), but I'd rather minimize the churn.

Without this, the behavior that we were seeing is that we'd end up with an pod install output like:
>   \> Copying PodFramework from `/Users/jmartin/Library/Caches/CocoaPods/ios-register/Pods/Release/PodFramework/1.2.3-134c1` to `Pods/PodFramework`

And we'd end up with the new pods content installed into `Pods/PodFramework/1.2.3-134c1` instead of into the root directory. By removing the `PodFramework` destination directory before the call to `cp_r`, we will restore the previous expected behavior.