### PR TITLE
chore: bump ruby macho to 4.1.0 to enable mergable libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Update ruby-macho to 4.1.0 to address new mergable libraries not beind detected correctly.  
+    [Parsa Nasirimehr](https://github.com/TheRogue76)
+    [#12691](https://github.com/CocoaPods/CocoaPods/pull/12691)
 
 
 ## 1.16.2 (2024-10-31)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ PATH
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 2.3.0, < 3.0)
+      ruby-macho (~> 4.1.0)
       xcodeproj (>= 1.27.0, < 2.0)
 
 GEM
@@ -294,7 +294,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.4)
-    ruby-macho (2.5.1)
+    ruby-macho (4.1.0)
     ruby-prof (1.7.1)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fourflusher',   '>= 2.3.0', '< 3.0'
   s.add_runtime_dependency 'gh_inspector',  '~> 1.0'
   s.add_runtime_dependency 'nap',           '~> 1.0'
-  s.add_runtime_dependency 'ruby-macho',    '>= 2.3.0', '< 3.0'
+  s.add_runtime_dependency 'ruby-macho',    '~> 4.1.0'
 
   s.add_runtime_dependency 'addressable', '~> 2.8'
 


### PR DESCRIPTION
## Description
To address https://github.com/CocoaPods/CocoaPods/issues/12388, this PR aims to update Ruby macho to 4.1.0, which now supports Mergable libraries. The local tests i ran ran ok, but i will leave it up to the CI to check as well since bundle exec rake spec was having some issue with my ruby 3.3.0. As far as i saw comparing 2.5.1 and 4.1.0, i couldn't see a breaking change in the APIs that cocoapods uses (it is used in `linkage_analyzer.rb` and the `linkage_analyzer_spec.rb`), so no further changes needed as far as i know
## Test Results (before it threw an unrelated error regarding my Ruby 3.3.0)
<img width="557" alt="Screenshot 2024-11-10 at 15 32 06" src="https://github.com/user-attachments/assets/577794eb-9dfc-4a12-9bd3-3ceebb3392fb">
