### PR TITLE
fix: remove implicit current-directory search from resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
     [#12691](https://github.com/CocoaPods/CocoaPods/pull/12691)
 
 * Harden executable lookup in `Pod::Executable.which` by removing implicit current-directory search, honoring explicit path executables only, and skipping unsafe PATH entries (`''` and `.`) to prevent local executable hijacking.  
-  [CocoaPods Team](https://github.com/CocoaPods)
-  [#TBD](https://github.com/CocoaPods/CocoaPods/pull/TBD)
+  [Sam Sanoop](https://github.com/snoopysecurity)
+  [#12899](https://github.com/CocoaPods/CocoaPods/pull/TBD)
 
 
 ## 1.16.2 (2024-10-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
     [Parsa Nasirimehr](https://github.com/TheRogue76)
     [#12691](https://github.com/CocoaPods/CocoaPods/pull/12691)
 
+* Harden executable lookup in `Pod::Executable.which` by removing implicit current-directory search, honoring explicit path executables only, and skipping unsafe PATH entries (`''` and `.`) to prevent local executable hijacking.  
+  [CocoaPods Team](https://github.com/CocoaPods)
+  [#TBD](https://github.com/CocoaPods/CocoaPods/pull/TBD)
+
 
 ## 1.16.2 (2024-10-31)
 

--- a/lib/cocoapods/executable.rb
+++ b/lib/cocoapods/executable.rb
@@ -90,17 +90,17 @@ module Pod
     #
     def self.which(program)
       program = program.to_s
+      if path_program?(program)
+        return executable_path_for(program)
+      end
+
       paths = ENV.fetch('PATH') { '' }.split(File::PATH_SEPARATOR)
-      paths.unshift('./')
       paths.uniq!
       paths.each do |path|
-        bin = File.expand_path(program, path)
-        if Gem.win_platform?
-          bin += '.exe'
-        end
-        if File.file?(bin) && File.executable?(bin)
-          return bin
-        end
+        next if path.nil? || path.empty? || path == '.'
+
+        bin = executable_path_for(program, path)
+        return bin if bin
       end
       nil
     end
@@ -169,6 +169,19 @@ module Pod
     end
 
     private
+
+    def self.path_program?(program)
+      separator = File::ALT_SEPARATOR
+      program.include?(File::SEPARATOR) || (separator && program.include?(separator))
+    end
+
+    def self.executable_path_for(program, path = nil)
+      bin = path ? File.expand_path(program, path) : File.expand_path(program)
+      if Gem.win_platform? && File.extname(bin).downcase != '.exe'
+        bin += '.exe'
+      end
+      return bin if File.file?(bin) && File.executable?(bin)
+    end
 
     def self.popen3(bin, command, stdout, stderr)
       require 'open3'

--- a/spec/unit/executable_spec.rb
+++ b/spec/unit/executable_spec.rb
@@ -108,6 +108,36 @@ module Pod
       ruby_path.should == 'ruby.exe'
     end
 
+    it 'does not search the current working directory before PATH locations' do
+      ENV.expects(:fetch).with('PATH').returns('/usr/bin:/bin')
+
+      expected_bin = File.expand_path('git', '/usr/bin')
+      File.expects(:file?).with(expected_bin).returns(true)
+      File.expects(:executable?).with(expected_bin).returns(true)
+
+      Executable.which('git').should == expected_bin
+    end
+
+    it 'supports explicit relative executable paths' do
+      explicit_bin = File.expand_path('./git')
+
+      ENV.expects(:fetch).never
+      File.expects(:file?).with(explicit_bin).returns(true)
+      File.expects(:executable?).with(explicit_bin).returns(true)
+
+      Executable.which('./git').should == explicit_bin
+    end
+
+    it 'ignores unsafe PATH entries for current directory' do
+      ENV.expects(:fetch).with('PATH').returns(':/usr/bin:.')
+
+      expected_bin = File.expand_path('git', '/usr/bin')
+      File.expects(:file?).with(expected_bin).returns(true)
+      File.expects(:executable?).with(expected_bin).returns(true)
+
+      Executable.which('git').should == expected_bin
+    end
+
     it 'adds --force-local flag for tar on Windows' do
       Executable.stubs(:which).returns('/usr/bin/tar.exe')
       status = Object.new


### PR DESCRIPTION
## Summary
`Pod::Executable.which` previously prepended `./` to its search paths, causing binaries in the current working directory (for example, `./git`) to be resolved before trusted system binaries. This PR fixes this issue in executable resolution that could allow local executable hijacking when running CocoaPods commands in an untrusted directory.

## Root Cause
- `which` forced current directory precedence with `paths.unshift('./')`.
- Empty/unsafe `PATH` entries could also implicitly include current directory.

## What Changed
- Removed implicit current-directory search from `PATH` resolution.
- Added explicit path handling:
  - If the requested program contains a path separator (for example `./tool`, `../tool`, `/usr/bin/tool`), CocoaPods resolves that exact path.
- Added defensive filtering of unsafe `PATH` entries:
  - Skip `''` and `'.'`.

## Impact
- Prevents accidental execution of attacker-controlled binaries from project directories.
- Preserves intentional execution of explicit local/absolute executables.

## Behavioral Notes
- `which('git')` now follows `PATH` without forced `./` precedence.
- `which('./git')` and absolute-path invocations continue to work.
- Windows `.exe` behavior is preserved.

## Tests Added
- `does not search the current working directory before PATH locations`
- `supports explicit relative executable paths`
- `ignores unsafe PATH entries for current directory`

## Validation
- `bundle exec ruby -I spec spec/unit/executable_spec.rb`
- Result: `16 specifications (30 requirements), 0 failures, 0 errors`

## Files Changed
- `lib/cocoapods/executable.rb`
- `spec/unit/executable_spec.rb`
- `CHANGELOG.md`
