### PR TITLE
Add Support for Xcode 14.3's ENABLE_MODULE_VERIFIER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Add Support for Xcode 14.3's ENABLE_MODULE_VERIFIER.  
+  [sharplet](https://github.com/sharplet)
+  [#12390](https://github.com/CocoaPods/CocoaPods/pull/12390)  
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/target/build_settings.rb
+++ b/lib/cocoapods/target/build_settings.rb
@@ -28,6 +28,7 @@ module Pod
         OTHER_CFLAGS
         OTHER_CPLUSPLUSFLAGS
         OTHER_LDFLAGS
+        OTHER_MODULE_VERIFIER_FLAGS
         OTHER_SWIFT_FLAGS
         REZ_SEARCH_PATHS
         SECTORDER_FLAGS
@@ -291,6 +292,11 @@ module Pod
       # @return [Array<String>]
       define_build_settings_method :other_cflags, :build_setting => true, :memoized => true do
         module_map_files.map { |f| "-fmodule-map-file=#{f}" }
+      end
+
+      # @return [Array<String>]
+      define_build_settings_method :other_module_verifier_flags, :build_setting => true, :memoized => true do
+        []
       end
 
       # @return [Array<String>]
@@ -1230,6 +1236,13 @@ module Pod
           flags += silenced_headers.uniq.flat_map { |p| ['-isystem', p] }
           flags += silenced_frameworks.uniq.flat_map { |p| ['-iframework', p] }
 
+          flags
+        end
+
+        # @return [Array<String>]
+        define_build_settings_method :other_module_verifier_flags, :memoized => true do
+          flags = super()
+          flags += pod_targets.map { |pt| '-F' + pt.build_settings[@configuration].configuration_build_dir }
           flags
         end
 

--- a/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
+++ b/spec/unit/target/build_settings/aggregate_target_settings_spec.rb
@@ -389,6 +389,10 @@ module Pod
               @xcconfig.to_hash['FRAMEWORK_SEARCH_PATHS'].should == '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework"'
             end
 
+            it 'adds the framework build path to the xcconfig, with quotes, as module verifier flags' do
+              @xcconfig.to_hash['OTHER_MODULE_VERIFIER_FLAGS'].should == '$(inherited) "-F${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework"'
+            end
+
             it 'adds the framework header paths to the xcconfig, with quotes, as local headers' do
               expected = '$(inherited) "${PODS_CONFIGURATION_BUILD_DIR}/OrangeFramework/OrangeFramework.framework/Headers"'
               @xcconfig.to_hash['HEADER_SEARCH_PATHS'].should == expected


### PR DESCRIPTION
The module verifier validates framework modularity in a clean test environment that doesn't work out of the box with the way CocoaPods framework targets are installed in `CONFIGURATION_BUILD_DIR`. Specifically, Xcode's default behaviour is to build framework bundles directly in `$(CONFIGURATION_BUILD_DIR)`, whereas pod framework targets are built in a nested directory `$(PODS_CONFIGURATION_BUILD_DIR)/PodName/`. The result is that any Xcode framework target with `ENABLE_MODULE_VERIFIER` set to `YES` will fail to locate pod framework headers when verifying modularity.

By customizing `OTHER_MODULE_VERIFIER_FLAGS`, we can add pod framework build directories to the framework search path, allowing Xcode framework targets that depend on pod framework targets to use the module verifier.