### PR TITLE
[pod_target_dependency_installer] Allows generation of static framework with resource files

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_dependency_installer.rb
@@ -63,7 +63,7 @@ module Pod
         def wire_resource_bundle_targets(resource_bundle_targets, native_target, pod_target)
           resource_bundle_targets.each do |resource_bundle_target|
             native_target.add_dependency(resource_bundle_target)
-            if pod_target.build_as_dynamic_framework? && pod_target.should_build?
+            if pod_target.build_as_framework? && pod_target.should_build?
               native_target.add_resources([resource_bundle_target.product_reference])
             end
           end


### PR DESCRIPTION
🌈 Hi, committers,

As mentioned in [this issue](https://github.com/leavez/cocoapods-binary/issues/50#issuecomment-476973282), it is no longer possible to generate static framework targets that contain resource files in CocoaPods 1.7 and above.

This change might not cause a problem, because static frameworks did not need to be embedded in the application normally. However, the situation changed when Apple required support for privacy manifests.

[According to Apple](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files), if you want to distribute an application using a third-party SDK that supports privacy manifest as a static library, you need to create a static framework that includes the privacy manifest file. However, the current CocoaPods cannot generate such a static framework target. Even if you write the `resource_bundle` specification in the podspec, the "Copy Bundle Resources" field in the build phases of the generated static framework target will be empty.

To solve this problem, I have created this pull request that make possible to include resource files in static framework targets.

I hope you will approve this change.