### PR TITLE
Update minimum Xcodeproj version

### DIFF
--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         if: ${{ matrix.task == 'EXAMPLES' }}
         with:
-          xcode-version: 15.1
+          xcode-version: 15.4
 
       - name: Run Tests
         run: bundle exec rake spec:all

--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -13,7 +13,7 @@ jobs:
             os: macos-12
             ruby: system
           - task: EXAMPLES
-            os: macos-latest
+            os: macos-14
             ruby: system
 
     name: ${{ matrix.task }} / ${{ matrix.os }} / Ruby ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,18 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 * Add Support for Xcode 14.3's ENABLE_MODULE_VERIFIER.  
   [sharplet](https://github.com/sharplet)
   [#12390](https://github.com/CocoaPods/CocoaPods/pull/12390)  
+* Xcode 16 support.
+  * Bump minimum `xcodeproj` to `1.26.0`
+  * Update project generator to set `GENERATE_INFOPLIST_FILE = NO` on pod targets
+  * Update project generator to set `ENABLE_USER_SCRIPT_SANDBOXING = NO` = NO` on pod targets to fix build failures with vendored frameworks.  
+  * Update project geneerator to set `SWIFT_INSTALL_OBJC_HEADER = YES` on pod targets to enable consuming Swift pods from Objective-C.
+
+[Eric Amorde](https://github.com/amorde)
+[#12656](https://github.com/CocoaPods/CocoaPods/pull/12656)
 
 ##### Bug Fixes
 
-* Fix pod install issue when git's `core.fsmonitor` feature is enabled (again)
+* Fix pod install issue when git's `core.fsmonitor` feature is enabled (again)  
   [Justin Martin](https://github.com/justinseanmartin)
   [#12349](https://github.com/CocoaPods/CocoaPods/issues/12349)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: d9cdb56b6b5d8bf11ab7b04cc3e01587f6196d8c
+  revision: ed4262149845bbc72de45b21ffa5f6677f37562e
   branch: master
   specs:
     cocoapods-core (1.15.2)
@@ -23,30 +23,30 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Molinillo.git
-  revision: 6bc3d6045edadf800ba1b634fef15d3574369e60
+  revision: 1d62d7d5f448e79418716dc779a4909509ccda2a
   branch: master
   specs:
     molinillo (0.8.0)
 
 GIT
   remote: https://github.com/CocoaPods/Nanaimo.git
-  revision: 93daa63ff5fd720879dbe8322fe4c1700185e0a9
+  revision: ed813249b497d236ec34dddabd0f7e6f103bce9a
   branch: master
   specs:
-    nanaimo (0.3.0)
+    nanaimo (0.4.0)
 
 GIT
   remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: f44d3bb6a223cf6d34c92b72171aa640d86a9b02
+  revision: a1d2206fc535b35853b52c6303d3c6470ad2e212
   branch: master
   specs:
-    xcodeproj (1.25.0)
+    xcodeproj (1.26.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (>= 3.3.2, < 4.0)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
 
 GIT
   remote: https://github.com/CocoaPods/cocoapods-deintegrate.git
@@ -136,7 +136,7 @@ PATH
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.25.0, < 2.0)
+      xcodeproj (>= 1.26.0, < 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -145,14 +145,14 @@ GEM
       base64
       nkf
       rexml
-    activesupport (6.1.7.6)
+    activesupport (6.1.7.10)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -160,7 +160,7 @@ GEM
     atomos (0.1.3)
     awesome_print (1.9.2)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.8)
     claide-plugins (0.9.2)
       cork
       nap
@@ -171,10 +171,11 @@ GEM
       pry (= 0.10.3)
     coderay (1.1.3)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     cork (0.3.0)
       colored2 (~> 3.1)
-    crack (0.4.5)
+    crack (1.0.0)
+      bigdecimal
       rexml
     danger (8.6.1)
       claide (~> 1.0)
@@ -189,12 +190,12 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (>= 1, < 4)
-    diffy (3.4.2)
-    docile (1.4.0)
+    diffy (3.4.3)
+    docile (1.4.1)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    faraday (1.10.3)
+    faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -214,28 +215,28 @@ GEM
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (1.0.1)
+    faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffi (1.16.3)
+    ffi (1.17.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     git (1.19.1)
       addressable (~> 2.8)
       rchardet (~> 1.8)
-    hashdiff (1.1.0)
+    hashdiff (1.1.1)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     inch (0.8.0)
       pry
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.9.12)
-    json (2.7.1)
+    json (2.7.4)
     kicker (3.0.0)
       listen (~> 1.3.0)
       notify (~> 0.5.2)
@@ -249,12 +250,12 @@ GEM
       rb-kqueue (>= 0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
-    minitest (5.22.0)
+    minitest (5.25.1)
     mocha (1.4.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.3)
       mocha (>= 0.13.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.1)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
@@ -264,7 +265,7 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    parallel (1.24.0)
+    parallel (1.26.3)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     powerpack (0.1.3)
@@ -279,13 +280,12 @@ GEM
       rake
     rake (12.3.3)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
     rb-kqueue (0.2.8)
       ffi (>= 0.5.0)
     rchardet (1.8.0)
-    rexml (3.3.4)
-      strscan
+    rexml (3.3.9)
     rubocop (0.50.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -295,7 +295,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.4)
     ruby-macho (2.5.1)
-    ruby-prof (1.7.0)
+    ruby-prof (1.7.1)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sawyer (0.8.2)
@@ -308,25 +308,25 @@ GEM
     simplecov-html (0.10.2)
     slop (3.6.0)
     sparkr (0.4.1)
-    strscan (3.1.0)
     sync (0.5.0)
-    term-ansicolor (1.7.1)
+    term-ansicolor (1.11.2)
       tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    tins (1.32.1)
+    tins (1.37.0)
+      bigdecimal
       sync
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    webmock (3.19.1)
+    webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.34)
-    zeitwerk (2.6.13)
+    yard (0.9.37)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cocoapods-trunk',       '>= 1.6.0', '< 2.0'
   s.add_runtime_dependency 'cocoapods-try',         '>= 1.1.0', '< 2.0'
   s.add_runtime_dependency 'molinillo',             '~> 0.8.0'
-  s.add_runtime_dependency 'xcodeproj',             '>= 1.25.0', '< 2.0'
+  s.add_runtime_dependency 'xcodeproj',             '>= 1.26.0', '< 2.0'
 
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'escape',        '~> 0.0.4'

--- a/examples/AppCenter Example/Podfile
+++ b/examples/AppCenter Example/Podfile
@@ -13,3 +13,13 @@ target 'iOS Example' do
   pod 'AppCenter', '4.2.0'
 end
 
+post_install do |installer|
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = DEFAULT_IOS_DEPLOYMENT_TARGET
+      end
+    end
+  end
+end
+

--- a/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
+++ b/examples/HeaderMappingsDir Example/HeaderMappingsDir Example.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "HeaderMappingsDir Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -417,6 +418,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "HeaderMappingsDir Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -433,6 +435,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "HeaderMappingsDir Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -448,6 +451,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "HeaderMappingsDir Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.HeaderMappingsDir-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;

--- a/examples/HeaderMappingsDir Example/Podfile
+++ b/examples/HeaderMappingsDir Example/Podfile
@@ -18,3 +18,14 @@ target 'CatalystApp' do
   platform :ios, DEFAULT_IOS_DEPLOYMENT_TARGET
   pod 'HeaderMappingsDirPod', :path => 'HeaderMappingsDirPod'
 end
+
+post_install do |installer|
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+          config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = DEFAULT_IOS_DEPLOYMENT_TARGET
+      end
+    end
+  end
+end
+

--- a/examples/Modules Example/Podfile
+++ b/examples/Modules Example/Podfile
@@ -34,3 +34,15 @@ abstract_target 'Abstract Target' do
         end
     end
 end
+
+post_install do |installer|
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+          config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = DEFAULT_MACOS_DEPLOYMENT_TARGET
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = DEFAULT_IOS_DEPLOYMENT_TARGET
+      end
+    end
+  end
+end
+

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -1106,6 +1106,9 @@ module Pod
             target.user_build_configurations.each do |bc_name, type|
               native_target.add_build_configuration(bc_name, type)
             end
+            native_target.build_configurations.each do |configuration|
+              configuration.build_settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
+            end
             unless target.archs.empty?
               native_target.build_configurations.each do |configuration|
                 configuration.build_settings['ARCHS'] = target.archs

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -226,6 +226,9 @@ module Pod
 
             settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = '$(inherited) '
 
+            # Added in Xcode 16. We manually generate our own Info.plist file so opt out.
+            settings['GENERATE_INFOPLIST_FILE'] = 'NO'
+
             if target.swift_version
               settings['SWIFT_VERSION'] = target.swift_version
             end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -228,6 +228,8 @@ module Pod
 
             # Added in Xcode 16. We manually generate our own Info.plist file so opt out.
             settings['GENERATE_INFOPLIST_FILE'] = 'NO'
+            # Added in Xcode 16. For Swift-only Pods to be visible to Objective-C we to enable this.
+            settings['SWIFT_INSTALL_OBJC_HEADER'] = 'YES'
 
             if target.swift_version
               settings['SWIFT_VERSION'] = target.swift_version

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -97,6 +97,9 @@ module Pod
             # This interferes with our custom run script phases
             settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
 
+            # We aren't yet ready to support this for our targets
+            settings['ENABLE_MODULE_VERIFIER'] = 'NO'
+
             settings
           end
 

--- a/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/target_installer.rb
@@ -94,6 +94,9 @@ module Pod
               settings.merge!('OTHER_LDFLAGS' => '', 'OTHER_LIBTOOLFLAGS' => '')
             end
 
+            # This interferes with our custom run script phases
+            settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
+
             settings
           end
 

--- a/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/target_installer_spec.rb
@@ -32,7 +32,7 @@ module Pod
             @target.stubs(:requires_frameworks?).returns(true)
             @target.stubs(:uses_swift?).returns(true)
             @installer.send(:add_target).resolved_build_setting('SWIFT_OPTIMIZATION_LEVEL').should == {
-              'Release' => '-O',
+              'Release' => nil,
               'Debug' => '-Onone',
               'Test' => nil,
               'AppStore' => nil,


### PR DESCRIPTION
Bump xcodeproj to [1.26.0](https://github.com/CocoaPods/Xcodeproj/releases/tag/1.26.0) which includes Xcode 16 support.