### PR TITLE
Fix Ruby version 3.0 for Specs tests

### DIFF
--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         task: [SPECS]
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, '3.0']
         os: [ubuntu-20.04]
         include:
           - task: SPECS


### PR DESCRIPTION
In order to work around a bug in GH Actions, it is required to wrap the 3.0 Ruby version declaration in quotes, otherwise it is interpreted as Ruby version 3, without major or minor version restrictions.

See
- official issue: https://github.com/actions/runner/issues/849
- ruby/setup-ruby setup instructions: https://github.com/ruby/setup-ruby/tree/v1/?tab=readme-ov-file#matrix-of-ruby-versions

Example workflow run: https://github.com/CocoaPods/CocoaPods/actions/runs/11768823762/job/32779090259
- job name is falsely `SPECS / ubuntu-20.04 / Ruby 3` instead of `SPECS / ubuntu-20.04 / Ruby 3.0`
- Set up Ruby step downloads `ruby-3.3.6-ubuntu-20.04.tar.gz`