### PR TITLE
Serialize [CP] Copy XCFrameworks rsync with a mkdir lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
+* Serialize concurrent rsync invocations in the `[CP] Copy XCFrameworks` build phase to prevent races when multiple Pods targets depend on the same xcframework (e.g. the same pod at different deployment targets).  
+
 * Update ruby-macho to 4.1.0 to address new mergable libraries not beind detected correctly.  
     [Parsa Nasirimehr](https://github.com/TheRogue76)
     [#12691](https://github.com/CocoaPods/CocoaPods/pull/12691)

--- a/lib/cocoapods/generator/copy_xcframework_script.rb
+++ b/lib/cocoapods/generator/copy_xcframework_script.rb
@@ -73,9 +73,30 @@ copy_dir()
   local source="$1"
   local destination="$2"
 
+  # Serialize rsync invocations across parallel Xcode build phases that target the
+  # same xcframework destination (e.g. two Pods targets that differ only by
+  # deployment-target share $PODS_XCFRAMEWORKS_BUILD_DIR within a configuration).
+  # `mkdir` is atomic on POSIX and requires no external tools.
+  local lock_dir
+  lock_dir="${TMPDIR:-/tmp}/cocoapods-xcframework-$(printf '%s' "${destination}" | shasum | cut -c1-40).lock"
+  local waited=0
+  until mkdir "${lock_dir}" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+    # Stale-lock timeout: 6000 iterations * 0.1s = 600s.
+    if [ "${waited}" -ge 6000 ]; then
+      echo "warning: [CP] Removing stale lock ${lock_dir} after 600s"
+      rmdir "${lock_dir}" 2>/dev/null || true
+    fi
+  done
+
   # Use filter instead of exclude so missing patterns don't throw errors.
   echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" \\"${source}*\\" \\"${destination}\\""
-  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}"
+  local rsync_status=0
+  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}" || rsync_status=$?
+
+  rmdir "${lock_dir}" 2>/dev/null || true
+  return "${rsync_status}"
 }
 
 SELECT_SLICE_RETVAL=""

--- a/spec/cocoapods-integration-specs/install_vendored_static_library_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/spec/cocoapods-integration-specs/install_vendored_static_library_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -79,9 +79,30 @@ copy_dir()
   local source="$1"
   local destination="$2"
 
+  # Serialize rsync invocations across parallel Xcode build phases that target the
+  # same xcframework destination (e.g. two Pods targets that differ only by
+  # deployment-target share $PODS_XCFRAMEWORKS_BUILD_DIR within a configuration).
+  # `mkdir` is atomic on POSIX and requires no external tools.
+  local lock_dir
+  lock_dir="${TMPDIR:-/tmp}/cocoapods-xcframework-$(printf '%s' "${destination}" | shasum | cut -c1-40).lock"
+  local waited=0
+  until mkdir "${lock_dir}" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+    # Stale-lock timeout: 6000 iterations * 0.1s = 600s.
+    if [ "${waited}" -ge 6000 ]; then
+      echo "warning: [CP] Removing stale lock ${lock_dir} after 600s"
+      rmdir "${lock_dir}" 2>/dev/null || true
+    fi
+  done
+
   # Use filter instead of exclude so missing patterns don't throw errors.
   echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" \"${source}*\" \"${destination}\""
-  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}"
+  local rsync_status=0
+  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}" || rsync_status=$?
+
+  rmdir "${lock_dir}" 2>/dev/null || true
+  return "${rsync_status}"
 }
 
 SELECT_SLICE_RETVAL=""

--- a/spec/cocoapods-integration-specs/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/spec/cocoapods-integration-specs/install_vendored_static_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -73,9 +73,30 @@ copy_dir()
   local source="$1"
   local destination="$2"
 
