### PR TITLE
Revert 1.15.0 regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Fix pod install issue when git's `core.fsmonitor` feature is enabled  
+* Fix pod install issue when git's `core.fsmonitor` feature is enabled
   [Justin Martin](https://github.com/justinseanmartin)
   [#11640](https://github.com/CocoaPods/CocoaPods/issues/11640)
 * None.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Fix pod install issue when git's `core.fsmonitor` feature is enabled  
   [Justin Martin](https://github.com/justinseanmartin)
   [#11640](https://github.com/CocoaPods/CocoaPods/issues/11640)
+* None.  
+
 
 * Don't use the `remove_destination` parameter in FileUtils.cp_r  
   [Justin Martin](https://github.com/justinseanmartin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Revert #12154, #12165, and #12158 to fix regressions in 1.15.0 and 1.15.1.  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#12226](https://github.com/CocoaPods/CocoaPods/issues/12226)
 
 ## 1.15.1 (2024-02-06)
 
@@ -38,11 +39,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* Fix pod install issue when git's `core.fsmonitor` feature is enabled
+* Fix pod install issue when git's `core.fsmonitor` feature is enabled  
   [Justin Martin](https://github.com/justinseanmartin)
   [#11640](https://github.com/CocoaPods/CocoaPods/issues/11640)
-* None.  
-
 
 * Don't use the `remove_destination` parameter in FileUtils.cp_r  
   [Justin Martin](https://github.com/justinseanmartin)

--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -51,8 +51,7 @@ module Pod
       if target && result.location && target != result.location
         UI.message "Copying #{request.name} from `#{result.location}` to #{UI.path target}", '> ' do
           Cache.read_lock(result.location) do
-            FileUtils.rm_rf(target)
-            FileUtils.cp_r(result.location, target)
+            FileUtils.cp_r(result.location, target, :remove_destination => true)
           end
         end
       end

--- a/lib/cocoapods/downloader.rb
+++ b/lib/cocoapods/downloader.rb
@@ -51,7 +51,8 @@ module Pod
       if target && result.location && target != result.location
         UI.message "Copying #{request.name} from `#{result.location}` to #{UI.path target}", '> ' do
           Cache.read_lock(result.location) do
-            FileUtils.cp_r(result.location, target, :remove_destination => true)
+            FileUtils.rm_rf target
+            FileUtils.cp_r(result.location, target)
           end
         end
       end

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -308,7 +308,7 @@ module Pod
         specs_by_platform = group_subspecs_by_platform([spec])
         destination.parent.mkpath
         Cache.write_lock(destination) do
-          Pod::Executable.execute_command('rsync', ['-a', '--exclude=.git/fsmonitor--daemon.ipc', '--delete', "#{source}/", destination])
+          FileUtils.cp_r(source, destination, :remove_destination => true)
           Pod::Installer::PodSourcePreparer.new(spec, destination).prepare!
           Sandbox::PodDirCleaner.new(destination, specs_by_platform).clean!
         end

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -235,38 +235,13 @@ module Pod
       #         was not found in the download cache.
       #
       def uncached_pod(request)
-        in_tmpdir do |tmp_dir|
-          result, podspecs = download(request, tmp_dir)
+        in_tmpdir do |target|
+          result, podspecs = download(request, target)
           result.location = nil
 
-          # Split by pods that require a prepare command or not to speed up installation.
-          no_prep_cmd_specs, prep_cmd_specs = podspecs.partition { |_, spec| spec.prepare_command.nil? }.map(&:to_h)
-
-          # Pods with a prepare command currently copy the entire repo, run the prepare command against the whole
-          # repo and then clean it up. We configure those first to ensure the repo is pristine.
-          prep_cmd_specs.each do |name, spec|
+          podspecs.each do |name, spec|
             destination = path_for_pod(request, :name => name, :params => result.checkout_options)
-            copy_source_and_clean(tmp_dir, destination, spec)
-            write_spec(spec, path_for_spec(request, :name => name, :params => result.checkout_options))
-            if request.name == name
-              result.location = destination
-            end
-          end
-
-          specs_by_platform = group_subspecs_by_platform(no_prep_cmd_specs.values)
-
-          # Remaining pods without a prepare command can be optimized by cleaning the repo first
-          # and then copying only the files needed.
-          pod_dir_cleaner = Sandbox::PodDirCleaner.new(tmp_dir, specs_by_platform)
-          Cache.write_lock(tmp_dir) do
-            pod_dir_cleaner.clean!
-          end
-
-          no_prep_cmd_specs.each do |name, spec|
-            destination = path_for_pod(request, :name => name, :params => result.checkout_options)
-            file_accessors = pod_dir_cleaner.file_accessors.select { |fa| fa.spec.root.name == spec.name }
-            files = Pod::Sandbox::FileAccessor.all_files(file_accessors).map(&:to_s)
-            copy_files(files, tmp_dir, destination)
+            copy_and_clean(target, destination, spec)
             write_spec(spec, path_for_spec(request, :name => name, :params => result.checkout_options))
             if request.name == name
               result.location = destination
@@ -304,57 +279,23 @@ module Pod
       #
       # @return [Void]
       #
-      def copy_source_and_clean(source, destination, spec)
-        specs_by_platform = group_subspecs_by_platform([spec])
+      def copy_and_clean(source, destination, spec)
+        specs_by_platform = group_subspecs_by_platform(spec)
         destination.parent.mkpath
         Cache.write_lock(destination) do
-          FileUtils.cp_r(source, destination, :remove_destination => true)
+          FileUtils.rm_rf(destination)
+          FileUtils.cp_r(source, destination)
           Pod::Installer::PodSourcePreparer.new(spec, destination).prepare!
           Sandbox::PodDirCleaner.new(destination, specs_by_platform).clean!
         end
       end
 
-      # Copies the `files` from the `source` directory to `destination` _without_ cleaning the
-      # `destination` directory of any files unused by `spec`. This is a faster version used when
-      # installing pods without a prepare command which has already happened prior.
-      #
-      # @param  [Array<Pathname>] files
-      #
-      # @param  [Pathname] source
-      #
-      # @param  [Pathname] destination
-      #
-      # @return [Void]
-      #
-      def copy_files(files, source, destination)
-        files = files.
-                map { |f| Pathname(f) }.
-                select { |p| p.exist? && p.file? }
-        destination.parent.mkpath
-        Cache.write_lock(destination) do
-          FileUtils.rm_rf(destination)
-          destination.mkpath
-          files_by_dir = files.group_by do |file|
-            relative_path = file.relative_path_from(source)
-            destination_path = File.join(destination, relative_path)
-            File.dirname(destination_path)
-          end
-
-          files_by_dir.each do |dir, files_to_copy|
-            FileUtils.mkdir_p(dir)
-            FileUtils.cp_r(files_to_copy, dir)
-          end
-        end
-      end
-
-      def group_subspecs_by_platform(specs)
+      def group_subspecs_by_platform(spec)
         specs_by_platform = {}
-        specs.each do |spec|
-          [spec, *spec.recursive_subspecs].each do |ss|
-            ss.available_platforms.each do |platform|
-              specs_by_platform[platform] ||= []
-              specs_by_platform[platform] << ss
-            end
+        [spec, *spec.recursive_subspecs].each do |ss|
+          ss.available_platforms.each do |platform|
+            specs_by_platform[platform] ||= []
+            specs_by_platform[platform] << ss
           end
         end
         specs_by_platform

--- a/lib/cocoapods/sandbox/pod_dir_cleaner.rb
+++ b/lib/cocoapods/sandbox/pod_dir_cleaner.rb
@@ -15,8 +15,10 @@ module Pod
       # @return [void]
       #
       def clean!
-        FileUtils.rm_rf(clean_paths) if root.exist?
+        clean_paths.each { |path| FileUtils.rm_rf(path) } if root.exist?
       end
+
+      private
 
       # @return [Array<Sandbox::FileAccessor>] the file accessors for all the
       #         specifications on their respective platform.
@@ -26,8 +28,6 @@ module Pod
           specs.flat_map { |spec| Sandbox::FileAccessor.new(path_list, spec.consumer(platform)) }
         end
       end
-
-      private
 
       # @return [Sandbox::PathList] The path list for this Pod.
       #

--- a/spec/unit/downloader/cache_spec.rb
+++ b/spec/unit/downloader/cache_spec.rb
@@ -49,7 +49,7 @@ module Pod
         end
       end
 
-      @cache.send(:group_subspecs_by_platform, [@spec]).should == {
+      @cache.send(:group_subspecs_by_platform, @spec).should == {
         Platform.new(:ios, '8.0') => [@spec.subspecs.first],
         Platform.new(:ios, '6.0') => [@spec],
         Platform.new(:osx, '10.7') => [@spec],
@@ -81,7 +81,7 @@ module Pod
         end
 
         it 'downloads the source' do
-          @cache.expects(:copy_files).twice
+          @cache.expects(:copy_and_clean).twice
           response = @cache.download_pod(@unreleased_request)
           response.should == Downloader::Response.new(@cache.root + @unreleased_request.slug, @spec, @spec.source)
         end


### PR DESCRIPTION
Fix #12226 

It reverts #12154 and two follow on PRs.  I'm fine to discard this PR if someone comes up with a fix forward solution.

Confirms it fixes this Podfile that broke in 1.15.0:

```
platform :ios, '11.0'

source 'https://cdn.cocoapods.org/'

target 'SymbolCollisionTest' do
  use_frameworks!
    pod 'GoogleAuthUtilities'
end
```