### PR TITLE
Fix an issue attempting to re-copy the same file when the destination does not have write permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix an issue when caching downloads of certain Pods.  
+  [Eric Amorde](https://github.com/amorde)
+  [#12226](https://github.com/CocoaPods/CocoaPods/issues/12226)
 
 
 ## 1.15.0 (2024-01-28)

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -327,13 +327,15 @@ module Pod
       # @return [Void]
       #
       def copy_files(files, source, destination)
-        files = files.select { |f| File.exist?(f) }
+        files = files.
+                map { |f| Pathname(f) }.
+                select { |p| p.exist? && p.file? }
         destination.parent.mkpath
         Cache.write_lock(destination) do
           FileUtils.rm_rf(destination)
           destination.mkpath
           files_by_dir = files.group_by do |file|
-            relative_path = Pathname(file).relative_path_from(Pathname(source)).to_s
+            relative_path = file.relative_path_from(source)
             destination_path = File.join(destination, relative_path)
             File.dirname(destination_path)
           end


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/CocoaPods/issues/12226

The underlying issue was attempting to copy a file when it already exists at the destination and does not have the write permission set, causing a write permission error.

The copy is duplicative because a previous pass had already copied a parent directory including the files. The fix is to update the logic to only copy individual files instead of also copying folders.

Note: this logic could be optimized a bit further, but I was looking for a reliable fast solution to the bug for now.