### PR TITLE
Fix pod install issue when git's `core.fsmonitor` feature is enabled (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Fix pod install issue when git's `core.fsmonitor` feature is enabled (again)
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#12349](https://github.com/CocoaPods/CocoaPods/issues/12349)
 
 
 ## 1.15.2 (2024-02-06)

--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -283,11 +283,14 @@ module Pod
         specs_by_platform = group_subspecs_by_platform(spec)
         destination.parent.mkpath
         Cache.write_lock(destination) do
-          FileUtils.rm_rf(destination)
-          FileUtils.cp_r(source, destination)
+          rsync_contents(source, destination)
           Pod::Installer::PodSourcePreparer.new(spec, destination).prepare!
           Sandbox::PodDirCleaner.new(destination, specs_by_platform).clean!
         end
+      end
+
+      def rsync_contents(source, destination)
+        Pod::Executable.execute_command('rsync', ['-a', '--exclude=.git', '--delete', "#{source}/", destination])
       end
 
       def group_subspecs_by_platform(spec)

--- a/spec/unit/validator_spec.rb
+++ b/spec/unit/validator_spec.rb
@@ -41,6 +41,10 @@ module Pod
       source.specification_path(name, version)
     end
 
+    def stub_downloader_cache_rsync
+      Downloader::Cache.any_instance.expects(:rsync_contents).with { |_, destination| FileUtils.mkdir_p(destination) }
+    end
+
     #-------------------------------------------------------------------------#
 
     describe 'Quick mode' do
@@ -786,6 +790,7 @@ module Pod
         require 'fourflusher'
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
+        stub_downloader_cache_rsync
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)
@@ -803,6 +808,7 @@ module Pod
         require 'fourflusher'
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
+        stub_downloader_cache_rsync
         PodTarget.any_instance.stubs(:should_build?).returns(true)
         Installer::Xcode::PodsProjectGenerator::PodTargetInstaller.any_instance.stubs(:validate_targets_contain_sources) # since we skip downloading
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
@@ -833,6 +839,7 @@ module Pod
         require 'fourflusher'
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
+        stub_downloader_cache_rsync
         PodTarget.any_instance.stubs(:should_build?).returns(true)
         Installer::Xcode::PodsProjectGenerator::PodTargetInstaller.any_instance.stubs(:validate_targets_contain_sources) # since we skip downloading
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
@@ -864,6 +871,7 @@ module Pod
         require 'fourflusher'
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
+        stub_downloader_cache_rsync
         PodTarget.any_instance.stubs(:should_build?).returns(true)
         Installer::Xcode::PodsProjectGenerator::PodTargetInstaller.any_instance.stubs(:validate_targets_contain_sources) # since we skip downloading
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
@@ -897,6 +905,7 @@ module Pod
         require 'fourflusher'
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
+        stub_downloader_cache_rsync
         PodTarget.any_instance.stubs(:should_build?).returns(true)
         Installer::Xcode::PodsProjectGenerator::PodTargetInstaller.any_instance.stubs(:validate_targets_contain_sources) # since we skip downloading
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
@@ -931,6 +940,7 @@ module Pod
         require 'fourflusher'
         Fourflusher::SimControl.any_instance.stubs(:destination).returns(['-destination', 'id=XXX'])
         Validator.any_instance.unstub(:xcodebuild)
+        stub_downloader_cache_rsync
         validator = Validator.new(podspec_path, config.sources_manager.master.map(&:url))
         validator.stubs(:check_file_patterns)
         validator.stubs(:validate_url)


### PR DESCRIPTION
Use rsync to exclude copying the `fsmonitor--daemon.ipc` (or anything under the `.git` directory for that matter). From the original PR #12158:

> This prevents a copy error where the system is unable to copy the ipc file due to being a socket. This would otherwise manifest as errors during pod install with the message "too long unix socket path" if git's core.fsmonitor feature is enabled.

I don't think this change was causing any of the issues that led to the revert in #12229 for the 1.15.2 release. I verified that I can reproduce the issue in #12226 against 1.15.0 and it does not reproduce against this branch.

This should again resolve #11640.