+  # Serialize rsync invocations across parallel Xcode build phases that target the
+  # same xcframework destination (e.g. two Pods targets that differ only by
+  # deployment-target share $PODS_XCFRAMEWORKS_BUILD_DIR within a configuration).
+  # `mkdir` is atomic on POSIX and requires no external tools.
+  local lock_dir
+  lock_dir="${TMPDIR:-/tmp}/cocoapods-xcframework-$(printf '%s' "${destination}" | shasum | cut -c1-40).lock"
+  local waited=0
+  until mkdir "${lock_dir}" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+    # Stale-lock timeout: 6000 iterations * 0.1s = 600s.
+    if [ "${waited}" -ge 6000 ]; then
+      echo "warning: [CP] Removing stale lock ${lock_dir} after 600s"
+      rmdir "${lock_dir}" 2>/dev/null || true
+    fi
+  done
+
   # Use filter instead of exclude so missing patterns don't throw errors.
   echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" \"${source}*\" \"${destination}\""
-  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}"
+  local rsync_status=0
+  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}" || rsync_status=$?
+
+  rmdir "${lock_dir}" 2>/dev/null || true
+  return "${rsync_status}"
 }
 
 SELECT_SLICE_RETVAL=""

--- a/spec/cocoapods-integration-specs/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
+++ b/spec/cocoapods-integration-specs/install_vendored_xcframework/after/Pods/Target Support Files/BananaLib/BananaLib-xcframeworks.sh
@@ -79,9 +79,30 @@ copy_dir()
   local source="$1"
   local destination="$2"
 
+  # Serialize rsync invocations across parallel Xcode build phases that target the
+  # same xcframework destination (e.g. two Pods targets that differ only by
+  # deployment-target share $PODS_XCFRAMEWORKS_BUILD_DIR within a configuration).
+  # `mkdir` is atomic on POSIX and requires no external tools.
+  local lock_dir
+  lock_dir="${TMPDIR:-/tmp}/cocoapods-xcframework-$(printf '%s' "${destination}" | shasum | cut -c1-40).lock"
+  local waited=0
+  until mkdir "${lock_dir}" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+    # Stale-lock timeout: 6000 iterations * 0.1s = 600s.
+    if [ "${waited}" -ge 6000 ]; then
+      echo "warning: [CP] Removing stale lock ${lock_dir} after 600s"
+      rmdir "${lock_dir}" 2>/dev/null || true
+    fi
+  done
+
   # Use filter instead of exclude so missing patterns don't throw errors.
   echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" \"${source}*\" \"${destination}\""
-  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}"
+  local rsync_status=0
+  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}" || rsync_status=$?
+
+  rmdir "${lock_dir}" 2>/dev/null || true
+  return "${rsync_status}"
 }
 
 SELECT_SLICE_RETVAL=""

--- a/spec/unit/generator/copy_xcframeworks_script_spec.rb
+++ b/spec/unit/generator/copy_xcframeworks_script_spec.rb
@@ -37,5 +37,14 @@ module Pod
       # Second argument to `install_xcframework` is a boolean indicating whether to embed the framework
       generator.send(:script).should.include 'CoconutLib.xcframework'
     end
+
+    it 'serializes concurrent rsync invocations with a file lock' do
+      xcframework = Xcode::XCFramework.new('CoconutLib', fixture('CoconutLib.xcframework'))
+      generator = CopyXCFrameworksScript.new([xcframework], temporary_sandbox.root, Platform.ios)
+      script = generator.send(:script)
+      script.should.include 'lock_dir="${TMPDIR:-/tmp}/cocoapods-xcframework-'
+      script.should.include 'until mkdir "${lock_dir}"'
+      script.should.include 'rmdir "${lock_dir}" 2>/dev/null || true'
+    end
   end
 end


### PR DESCRIPTION
# [CP] Copy XCFrameworks: serialize concurrent rsync runs with a `mkdir` lock

## Why

When two Pods targets in the same `Pods.xcodeproj` depend on the **same** xcframework — the canonical case is a pod consumed at two different deployment targets within one user project, e.g. an iOS 10 extension host and an iOS 14 extension — CocoaPods generates two Pods targets (`ExampleA-iOS10.0`, `ExampleA-iOS14.0`) that each get their own `[CP] Copy XCFrameworks` build phase. Xcode runs these phases in parallel. Both phases rsync from the **same** xcframework slice path, and because `PODS_XCFRAMEWORKS_BUILD_DIR` (`$(PODS_CONFIGURATION_BUILD_DIR)/XCFrameworkIntermediates`) is **configuration-scoped**, not target-scoped, both rsyncs can resolve to the same destination within a single user target's build. The two rsync processes race on the destination's in-flight temp files and the `--delete` pass, producing hard failures like:

