### PR TITLE
fix: ensure real path for header_mappings_dir

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -1059,7 +1059,7 @@ module Pod
 
             if target.build_as_framework? && !header_mappings_dir(file_accessor).nil? && acl != 'Project'
               relative_path = if mapping_dir = header_mappings_dir(file_accessor)
-                                file_ref.real_path.relative_path_from(mapping_dir)
+                                file_ref.real_path.relative_path_from(Pathname.new(mapping_dir).realpath)
                               else
                                 file_ref.real_path.relative_path_from(file_accessor.path_list.root)
                               end


### PR DESCRIPTION
If `header_mappings_dir` is set to symlinked path, the header directory structure is not preserved currently because cocoapods uses header's real path to find relative path from `header_mappings_dir`, but header_mappings_dir is not ensured to be a real path(it could be symlinked path).

We can easily reproduce issue with following conditions:
- React Native 0.73+: it uses `header_mappings_dir` in its [local podspecs](https://github.com/facebook/react-native/blob/ff5e1a605ad4a905053292ff8231828087153336/packages/react-native/ReactCommon/yoga/Yoga.podspec#L55)
- with `use_frameworks! :linkage => :static`.
- pnpm: React Native add podspecs from Node.js' node_module directory, and pnpm uses symlink when creating node_module directory.

Related issue: https://github.com/facebook/react-native/issues/41938