### PR TITLE
Don't exclude .git folder from rsync

### DIFF
--- a/lib/cocoapods/downloader/cache.rb
+++ b/lib/cocoapods/downloader/cache.rb
@@ -290,7 +290,7 @@ module Pod
       end
 
       def rsync_contents(source, destination)
-        Pod::Executable.execute_command('rsync', ['-a', '--exclude=.git', '--delete', "#{source}/", destination])
+        Pod::Executable.execute_command('rsync', ['-a', '--delete', "#{source}/", destination])
       end
 
       def group_subspecs_by_platform(spec)


### PR DESCRIPTION
As detailed in [this issue](https://github.com/CocoaPods/CocoaPods/issues/12674), latest version breaks pods that depends on the `.git` folder.

This PR remove `--exclude=.git` option from the rsync command.