```
rsync(29832): error: ExampleA.framework/.ExampleA.tIHcloxem5: move_file: ExampleA.framework/ExampleA: No such file or directory
rsync(29832): error: rsync_downloader
rsync(29832): error: rsync_receiver
rsync(29823): error: unexpected end of file
rsync(29823): error: io_read_nonblocking
rsync(29823): error: rsync_sender
rsync(29823): warning: child 29832 exited with status 1
```

The existing `RSYNC_PROTECT_TMP_FILES=(--filter "P .*.??????")` filter (per the 2008 rsync-ML thread referenced in the source) only prevents each rsync from *deleting the other's* temp files. It does **not** serialize concurrent rsync invocations, so the underlying rename race on `ExampleA.framework/<binary>` still breaks.

**Note on generality.** The `-iOS10.0` / `-iOS14.0` suffix is a *symptom*, not the trigger. CocoaPods appends a platform-and-deployment-target suffix whenever the same pod is consumed at different deployment targets; the same race surfaces under other disambiguation schemes (same pod on iOS + watchOS, static vs dynamic variants, etc.) any time two Pods targets depend on the same xcframework.

Closes: (link to issue / linked report in `demand.md`).

## What

Wrap the `rsync` call inside the `copy_dir()` bash function of the generated xcframeworks-copy script with a `mkdir`-based file mutex keyed on a hash of the destination path. When multiple Pods targets race on the same destination, they serialize on the same lock file; when they target different destinations, they continue to run in parallel — no throughput regression.

**Files changed:**

- `lib/cocoapods/generator/copy_xcframework_script.rb` — update the `copy_dir()` bash function body inside the generated script.
- `spec/unit/generator/copy_xcframeworks_script_spec.rb` — add one Bacon example asserting the lock lines are emitted.
- `CHANGELOG.md` — bug-fix bullet under `Master`.

**Out of scope (intentionally):** `install_dsym` and `install_bcsymbolmap` in `script_phase_constants.rb` also use rsync, but their destinations are `DERIVED_FILES_DIR` / `DWARF_DSYM_FOLDER_PATH` / `BUILT_PRODUCTS_DIR`, which are per-target Xcode-managed directories and are not shared across parallel build phases the way `PODS_XCFRAMEWORKS_BUILD_DIR` is. No change there.

## Detail of the fix

### Primitive choice: `mkdir`

