### PR TITLE
Introducing `--no-lint` option for `pod repo push` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Added `--no-lint` option for `pod repo push` command to allow skipping Lint phase when publishing a Pod.  
+  [Guillermo Mazzola](https://github.com/gmazzo)
+  [#12706](https://github.com/CocoaPods/CocoaPods/pull/12706)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods/command/repo/push.rb
+++ b/lib/cocoapods/command/repo/push.rb
@@ -28,6 +28,7 @@ module Pod
             ["--sources=#{Pod::TrunkSource::TRUNK_REPO_URL}", 'The sources from which to pull dependent pods ' \
              '(defaults to all available repos). Multiple sources must be comma-delimited'],
             ['--local-only', 'Does not perform the step of pushing REPO to its remote'],
+            ['--no-lint', 'Does not perform the Lint step'],
             ['--no-private', 'Lint includes checks that apply only to public repos'],
             ['--skip-import-validation', 'Lint skips validating that the pod can be imported'],
             ['--skip-tests', 'Lint skips building and running tests during validation'],
@@ -52,6 +53,7 @@ module Pod
           @podspec = argv.shift_argument
           @use_frameworks = !argv.flag?('use-libraries')
           @use_modular_headers = argv.flag?('use-modular-headers', false)
+          @lint = argv.flag?('lint', true)
           @private = argv.flag?('private', true)
           @message = argv.option('commit-message')
           @commit_message = argv.flag?('commit-message', false)
@@ -78,7 +80,7 @@ module Pod
           open_editor if @commit_message && @message.nil?
           check_if_push_allowed
           update_sources if @update_sources
-          validate_podspec_files
+          validate_podspec_files if @lint
           check_repo_status
           update_repo
           add_specs_to_repo

--- a/spec/functional/command/repo/push_spec.rb
+++ b/spec/functional/command/repo/push_spec.rb
@@ -160,6 +160,15 @@ module Pod
       (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
     end
 
+    it 'successfully pushes spec without validating it when flag no-lint' do
+      cmd = command('repo', 'push', 'master', '--no-lint')
+      Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }
+      cmd.expects(:validate_podspec_files).never
+      Dir.chdir(temporary_directory) { cmd.run }
+      Dir.chdir(@upstream) { `git checkout main -q` }
+      (@upstream + 'PushTest/1.4/PushTest.podspec').read.should.include('PushTest')
+    end
+
     it 'successfully pushes a spec to URL' do
       cmd = command('repo', 'push', @upstream)
       Dir.chdir(@upstream) { `git checkout -b tmp_for_push -q` }


### PR DESCRIPTION
Adds `--no-lint` option to `pod repo push` command.

This flag will skip `validate_podspec_files` method from being invoked as part of the `Push` command.

### Use case
To enable publishing an iOS Pod from non-Mac environments like UNIX systems.