### PR TITLE
An error message has been added to the 'Embed Pods Frameworks' script…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* An error message has been added to the '**Embed Pods Frameworks**' script, when the app target's `ENABLE_USER_SCRIPT_SANDBOXING` is set to `YES`.  
+  [CrazyFanFan](https://github.com/CrazyFanFan)
+  [#12235](https://github.com/CocoaPods/CocoaPods/pull/12235)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -59,6 +59,11 @@ if [ -z ${FRAMEWORKS_FOLDER_PATH+x} ]; then
   exit 0
 fi
 
+if [ "${ENABLE_USER_SCRIPT_SANDBOXING}" = "YES" ]; then
+  echo "error: Copy Frameworks operation failed due to User-Space Script Sandboxing being enabled. Disable 'ENABLE_USER_SCRIPT_SANDBOXING' in your Xcode target build_settings and try again."
+  exit 1
+fi
+
 echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 


### PR DESCRIPTION
An error message has been added to the '**Embed Pods Frameworks**' script, when the app target's `ENABLE_USER_SCRIPT_SANDBOXING` is set to `YES`.

By default, `ENABLE_USER_SCRIPT_SANDBOXING` is enabled when a project is created with Xcode 15 or above.

Attached is a Demo Project that reproduces the problem.
[Foo.zip](https://github.com/CocoaPods/CocoaPods/files/14108582/Foo.zip)
