### PR TITLE
[Feature][DerivedData] Add an environment variable to customize the derived data path

### DIFF
--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -1115,6 +1115,10 @@ module Pod
         command += %w(CLANG_ANALYZER_OUTPUT=html CLANG_ANALYZER_OUTPUT_DIR=analyzer)
       end
 
+      if !ENV['COCOAPODS_DERIVED_DATA_PATH'].nil? && !ENV['COCOAPODS_DERIVED_DATA_PATH'].empty?
+        command += %W(-derivedDataPath #{ENV['COCOAPODS_DERIVED_DATA_PATH']})
+      end
+
       begin
         _xcodebuild(command, true)
       rescue => e


### PR DESCRIPTION
I made this PR to add an environment variable `COCOAPODS_DERIVED_DATA_PATH ` to customize the `-derivedDataPath` of `xcodebuild` when user attempts to run the CocoaPods command, such as `pod lib lint`, `pod repo push`, etc.