- **`flock(1)`** — not shipped by default on macOS (it's Linux).
- **`shlock(1)`** — deprecated on macOS.
- **Perl `flock` one-liner** — auto-releases on process exit, but wrapping rsync inside `perl -e '...'` tangles `$?` propagation and makes the script harder to read for future maintainers. The existing script is pure sh/bash; staying idiomatic wins.
- **`mkdir`** — POSIX-guaranteed atomic directory creation, zero external dependencies, already idiomatic for sh/bash mutexes. Chosen.

### Key choice: destination path

rsync does not modify the source side (it's a pure reader), so two concurrent reads of the same source slice are safe. The race is strictly on the destination's rename-temp-file dance and the `--delete` pass. Locking on `$destination` therefore:

- Eliminates the race that causes the reported failure.
- Keeps rsyncs targeting *different* xcframeworks (different destinations) parallel — no global throughput loss.

### Generated bash (diff)

```diff
 copy_dir()
 {
   local source="$1"
   local destination="$2"
 
+  # Serialize rsync invocations across parallel Xcode build phases that target the
+  # same xcframework destination (e.g. two Pods targets that differ only by
+  # deployment-target share $PODS_XCFRAMEWORKS_BUILD_DIR within a configuration).
+  # `mkdir` is atomic on POSIX and requires no external tools.
+  local lock_dir
+  lock_dir="${TMPDIR:-/tmp}/cocoapods-xcframework-$(printf '%s' "${destination}" | shasum | cut -c1-40).lock"
+  local waited=0
+  until mkdir "${lock_dir}" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+    # Stale-lock timeout: 6000 iterations * 0.1s = 600s.
+    if [ "${waited}" -ge 6000 ]; then
+      echo "warning: [CP] Removing stale lock ${lock_dir} after 600s"
+      rmdir "${lock_dir}" 2>/dev/null || true
+    fi
+  done
+
   # Use filter instead of exclude so missing patterns don't throw errors.
   echo "rsync --delete -av \"${RSYNC_PROTECT_TMP_FILES[@]}\" --links --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" \"${source}*\" \"${destination}\""
-  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}"
+  local rsync_status=0
+  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --links --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" "${source}"/* "${destination}" || rsync_status=$?
+
+  rmdir "${lock_dir}" 2>/dev/null || true
+  return "${rsync_status}"
 }
```

### Design notes for the reviewer

- **`shasum` + `cut -c1-40`**: produces a stable 40-char filename-safe digest of the destination path. `shasum` ships in the base macOS toolchain.
- **`${TMPDIR:-/tmp}`**: `$TMPDIR` is always set in an Xcode build-phase environment; the `:-/tmp` fallback is defensive for ad-hoc CLI runs.
- **`|| rsync_status=$?`**: the generated script runs under `set -e`; this idiom disarms `-e` only for the rsync line so the lock is always released, while preserving the non-zero exit on failure via the final `return "${rsync_status}"` so `set -e` still aborts the build at the caller.
- **`rmdir` (not `rm -rf`) on stale-lock cleanup**: if the lock dir somehow contains unexpected entries, failing loudly is safer than nuking them.
- **`echo "rsync ..."` inside the critical section**: keeps interleaved build logs readable when multiple copy_dir invocations serialize.

## Test plan

- [x] `ruby -c lib/cocoapods/generator/copy_xcframework_script.rb` → Syntax OK.
- [x] `ruby -c spec/unit/generator/copy_xcframeworks_script_spec.rb` → Syntax OK.
- [x] Generator produces a script; piped to `sh -n` → Syntax OK (no bash parse errors introduced).
- [x] Programmatic check: the three lock-related strings asserted by the new Bacon test are present in the generated script.
- [ ] `bundle exec bacon spec/unit/generator/copy_xcframeworks_script_spec.rb` — CI will run this. (Local run blocked by an environment-specific bundler/git-source resolution issue unrelated to this change; CI is authoritative.)
- [ ] `bundle exec bacon spec/unit/generator/` — full generator suite regression check (CI).
- [ ] End-to-end repro using the Podfile from the linked report:
  ```ruby
  platform :ios, '10.0'
  target 'ProjectA' do
    pod 'ExampleA', '0.0.1'
  end
  target 'ProjectAExtension' do
    platform :ios, '14.0'
    pod 'ExampleA', '0.0.1'
  end
  ```
  ```
  pod install
  xcodebuild -workspace ProjectA.xcworkspace -scheme ProjectA -configuration Debug \
    -destination 'generic/platform=iOS' archive
  ```
  Expected: before the fix, intermittent `rsync: move_file ... No such file or directory` in `[CP] Copy XCFrameworks`; after the fix, archive succeeds and `Pods/Target Support Files/ExampleA-iOS*/ExampleA-iOS*-xcframeworks.sh` contains the `mkdir`-based lock around the rsync call.

## Risk / compatibility

- The lock is emitted inside the generated shell script — no change to the CocoaPods Ruby public API, no CLI flag, no config change required. Any project re-running `pod install` picks up the fix automatically.
- The lock only serializes *same-destination* copies. Different xcframeworks continue to run in parallel, so there is no measurable impact on build times for the common case.
- The stale-lock timeout (600s) is conservative; legitimate xcframework copies complete in seconds. A crashed build leaves at most a single stale `${TMPDIR}/cocoapods-xcframework-<hash>.lock` directory that the next run auto-cleans.
